### PR TITLE
Fix line numbers to change size, add context menu to toggle breakpoint

### DIFF
--- a/bluej/lib/stylesheets/flow.css
+++ b/bluej/lib/stylesheets/flow.css
@@ -33,7 +33,6 @@
 }
 
 .flow-line-label {
-    -fx-font-size: 10px;
     -fx-alignment: center-right;
     -fx-graphic-text-gap: 0;
     -fx-label-padding: 0 2 0 0;

--- a/bluej/src/main/java/bluej/debugmgr/ExecControls.java
+++ b/bluej/src/main/java/bluej/debugmgr/ExecControls.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -578,7 +578,7 @@ public class ExecControls
         stackList = new ListView<>();
         stackList.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         JavaFXUtil.addStyleClass(stackList, "debugger-stack");
-        stackList.styleProperty().bind(PrefMgr.getEditorFontCSS(false));
+        stackList.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY));
         JavaFXUtil.addChangeListenerPlatform(stackList.getSelectionModel().selectedIndexProperty(), index -> {
             DebuggerThread thread = getSelectedThreadDetails() == null ? null : getSelectedThreadDetails().getThread();
             boolean showSource = !autoSelectionEvent;
@@ -891,7 +891,7 @@ public class ExecControls
             // The spacing is added via CSS, not by space characters:
             HBox hBox = new HBox(access, type, name, new Label("="), objectImageView, this.value);
             hBox.visibleProperty().bind(nonEmpty);
-            hBox.styleProperty().bind(PrefMgr.getEditorFontCSS(false));
+            hBox.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY));
             JavaFXUtil.addStyleClass(hBox, "debugger-var-cell");
             JavaFXUtil.addStyleClass(access, "debugger-var-access");
             JavaFXUtil.addStyleClass(type, "debugger-var-type");

--- a/bluej/src/main/java/bluej/debugmgr/codepad/CodePad.java
+++ b/bluej/src/main/java/bluej/debugmgr/codepad/CodePad.java
@@ -499,8 +499,8 @@ public class CodePad extends VBox
                 historyView.getSelectionModel().selectLast();
         });
 
-        inputField.styleProperty().bind(PrefMgr.getEditorFontCSS(false));
-        historyView.styleProperty().bind(PrefMgr.getEditorFontCSS(false));
+        inputField.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY));
+        historyView.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY));
 
         Nodes.addInputMap(inputField, InputMap.sequence(
             InputMap.consume(EventPattern.keyPressed(KeyCode.EQUALS, KeyCombination.SHORTCUT_DOWN), e -> Utility.increaseFontSize(PrefMgr.getEditorFontSize())),

--- a/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2021,2022,2023  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -121,7 +121,7 @@ public abstract class BaseEditorPane extends Region
         horizontalScroll = new ScrollBar();
         horizontalScroll.setOrientation(Orientation.HORIZONTAL);
         horizontalScroll.setVisible(false);
-        lineDisplay = new LineDisplay(horizontalScroll.valueProperty(), PrefMgr.getEditorFontCSS(true), showLeftMargin, listener);
+        lineDisplay = new LineDisplay(horizontalScroll.valueProperty(), PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_AND_FAMILY), showLeftMargin, listener);
         lineContainer = new LineContainer(lineDisplay, false);
 
 

--- a/bluej/src/main/java/bluej/editor/base/MarginAndTextLine.java
+++ b/bluej/src/main/java/bluej/editor/base/MarginAndTextLine.java
@@ -318,6 +318,7 @@ public class MarginAndTextLine extends Region
                         label.setEllipsisString("\u2026");
                         label.setTextOverrun(OverrunStyle.LEADING_ELLIPSIS);
                         JavaFXUtil.addStyleClass(label, "flow-line-label");
+                        label.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.LINE_NUMBER_SIZE_ONLY));
                         label.setMouseTransparent(true);
                         return label;
                     case STEP_MARK:

--- a/bluej/src/main/java/bluej/editor/base/MarginAndTextLine.java
+++ b/bluej/src/main/java/bluej/editor/base/MarginAndTextLine.java
@@ -181,6 +181,13 @@ public class MarginAndTextLine extends Region
         ContextMenu contextMenu = new ContextMenu();
         contextMenu.getItems().add(
             JavaFXUtil.makeMenuItem(
+                Config.getString("editor.toggle-breakpointLabel"),
+                () -> onClick.get(),
+                null
+            )
+        );
+        contextMenu.getItems().add(
+            JavaFXUtil.makeMenuItem(
                 Config.getString("prefmgr.edit.displaylinenumbers"),
                 () -> {PrefMgr.setFlag(PrefMgr.LINENUMBERS, !PrefMgr.getFlag(PrefMgr.LINENUMBERS)); },
                 null

--- a/bluej/src/main/java/bluej/editor/base/MarginAndTextLine.java
+++ b/bluej/src/main/java/bluej/editor/base/MarginAndTextLine.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2019,2020,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 2019,2020,2021,2023  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -179,7 +179,6 @@ public class MarginAndTextLine extends Region
 
         // Context menu to show or hide line numbers
         ContextMenu contextMenu = new ContextMenu();
-        // If they right-click on us, we show new-class and import-class actions:
         contextMenu.getItems().add(
             JavaFXUtil.makeMenuItem(
                 Config.getString("prefmgr.edit.displaylinenumbers"),
@@ -198,7 +197,7 @@ public class MarginAndTextLine extends Region
             e.consume();
         });
 
-        // Right-clicks/control-clicks anywhere else in the line show this menu:
+        // Right-clicks/control-clicks anywhere else in the line show the menu passed to us:
         this.setOnContextMenuRequested(e -> {
             getContextMenuToShow.get().show(this, e.getScreenX(), e.getScreenY());
             e.consume();

--- a/bluej/src/main/java/bluej/editor/fixes/FixDisplayManager.java
+++ b/bluej/src/main/java/bluej/editor/fixes/FixDisplayManager.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program.
- Copyright (C) 2020,2022 Michael Kölling and John Rosenberg
+ Copyright (C) 2020,2022,2023 Michael Kölling and John Rosenberg
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -77,7 +77,7 @@ public abstract class FixDisplayManager
             getChildren().addAll(l, enterHint);
             HBox.setHgrow(l, Priority.ALWAYS);
             l.setMaxWidth(9999);
-            setStyle(PrefMgr.getEditorFontCSS(false).get());
+            setStyle(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY).get());
         }
         private void setHighlight(boolean highlight)
         {

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -539,7 +539,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
         BorderPane.setAlignment(info, Pos.TOP_LEFT);
         BorderPane.setAlignment(saveState, Pos.CENTER_RIGHT);
         JavaFXUtil.addStyleClass(commentsPanel, "moe-bottom-status-row");
-        commentsPanel.styleProperty().bind(PrefMgr.getEditorFontCSS(false));
+        commentsPanel.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY));
 
         bottomArea.setBottom(commentsPanel);
         bottomArea.setTop(finder);
@@ -3228,7 +3228,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
                 return;
             Bounds spLoc = flowEditorPane.screenToLocal(screenPos);
 
-            StringExpression editorFontCSS = PrefMgr.getEditorFontCSS(true);
+            StringExpression editorFontCSS = PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_AND_FAMILY);
             SuggestionList suggestionList = new SuggestionList(new SuggestionListParent()
             {
                 @Override
@@ -3852,7 +3852,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
             });
             errorVBox.getStyleClass().add("java-error-popup");
             // No need to bind as only matters if user increases font size while error showing:
-            tf.setStyle(PrefMgr.getEditorFontCSS(false).get());
+            tf.setStyle(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY).get());
             Config.addPopupStylesheets(errorVBox);
         }
     }

--- a/bluej/src/main/java/bluej/editor/flow/Info.java
+++ b/bluej/src/main/java/bluej/editor/flow/Info.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2011,2013,2014,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2011,2013,2014,2016,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -52,7 +52,7 @@ public final class Info extends TextFlow
         JavaFXUtil.addStyleClass(text, "moe-info-text");
         getChildren().add(text);
 
-        text.styleProperty().bind(PrefMgr.getEditorFontCSS(false));
+        text.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY));
 
         isClear = true;
     }

--- a/bluej/src/main/java/bluej/editor/flow/StatusLabel.java
+++ b/bluej/src/main/java/bluej/editor/flow/StatusLabel.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2011,2019,2021  Michael Kolling and John Rosenberg 
+ Copyright (C) 1999-2009,2011,2019,2021,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -65,7 +65,7 @@ public final class StatusLabel extends VBox
     public StatusLabel(Status initialState, FlowEditor editor, FlowErrorManager errorManager)
     {
         JavaFXUtil.addStyleClass(this, "moe-status-label-wrapper");
-        styleProperty().bind(PrefMgr.getEditorFontCSS(false));
+        styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_ONLY));
         state = initialState;
         statusLabel = new Label();
         errorLabel = new Label();

--- a/bluej/src/main/java/bluej/prefmgr/PrefMgr.java
+++ b/bluej/src/main/java/bluej/prefmgr/PrefMgr.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -28,6 +28,7 @@ import java.util.*;
 import bluej.utility.javafx.JavaFXUtil;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanExpression;
+import javafx.beans.binding.NumberBinding;
 import javafx.beans.binding.StringExpression;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
@@ -101,6 +102,8 @@ public class PrefMgr
     @OnThread(Tag.FX)
     private static final IntegerProperty editorFontSize = new SimpleIntegerProperty(DEFAULT_JAVA_FONT_SIZE);
     @OnThread(Tag.FX)
+    private static final NumberBinding editorLineNumberFontSize = Bindings.multiply(editorFontSize, 0.75);
+    @OnThread(Tag.FX)
     private static final StringProperty editorStandardFont = new SimpleStringProperty("Roboto Mono");
     private static final StringProperty editorFallbackFont = new SimpleStringProperty("monospace");
     @OnThread(Tag.FX)
@@ -143,6 +146,8 @@ public class PrefMgr
     // slightly shrunken and doesn't set family
     @OnThread(Tag.FX)
     private static StringExpression editorFontSizeOnlyCSS;
+    @OnThread(Tag.FX)
+    private static StringExpression editorLineNumberFontSizeOnlyCSS;
 
     // A property to hold the Greenfoot player's name
     private static StringProperty playerName;
@@ -322,8 +327,10 @@ public class PrefMgr
         return editorFontSize;
     }
 
+    public static enum FontCSS { EDITOR_SIZE_ONLY, EDITOR_SIZE_AND_FAMILY, LINE_NUMBER_SIZE_ONLY }
+
     @OnThread(Tag.FX)
-    public static StringExpression getEditorFontCSS(boolean includeFamily)
+    public static StringExpression getEditorFontCSS(FontCSS type)
     {
         if (editorFontCSS == null)
         {
@@ -333,8 +340,14 @@ public class PrefMgr
                     "-fx-font-size: ", editorFontSize, "pt;",
                     "-fx-font-family: \"", editorStandardFont, "\";"
             );
+            editorLineNumberFontSizeOnlyCSS = Bindings.concat(
+                    "-fx-font-size: ", editorLineNumberFontSize, "pt;");
         }
-        return includeFamily ? editorFontCSS : editorFontSizeOnlyCSS;
+        return switch (type) {
+            case EDITOR_SIZE_ONLY -> editorFontSizeOnlyCSS;
+            case EDITOR_SIZE_AND_FAMILY -> editorFontCSS;
+            case LINE_NUMBER_SIZE_ONLY -> editorLineNumberFontSizeOnlyCSS;
+        };
     }
 
     /**

--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -194,7 +194,7 @@ public final class Terminal
             sendInput(false);
             e.consume();
         });
-        input.styleProperty().bind(PrefMgr.getEditorFontCSS(true));
+        input.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_AND_FAMILY));
         input.setEditable(false);
         // Mainly for visuals, we disable when not in use:
         JavaFXUtil.addChangeListenerAndCallNow(input.editableProperty(), newVal ->
@@ -750,7 +750,7 @@ public final class Terminal
                 }
             };
             errorText.getStyleClass().add("terminal-error");
-            errorText.styleProperty().bind(PrefMgr.getEditorFontCSS(true));
+            errorText.styleProperty().bind(PrefMgr.getEditorFontCSS(PrefMgr.FontCSS.EDITOR_SIZE_AND_FAMILY));
             // Any selection in the error pane should clear existing selection in the output text pane
 
             errorText.addSelectionListener((caret, anchor) -> {


### PR DESCRIPTION
Made the font size of line numbers change as the main editor font size changes, and added an item to the margin context menu to allow toggling a breakpoint (which you can do just by left-clicking there, but it makes sense to have a context menu item too, since we do have a context menu there).

Fixes #435 
Fixes #1256