### PR TITLE
Made birds eye mode work with screen readers.

### DIFF
--- a/bluej/src/main/java/bluej/editor/stride/BirdseyeManager.java
+++ b/bluej/src/main/java/bluej/editor/stride/BirdseyeManager.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2015,2016 Michael Kölling and John Rosenberg 
+ Copyright (C) 2015,2016,2022 Michael Kölling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -21,6 +21,7 @@
  */
 package bluej.editor.stride;
 
+import bluej.stride.generic.Frame.View;
 import javafx.scene.Node;
 
 import bluej.stride.generic.FrameCursor;
@@ -33,6 +34,11 @@ import bluej.utility.javafx.FXRunnable;
  */
 public interface BirdseyeManager
 {
+    /**
+     * Gets the description of the current frame for the screen reader.
+     */
+    String getAccessibleText(View viewMode);
+    
     /**
      * Gets the graphical Node corresponding to the frame around which the bird's eye view
      * selection rectangle should be drawn

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/AssignFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/AssignFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2018,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2018,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -130,7 +130,7 @@ public class AssignFrame extends SingleLineFrame
     }
 
     //From Cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String lhs, rhs;
         lhs = (slotLHS.getText().trim().isEmpty())? "blank" : slotLHS.getScreenreaderText();
         rhs = (slotRHS.getText().trim().isEmpty())? "blank" : slotRHS.getScreenreaderText();

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/CallFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/CallFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -94,7 +94,7 @@ public class CallFrame extends SingleLineFrame
 
     //cherry & Babis
     @Override
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String contentString;
         contentString = (content.getText().trim().equals("()"))? "blank" : content.getScreenreaderText();
         return frameName + contentString;

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/CaseFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/CaseFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -45,7 +45,6 @@ import bluej.stride.generic.FrameCursor;
 import bluej.stride.generic.FrameFactory;
 import bluej.stride.generic.InteractionManager;
 import bluej.stride.generic.SingleCanvasFrame;
-import bluej.stride.operations.FrameOperation;
 import bluej.stride.slots.EditableSlot;
 import bluej.stride.slots.SlotLabel;
 import bluej.utility.Utility;
@@ -126,7 +125,7 @@ public class CaseFrame extends SingleCanvasFrame
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String condition;
         condition = (paramCondition.getText().equals(""))? "blank" : paramCondition.getScreenreaderText();
         return "'case' frame with value " + condition;

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/ClassFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/ClassFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -571,11 +571,16 @@ public class ClassFrame extends TopLevelDocumentMultiCanvasFrame<ClassElement>
         // Keep compiler happy:
         final int finalStartingCanvas = startingCanvas;
         final Frame finalStartingFrame = startingFrame;
-
         return new BirdseyeManager()
         {
             private int canvasIndex = finalStartingCanvas;
             private Frame frame = finalStartingFrame;
+
+            @Override
+            public String getAccessibleText(View viewMode)
+            {
+                return frame.getScreenReaderText(viewMode);
+            }
 
             @Override
             public Node getNodeForRectangle()

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/CommentFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/CommentFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -26,10 +26,7 @@
 package bluej.stride.framedjava.frames;
 
 
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import bluej.stride.generic.CanvasParent;
 import bluej.stride.generic.DocumentationTextArea;
@@ -40,15 +37,12 @@ import bluej.stride.generic.FrameFactory;
 import bluej.stride.generic.InteractionManager;
 import bluej.stride.generic.RecallableFocus;
 import bluej.stride.generic.SingleLineFrame;
-import bluej.stride.operations.FrameOperation;
 import bluej.stride.slots.EditableSlot;
-import bluej.utility.Debug;
 import bluej.utility.javafx.JavaFXUtil;
 import bluej.utility.javafx.SharedTransition;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import javafx.scene.Node;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.input.KeyEvent;
@@ -141,7 +135,7 @@ public class CommentFrame extends SingleLineFrame implements CodeFrame<CommentEl
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String commentString = (comment.getText().equals(""))? "blank" : comment.getText();
         return "comment. " + commentString;
     }

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/ConstructorFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/ConstructorFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2020,2021 Michael Kölling and John Rosenberg 
+ Copyright (C) 2014,2015,2016,2020,2021,2022 Michael Kölling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -120,7 +120,7 @@ public class ConstructorFrame extends MethodFrameWithBody<ConstructorElement> {
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
 
         String text = "Constructor " + ScreenreaderDictionary.transcribeForScreenreader(getEditor().nameProperty().get());
 
@@ -128,8 +128,11 @@ public class ConstructorFrame extends MethodFrameWithBody<ConstructorElement> {
         if (paramString.length() != 0) {
             text += " with parameters " + paramString.toString();
         }
-        // add documentation
-        text += ". Documentation: " + getDocumentation();
+        if (viewMode != View.BIRDSEYE_NODOC)
+        {
+            // add documentation
+            text += ". Documentation: " + getDocumentation();
+        }
 
         return text;
     }

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/ForeachFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/ForeachFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -105,7 +105,7 @@ public class ForeachFrame extends SingleCanvasFrame
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String typeString, varString, collectionString;
 
         typeString = (type.getText().equals(""))? "blank" : type.getText();

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/IfFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/IfFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -125,7 +125,7 @@ public class IfFrame extends SandwichCanvasesFrame
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String condition;
         condition = (ifCondition.getText().equals(""))? "blank" : ifCondition.getScreenreaderText();
         return "if frame with condition " + condition;

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/ImportFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/ImportFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2015,2016,2018,2019,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2015,2016,2018,2019,2020,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -222,7 +222,7 @@ public class ImportFrame extends SingleLineFrame implements CodeFrame<ImportElem
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String fieldString;
         fieldString = (importField.getText().equals(""))? "blank" : importField.getText();
         return "import " + fieldString;

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/InheritedMethodFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/InheritedMethodFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2020,2021 Michael Kölling and John Rosenberg 
+ Copyright (C) 2014,2015,2016,2020,2021,2022 Michael Kölling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -116,7 +116,7 @@ public class InheritedMethodFrame extends SingleLineFrame
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         StringBuilder paramString = new StringBuilder();
         for(ParamInfo pair : params) {
             paramString.append(pair.getUnqualifiedType() + " " +  pair.getDummyName() + " ");

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/MethodProtoFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/MethodProtoFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2020,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -41,15 +41,8 @@ import bluej.stride.operations.CustomFrameOperation;
 import bluej.stride.operations.FrameOperation;
 import bluej.stride.slots.*;
 import bluej.utility.javafx.JavaFXUtil;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.collections.FXCollections;
 import threadchecker.OnThread;
 import threadchecker.Tag;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class MethodProtoFrame extends DocumentedSingleLineFrame implements CodeFrame<MethodProtoElement>
 {
@@ -104,7 +97,7 @@ public class MethodProtoFrame extends DocumentedSingleLineFrame implements CodeF
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         StringBuilder paramString = new StringBuilder();
         String name, type;
 
@@ -127,8 +120,11 @@ public class MethodProtoFrame extends DocumentedSingleLineFrame implements CodeF
         if (parentIsClass.get()) {
             text = abstractLabel.getText() + " " + text;
         }
-        // add documentation
-        text += ". Documentation: " + getDocumentation();
+        if (viewMode != View.BIRDSEYE_NODOC)
+        {
+            // add documentation
+            text += ". Documentation: " + getDocumentation();
+        }
 
         return text;
     }

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/NormalMethodFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/NormalMethodFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2019,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2019,2020,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -165,7 +165,7 @@ public class NormalMethodFrame extends MethodFrameWithBody<NormalMethodElement> 
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         // build string out of all params
         StringBuilder paramString = new StringBuilder();
         String name, type;
@@ -192,8 +192,11 @@ public class NormalMethodFrame extends MethodFrameWithBody<NormalMethodElement> 
         if (staticModifier.get()) {
             text = staticLabel.getText() + " " + text;
         }
-        // append documentation
-        text += ". Documentation: " + getDocumentation();
+        if (viewMode != View.BIRDSEYE_NODOC)
+        {
+            // append documentation
+            text += ". Documentation: " + getDocumentation();
+        }
 
         return text;
     }

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/ReturnFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/ReturnFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -26,7 +26,6 @@
 package bluej.stride.framedjava.frames;
 
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import bluej.stride.slots.EditableSlot;
@@ -37,8 +36,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Cursor;
 import bluej.stride.framedjava.ast.ExpressionSlotFragment;
-import bluej.stride.framedjava.ast.HighlightedBreakpoint;
-import bluej.stride.framedjava.canvases.JavaCanvas;
 import bluej.stride.framedjava.elements.ReturnElement;
 import bluej.stride.framedjava.slots.OptionalExpressionSlot;
 import bluej.stride.generic.Frame;
@@ -46,7 +43,6 @@ import bluej.stride.generic.FrameCanvas;
 import bluej.stride.generic.FrameFactory;
 import bluej.stride.generic.InteractionManager;
 import bluej.stride.generic.SingleLineFrame;
-import bluej.stride.operations.FrameOperation;
 import bluej.stride.slots.HeaderItem;
 import bluej.stride.slots.SlotLabel;
 import bluej.utility.javafx.FXRunnable;
@@ -128,7 +124,7 @@ public class ReturnFrame extends SingleLineFrame
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String valueString;
         valueString = (value.getText().equals(""))? "blank" : value.getScreenreaderText();
         return "return " + valueString;

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/SwitchFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/SwitchFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -114,7 +114,7 @@ public class SwitchFrame extends MultiCanvasFrame
     }
 
     @Override
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         return frameName+" with condition "+ expression.getScreenreaderText();
     }
 

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/ThrowFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/ThrowFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -26,21 +26,16 @@
 package bluej.stride.framedjava.frames;
 
 
-import java.util.List;
-
 import bluej.stride.generic.FrameCanvas;
 import javafx.beans.property.SimpleIntegerProperty;
 import bluej.stride.framedjava.ast.ExpressionSlotFragment;
 import bluej.stride.framedjava.ast.FilledExpressionSlotFragment;
-import bluej.stride.framedjava.ast.HighlightedBreakpoint;
-import bluej.stride.framedjava.canvases.JavaCanvas;
 import bluej.stride.framedjava.elements.ThrowElement;
 import bluej.stride.framedjava.slots.ExpressionSlot;
 import bluej.stride.framedjava.slots.FilledExpressionSlot;
 import bluej.stride.generic.FrameFactory;
 import bluej.stride.generic.InteractionManager;
 import bluej.stride.generic.SingleLineFrame;
-import bluej.stride.operations.FrameOperation;
 
 /**
  * A Throw statement
@@ -78,7 +73,7 @@ public class ThrowFrame extends SingleLineFrame
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String thrown;
         thrown = (param1.getText().equals(""))? "blank" : param1.getScreenreaderText();
         return "throw " + thrown;

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/VarFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/VarFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2019,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2019,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -221,7 +221,7 @@ public class VarFrame extends SingleLineFrame implements CodeFrame<VarElement>, 
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String text, name, type, accessString;
         name = (slotName.getText().trim().isEmpty())? "blank" : ScreenreaderDictionary.transcribeForScreenreader(slotName.getText());
         type = (slotType.getText().trim().isEmpty())? "blank" : slotType.getText();

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/WhileFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/WhileFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -141,7 +141,7 @@ public class WhileFrame extends SingleCanvasFrame
     }
 
     //cherry
-    public String getScreenReaderText() {
+    public String getScreenReaderText(View viewMode) {
         String condition;
         condition = (paramCondition.getScreenreaderText().equals(""))? "blank" : paramCondition.getScreenreaderText();
         return "while frame with condition " + condition;

--- a/bluej/src/main/java/bluej/stride/generic/Frame.java
+++ b/bluej/src/main/java/bluej/stride/generic/Frame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -31,13 +31,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import bluej.Config;
 import bluej.stride.framedjava.elements.LocatableElement.LocationMap;
 import bluej.stride.framedjava.slots.StructuredSlot;
 import bluej.stride.generic.ExtensionDescription.ExtensionSource;
 import bluej.utility.javafx.*;
-import javafx.beans.binding.DoubleExpression;
-import javafx.beans.binding.When;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -154,7 +151,7 @@ public abstract class Frame implements CursorFinder, FocusParent<FrameContentIte
     }
 
     //cherry - Babis, I made it to return the frameName by default.
-    public String getScreenReaderText()
+    public String getScreenReaderText(View viewMode)
     {
         return frameName;
     }

--- a/bluej/src/main/java/bluej/stride/generic/FrameCursor.java
+++ b/bluej/src/main/java/bluej/stride/generic/FrameCursor.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2020,2021,2022 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -286,7 +286,7 @@ public class FrameCursor implements RecallableFocus
                 this.helpText = "frame cursor help text";
                 if (getFrameAfter() != null)
                 {
-                    this.normalText = getFrameAfter().getScreenReaderText();
+                    this.normalText = getFrameAfter().getScreenReaderText(getEditor().viewProperty().get());
                     this.helpText = "you are before a" + getFrameAfter().getFrameName() + "," + parentCanvas.getParentLocationDescription();
                 }
                 else


### PR DESCRIPTION
I discovered while preparing the talk for next week that birds eye mode in Stride didn't work with screen readers.  This fixes it to read out the text of the selected frame as you traverse up and down.