### PR TITLE
Removed unused properties in defs file (for terminal font)

### DIFF
--- a/bluej/lib/bluej.defs
+++ b/bluej/lib/bluej.defs
@@ -344,11 +344,6 @@ bluej.menu.fontsize=12
 # default fontsize for the editor (can be changed in Preferences dialog)
 bluej.editor.fontsize=12
 
-# font and fontsize for the terminal (the size defaults to the editor font size
-# if not specified here)
-bluej.terminal.font=Monospaced
-#bluej.terminal.font=Monospaced-bold
-
 # The editor font. Only the font face is specified here, the font
 # size is specified in the BlueJ preference dialogue.  You can specify
 # any font name which has a corresponding TTF file in the lib/fonts directory:


### PR DESCRIPTION
This small change is in relation to a support email we received about monospace font display in the terminal.
The related property in the bluej.defs file is no longer relevant.
(For info, changes to the terminal font can be done via the CSS files.)