### PR TITLE
Fix version number in the MSI build

### DIFF
--- a/bluej/package/winsetup/bluej.wxs
+++ b/bluej/package/winsetup/bluej.wxs
@@ -5,7 +5,7 @@
      If you get a build failure here with a message about ${bluej-3.1.7} or similar not being a legal
       guid value, then it is because you failed to make a new GUID for this version: see the
       update-version-number task in ant for details on what to do. -->
-<Product Version='5.1.0' Id='af0bea9e-1ab2-4613-a6b5-4ecc105a8a23'
+<Product Version='5.2.0' Id='8da631f6-8578-4bc0-8672-b46cb91b125d'
     Name='BlueJ' UpgradeCode='f4b4357e-6101-4cb1-8e38-3d4f3afb4be2'
     Language='1033' Codepage='1252' Manufacturer='BlueJ Team'>
     
@@ -23,7 +23,7 @@
     <Property Id="ALLUSERS" Secure="yes" />
     
     <Property Id="SOFTWARE" Value="BlueJ"/>
-    <Property Id="SOFTWAREVERSION" Value="5.1.0"/>
+    <Property Id="SOFTWAREVERSION" Value="5.2.0"/>
     <Property Id="SOFTWAREPROJECTEXT" Value="bluej"/>
     <Property Id="SOFTWAREARCHIVEEXT" Value="bjar"/>
     <!-- Define all the necessary GUIDs here, to make sure they are different from Greenfoot -->

--- a/boot/build.gradle
+++ b/boot/build.gradle
@@ -121,22 +121,22 @@ task updateVersionNumber {
     }
     // Update BlueJ version number in launcher EXE info:
     ant.replaceregexp(match:'(FILE|PRODUCT)VERSION .*', replace:"\\1VERSION ${bluejVersionCommas},0", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'bluej-version.rc')
+        fileset(dir: '../bluej/package/winsetup', includes: 'bluej-version.rc')
     }
     ant.replaceregexp(match:'(\\s*VALUE \"\\w+Version\",).*', replace:"\\1 \"${bluejVersionNoSuffix}\"", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'bluej-version.rc')
+        fileset(dir: '../bluej/package/winsetup', includes: 'bluej-version.rc')
     }
     // And in the launcher manifest:
     ant.replaceregexp(match:'(\\s*<assemblyIdentity\\s+version=)\".*\"', replace:"\\1\"${bluejVersionNoSuffix}.0\"", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'bjmanifest.xml')
+        fileset(dir: '../bluej/package/winsetup', includes: 'bjmanifest.xml')
     }
     def bjMSIProductId = versionProps["bluej-" + bluejVersion];
     // Update the WiX build files with the GUID:
     ant.replaceregexp(match:'<Product Version=\'.*\' Id=\'.*\'', replace:"<Product Version='${bluejVersionNoSuffix}' Id='${bjMSIProductId}'", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'bluej.wxs')
+        fileset(dir: '../bluej/package/winsetup', includes: 'bluej.wxs')
     }
     ant.replaceregexp(match:'(\\s*<Property\\s+Id=\"SOFTWAREVERSION\"\\s+Value=).*', replace:"\\1\"${bluejVersionNoSuffix}\"/>", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'bluej.wxs')
+        fileset(dir: '../bluej/package/winsetup', includes: 'bluej.wxs')
     }
 
     //////////////////////////////////////
@@ -155,22 +155,22 @@ task updateVersionNumber {
     }
     // Update Greenfoot version number in launcher EXE info:
     ant.replaceregexp(match:'(FILE|PRODUCT)VERSION .*', replace:"\\1VERSION ${greenfootVersionCommas},0", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'greenfoot-version.rc')
+        fileset(dir: '../bluej/package/winsetup', includes: 'greenfoot-version.rc')
     }
     ant.replaceregexp(match:'(\\s*VALUE \"\\w+Version\",).*', replace:"\\1 \"${greenfootVersionNoSuffix}\"", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'greenfoot-version.rc')
+        fileset(dir: '../bluej/package/winsetup', includes: 'greenfoot-version.rc')
     }
     // And in the launcher manifest:
     ant.replaceregexp(match:'(\\s*<assemblyIdentity\\s+version=)\".*\"', replace:"\\1\"${greenfootVersionNoSuffix}.0\"", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'gfmanifest.xml')
+        fileset(dir: '../bluej/package/winsetup', includes: 'gfmanifest.xml')
     }
     def gfMSIProductId = versionProps["greenfoot-" + greenfootVersion];
     // Update the WiX build files with the GUID:
     ant.replaceregexp(match:'<Product Version=\'.*\' Id=\'.*\'', replace:"<Product Version='${greenfootVersionNoSuffix}' Id='${gfMSIProductId}'", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'greenfoot.wxs')
+        fileset(dir: '../bluej/package/winsetup', includes: 'greenfoot.wxs')
     }
     ant.replaceregexp(match:'(\\s*<Property\\s+Id=\"SOFTWAREVERSION\"\\s+Value=).*', replace:"\\1\"${greenfootVersionNoSuffix}\"/>", byline:true) {
-        fileset(dir: '../bluej/package/winlaunch', includes: 'greenfoot.wxs')
+        fileset(dir: '../bluej/package/winsetup', includes: 'greenfoot.wxs')
     }
 }
 


### PR DESCRIPTION
There was an error in the updateVersionNumber task which meant that during the build, the MSI details were not updated correctly.  Thus the 5.2.0 MSI accidentally had internal version number of 5.1.0 and the old GUID too.