### PR TITLE
Fix show source link, and other fixes

### DIFF
--- a/bluej/src/main/java/bluej/debugmgr/codepad/CodePad.java
+++ b/bluej/src/main/java/bluej/debugmgr/codepad/CodePad.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2011,2012,2013,2016,2017,2018,2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2011,2012,2013,2016,2017,2018,2019,2020,2021,2022,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -733,7 +733,7 @@ public class CodePad extends VBox
         @OnThread(Tag.FXPlatform)
         public void beginExecution(InvokerRecord ir)
         {
-            BlueJEvent.raiseEvent(BlueJEvent.METHOD_CALL, ir);
+            BlueJEvent.raiseEvent(BlueJEvent.METHOD_CALL, ir, frame.getProject());
         }
 
         /*

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2019,2020,2021,2022,2023  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -1204,30 +1204,20 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
             if (doc != null)
             {
                 /* Javadoc looks like this:
-                <a id="sampleMethod(java.lang.String)">
-                <!--   -->
-                </a>
-                <ul>
-                <li>
-                <h4>sampleMethod</h4>
+                <section class="detail" id="sampleMethod(int)">
+                <h3>sampleMethod</h3>
                  */
 
-                // First find the anchor.  Ignore anchors with ids that do not end in a closing bracket (they are not methods):
-                NodeList anchors = doc.getElementsByTagName("a");
-                for (int i = 0; i < anchors.getLength(); i++)
+                // First find the section.  Ignore sections with ids that do not end in a closing bracket (they are not methods):
+                NodeList sections = doc.getElementsByTagName("section");
+                for (int i = 0; i < sections.getLength(); i++)
                 {
-                    org.w3c.dom.Node anchorItem = anchors.item(i);
+                    org.w3c.dom.Node anchorItem = sections.item(i);
                     org.w3c.dom.Node anchorName = anchorItem.getAttributes().getNamedItem("id");
                     if (anchorName != null && anchorName.getNodeValue() != null && anchorName.getNodeValue().endsWith(")"))
                     {
-                        // Then find the ul child, then the li child of that, then the h4 child of that:
-                        org.w3c.dom.Node ulNode = findHTMLNode(anchorItem, org.w3c.dom.Node::getNextSibling, n -> "ul".equals(n.getLocalName()));
-                        if (ulNode == null)
-                            continue;
-                        org.w3c.dom.Node liNode = findHTMLNode(ulNode.getFirstChild(), org.w3c.dom.Node::getNextSibling, n -> "li".equals(n.getLocalName()));
-                        if (liNode == null)
-                            continue;
-                        org.w3c.dom.Node headerNode = findHTMLNode(liNode.getFirstChild(), org.w3c.dom.Node::getNextSibling, n -> "h4".equals(n.getLocalName()));
+                        // Then find the first h3 child of that:
+                        org.w3c.dom.Node headerNode = findHTMLNode(anchorItem.getFirstChild(), org.w3c.dom.Node::getNextSibling, n -> "h3".equals(n.getLocalName()));
                         if (headerNode != null)
                         {
                             // Make a link, and set a listener for it:

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -1212,12 +1212,12 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
                 NodeList sections = doc.getElementsByTagName("section");
                 for (int i = 0; i < sections.getLength(); i++)
                 {
-                    org.w3c.dom.Node anchorItem = sections.item(i);
-                    org.w3c.dom.Node anchorName = anchorItem.getAttributes().getNamedItem("id");
-                    if (anchorName != null && anchorName.getNodeValue() != null && anchorName.getNodeValue().endsWith(")"))
+                    org.w3c.dom.Node sectionItem = sections.item(i);
+                    org.w3c.dom.Node sectionId = sectionItem.getAttributes().getNamedItem("id");
+                    if (sectionId != null && sectionId.getNodeValue() != null && sectionId.getNodeValue().endsWith(")"))
                     {
                         // Then find the first h3 child of that:
-                        org.w3c.dom.Node headerNode = findHTMLNode(anchorItem.getFirstChild(), org.w3c.dom.Node::getNextSibling, n -> "h3".equals(n.getLocalName()));
+                        org.w3c.dom.Node headerNode = findHTMLNode(sectionItem.getFirstChild(), org.w3c.dom.Node::getNextSibling, n -> "h3".equals(n.getLocalName()));
                         if (headerNode != null)
                         {
                             // Make a link, and set a listener for it:
@@ -1228,7 +1228,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
 
                             ((EventTarget) newLink).addEventListener("click", e ->
                             {
-                                String[] tokens = anchorName.getNodeValue().split("[(,)]");
+                                String[] tokens = sectionId.getNodeValue().split("[(,)]");
                                 List<String> paramTypes = new ArrayList<>();
                                 for (int t = 1; t < tokens.length; t++)
                                 {

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -2435,6 +2435,17 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
             && paramsMatch(tree.getNode(), paramTypes))
         {
             switchToSourceView();
+            // This is a bit of a hack.  We don't record the position of the
+            // actual method header that we want to focus.  But the start of the
+            // method node is either that position, or the start of the preceding
+            // Javadoc.  So if there's Javadoc we skip forward by that length,
+            // plus one (which we assume to be the newline afterwards).  This
+            // should work for most code, or at least get closer than the start
+            // of the Javadoc.
+            if (tree.getNode() instanceof MethodNode m && m.getJavadoc() != null)
+            {
+                offset += m.getJavadoc().length() + 1;
+            }
             flowEditorPane.positionCaret(offset);
             return true;
         }

--- a/bluej/src/test/java/bluej/editor/flow/TestBasicEditorInteraction.java
+++ b/bluej/src/test/java/bluej/editor/flow/TestBasicEditorInteraction.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2019,2020,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2019,2020,2022,2023  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -314,7 +314,7 @@ public class TestBasicEditorInteraction extends FXTest
                     // Cut to end of caret line (ignoring anchor)
                     clearClipboard();
                     fx_(() -> flowEditor.getActions().getActionByName("cut-end-of-line").actionPerformed(false));
-                    assertEquals(content.substring(curPos, curLineEnd), fx(() -> Clipboard.getSystemClipboard().getString()));
+                    assertEquals(curPos == curLineEnd ? null : content.substring(curPos, curLineEnd), fx(() -> Clipboard.getSystemClipboard().getString()));
                     content = beforeLine + content.substring(curLineStart, curPos) + afterLine;
                     assertEquals(content, fx(() -> flowEditorPane.getDocument().getFullContent()));
                     break;


### PR DESCRIPTION
Fix bugs with the "show source in BlueJ" link that we add to the Javadoc, another bug with the codepad and the terminal, and a test failure.

Fixes #1324
Fixes #2217 
Fixes #1255