### PR TITLE
Fixed bugs with Terminal scrolling and JUnit support

### DIFF
--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     implementation 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
     implementation 'org.junit.platform:junit-platform-launcher:1.5.2'
+    implementation 'org.junit.platform:junit-platform-suite-api:1.5.2'
     implementation 'org.junit.vintage:junit-vintage-engine:5.5.2'
     implementation 'xom:xom:1.3.7'
 

--- a/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
@@ -635,6 +635,14 @@ public abstract class BaseEditorPane extends Region
     }
 
     /**
+     * Gets the height of the lineContainer object.
+     */
+    protected final double getLineContainerHeight()
+    {
+        return lineContainer.getHeight();
+    }
+
+    /**
      * A listener for some mouse events that can occur in the editor but need handling elsewhere. 
      */
     @OnThread(Tag.FXPlatform)

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -596,8 +596,8 @@ public class ClassTarget extends DependentTarget
             }
 
         }
-        catch (ClassNotFoundException cnfe) {}
-        catch (LinkageError le) {}
+        catch (ClassNotFoundException cnfe) { Debug.reportError(cnfe); }
+        catch (LinkageError le) { Debug.reportError(le); }
 
         // No suitable annotations found, so not a test class
         return false;
@@ -676,9 +676,11 @@ public class ClassTarget extends DependentTarget
         }
         catch (ClassNotFoundException cnfe)
         {
+            Debug.reportError(cnfe);
         }
         catch (LinkageError le)
         {
+            Debug.reportError(le);
         }
 
         // No suitable annotations found, so not a test class
@@ -710,8 +712,8 @@ public class ClassTarget extends DependentTarget
                 try {
                     junitClass = clLoader.loadClass("junit.framework.TestCase");
                 }
-                catch (ClassNotFoundException cnfe) {}
-                catch (LinkageError le) {}
+                catch (ClassNotFoundException cnfe) { Debug.reportError(cnfe); }
+                catch (LinkageError le) { Debug.reportError(le); }
             }
             
             if (junitClass == null) {

--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -474,7 +474,8 @@ public final class Terminal
                 pane.trimToMostRecentNLines(MAX_BUFFER_LINES);
         }
 
-        pane.scrollToEnd();
+        // We must wait the terminal to show before we try to scroll to the end:
+        JavaFXUtil.runAfterCurrent(pane::scrollToEnd);
     }
 
     /**

--- a/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
+++ b/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2021,2022,2023  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -442,7 +442,7 @@ public abstract class TerminalTextPane extends BaseEditorPane
      */
     public void scrollToEnd()
     {
-        lineDisplay.ensureLineVisible(content.size() - 1, getHeight(), getLineCount());
+        lineDisplay.ensureLineVisible(content.size() - 1, getLineContainerHeight(), getLineCount());
         updateRender(false);
     }
 

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=2
 bluej_release=0
 bluej_suffix=
-bluej_rcnumber=1
+bluej_rcnumber=2
 
 greenfoot_major=3
 greenfoot_minor=7


### PR DESCRIPTION
Turns out, 5.2.0-rc1 didn't support JUnit due to a missing dependency on a JUnit 5 library (JUnit 5 has splintered into lots of smaller libraries and the Gradle dependency missed one).  Also fixed a bug with scrolling to the bottom of the terminal.