### PR TITLE
Add the ability to select input/output audio devices for Greenfoot

### DIFF
--- a/bluej/src/main/java/bluej/prefmgr/MiscPrefPanel.java
+++ b/bluej/src/main/java/bluej/prefmgr/MiscPrefPanel.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import bluej.pkgmgr.Project;
 import bluej.debugger.RunOnThread;
+import com.google.common.collect.ImmutableList;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
@@ -58,6 +59,7 @@ import threadchecker.Tag;
 public class MiscPrefPanel extends VBox 
                            implements PrefPanelListener
 {
+    private final int normalChildren;
     private CheckBox linkToLibBox;
     private CheckBox showUncheckedBox; // show "unchecked" compiler warning
     private TextField playerNameField;
@@ -66,6 +68,7 @@ public class MiscPrefPanel extends VBox
     private Label statusLabel;
     private ComboBox<RunOnThread> runOnThread;
     private Node threadRunSetting;
+    private List<MiscPrefPanelItem> extraItems;
 
     /**
      * Setup the UI for the dialog and event handlers for the buttons.
@@ -87,6 +90,7 @@ public class MiscPrefPanel extends VBox
             getChildren().add(makeVMPanel());
             getChildren().add(makeDataCollectionPanel());
         }
+        normalChildren = getChildren().size();
     }
 
     private Node makeDataCollectionPanel()
@@ -189,9 +193,13 @@ public class MiscPrefPanel extends VBox
         {
             playerNameField.setText(PrefMgr.getPlayerName().get());
         }
+        extraItems.forEach(p -> p.beginEditing(project));
     }
 
-    public void revertEditing(Project project) { }
+    public void revertEditing(Project project)
+    {
+        extraItems.forEach(p -> p.revertEditing(project));
+    }
 
     public void commitEditing(Project project)
     {
@@ -214,5 +222,24 @@ public class MiscPrefPanel extends VBox
         {
             PrefMgr.getPlayerName().set(playerNameField.getText());
         }
+        extraItems.forEach(p -> p.commitEditing(project));
+    }
+
+    /**
+     * Sets the extra items at the bottom of the panel (in Greenfoot, this is the sound devices).
+     * Replaces the previous extra items
+     * 
+     * @param miscPrefPanelItems The extra items to set.  All existing items will be removed.  Pass the empty list to make it blank.
+     */
+    public void setExtraItems(List<MiscPrefPanelItem> miscPrefPanelItems)
+    {
+        // Get rid of any old extra items:
+        getChildren().remove(normalChildren, getChildren().size());
+        // Add the new ones:
+        for (MiscPrefPanelItem miscPrefPanelItem : miscPrefPanelItems)
+        {
+            getChildren().add(PrefMgrDialog.headedVBoxTranslated(miscPrefPanelItem.getMiscPanelTitle(), miscPrefPanelItem.getMiscPanelContents()));
+        }
+        this.extraItems = ImmutableList.copyOf(miscPrefPanelItems);
     }
 }

--- a/bluej/src/main/java/bluej/prefmgr/MiscPrefPanelItem.java
+++ b/bluej/src/main/java/bluej/prefmgr/MiscPrefPanelItem.java
@@ -1,0 +1,44 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2023  Michael Kolling and John Rosenberg
+ 
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+ 
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+ 
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+ 
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.prefmgr;
+
+import javafx.scene.Node;
+
+import java.util.List;
+
+/**
+ * An item that can be shown at the bottom of the miscellaneous preferences panel.
+ * 
+ * It inherits the begin/commit/revert events from PrefPanelListener
+ */
+public interface MiscPrefPanelItem extends PrefPanelListener
+{
+    /**
+     * Gets the nodes to add to the VBox as the content of the extra item
+     */
+    public List<Node> getMiscPanelContents();
+
+    /**
+     * Gets the title (already localised) of the item, to put as the header for that section.
+     */
+    public String getMiscPanelTitle();
+}

--- a/bluej/src/main/java/bluej/prefmgr/PrefMgr.java
+++ b/bluej/src/main/java/bluej/prefmgr/PrefMgr.java
@@ -80,6 +80,9 @@ public class PrefMgr
     // (if we called it 0,1,2, tiny would be -1 which seems like a bad idea)
     public static final String PRINT_FONT_SIZE = "bluej.print.fontSize";
     
+    public static final String GREENFOOT_SOUND_INPUT_DEVICE = "greenfoot.sound.device.input";
+    public static final String GREENFOOT_SOUND_OUTPUT_DEVICE = "greenfoot.sound.device.output";
+    
     public static final int MIN_EDITOR_FONT_SIZE = 6;
     public static final int MAX_EDITOR_FONT_SIZE = 160;
     public static final int DEFAULT_STRIDE_FONT_SIZE = 11;

--- a/greenfoot/labels/english/greenfoot/greenfoot-labels
+++ b/greenfoot/labels/english/greenfoot/greenfoot-labels
@@ -366,3 +366,4 @@ greenfoot.sound.input=Microphone
 greenfoot.sound.output=Output
 greenfoot.sound.prefs=Sound devices
 greenfoot.sound.warning=You will need to restart Greenfoot for any changes to take effect in the scenario.
+greenfoot.sound.device.default=Java default

--- a/greenfoot/labels/english/greenfoot/greenfoot-labels
+++ b/greenfoot/labels/english/greenfoot/greenfoot-labels
@@ -361,3 +361,8 @@ notAProject.greenfoot.message=The selected folder does not contain a Greenfoot s
 notAProject.greenfoot.subDirs=Some child folders contain Greenfoot scenarios.  Did you mean:
 notAProject.greenfoot.subDirButton=Open Selected
 notAProject.greenfoot.button=Choose Again...
+
+greenfoot.sound.input=Microphone
+greenfoot.sound.output=Output
+greenfoot.sound.prefs=Sound devices
+greenfoot.sound.warning=You will need to restart Greenfoot for any changes to take effect in the scenario.

--- a/greenfoot/src/main/java/greenfoot/core/ProjectManager.java
+++ b/greenfoot/src/main/java/greenfoot/core/ProjectManager.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2015,2017,2018,2019,2021  Poul Henriksen and Michael Kolling
+ Copyright (C) 2005-2015,2017,2018,2019,2021,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -43,6 +43,7 @@ import bluej.pkgmgr.DocPathEntry;
 import bluej.pkgmgr.Package;
 import bluej.pkgmgr.Project;
 import bluej.pkgmgr.target.ClassTarget;
+import bluej.prefmgr.PrefMgr;
 import bluej.utility.Debug;
 import bluej.utility.DialogManager;
 import greenfoot.core.GreenfootMain.VersionCheckInfo;
@@ -463,9 +464,16 @@ public class ProjectManager
         
         
         Properties debugVMProps = new Properties();
-        debugVMProps.put("bluej.language", Config.getPropString("bluej.language", ""));
-        debugVMProps.put("vm.language", Config.getPropString("vm.language", ""));
-        debugVMProps.put("vm.country", Config.getPropString("vm.country", ""));
+        // These are the only properties that need carrying across to the debug VM:
+        for (String prop : List.of(
+            "bluej.language",
+            "vm.language",
+            "vm.country",
+            PrefMgr.GREENFOOT_SOUND_INPUT_DEVICE,
+            PrefMgr.GREENFOOT_SOUND_OUTPUT_DEVICE))
+        {
+            debugVMProps.put(prop, Config.getPropString(prop, ""));
+        }
         File tmpPropsFile = null;
         try
         {

--- a/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2017,2018,2019,2019,2020,2021,2022  Poul Henriksen and Michael Kolling
+ Copyright (C) 2017,2018,2019,2019,2020,2021,2022,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -86,6 +86,7 @@ import greenfoot.guifx.images.NewImageClassFrame;
 import greenfoot.guifx.images.SelectImageFrame;
 import greenfoot.guifx.soundrecorder.SoundRecorderControls;
 import greenfoot.record.GreenfootRecorder;
+import greenfoot.sound.SoundPreferencePanel;
 import greenfoot.util.GreenfootUtil;
 import greenfoot.vmcomm.GreenfootDebugHandler;
 import greenfoot.vmcomm.GreenfootDebugHandler.SimulationStateListener;
@@ -1290,7 +1291,7 @@ public class GreenfootStage extends Stage implements FXCompileObserver,
      */
     public static void showPreferences()
     {
-        PrefMgrDialog.showDialog(null);
+        PrefMgrDialog.showDialog(null, new SoundPreferencePanel());
     }
 
     /**

--- a/greenfoot/src/main/java/greenfoot/sound/MicLevelGrabber.java
+++ b/greenfoot/src/main/java/greenfoot/sound/MicLevelGrabber.java
@@ -51,6 +51,7 @@ public class MicLevelGrabber
             try {
                 Mixer mixer = SoundUtils.loadMixer(true);
                 Info info = new Info(TargetDataLine.class, format);
+                // Use the specific mixer from the preferences if it is available (i.e. non-null):
                 TargetDataLine line = (TargetDataLine)(mixer == null ? AudioSystem.getLine(info) : mixer.getLine(info));
                 line.open();
                 line.start();

--- a/greenfoot/src/main/java/greenfoot/sound/MicLevelGrabber.java
+++ b/greenfoot/src/main/java/greenfoot/sound/MicLevelGrabber.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2011,2016,2021  Poul Henriksen and Michael Kolling
+ Copyright (C) 2011,2016,2021,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -23,8 +23,9 @@ package greenfoot.sound;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.DataLine;
+import javax.sound.sampled.DataLine.Info;
 import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.Mixer;
 import javax.sound.sampled.TargetDataLine;
 
 /**
@@ -48,7 +49,9 @@ public class MicLevelGrabber
         format = new AudioFormat(22050, 8, 1, true, true);
         updator = () -> {
             try {
-                TargetDataLine line = (TargetDataLine) AudioSystem.getLine(new DataLine.Info(TargetDataLine.class, format));
+                Mixer mixer = SoundUtils.loadMixer(true);
+                Info info = new Info(TargetDataLine.class, format);
+                TargetDataLine line = (TargetDataLine)(mixer == null ? AudioSystem.getLine(info) : mixer.getLine(info));
                 line.open();
                 line.start();
                 int bufferSize = (int) (format.getSampleRate() / 20) * format.getFrameSize();

--- a/greenfoot/src/main/java/greenfoot/sound/SoundClip.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundClip.java
@@ -36,6 +36,7 @@ import javax.sound.sampled.FloatControl;
 import javax.sound.sampled.LineEvent;
 import javax.sound.sampled.LineListener;
 import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.Mixer;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
 /**
@@ -140,8 +141,9 @@ public class SoundClip implements Sound, LineListener
         AudioInputStream stream = new AudioInputStream(is, format, clipData.getLength());
         DataLine.Info info = new DataLine.Info(Clip.class, format);
 
+        Mixer mixer = SoundUtils.loadMixer(false);
         // getLine throws illegal argument exception if it can't find a line.
-        soundClip = (Clip) AudioSystem.getLine(info);
+        soundClip = (Clip) (mixer == null ? AudioSystem.getLine(info) : mixer.getLine(info));
         soundClip.open(stream);
         
         // Note we don't use soundClip.getMicrosecondLength() due to an IcedTea bug:

--- a/greenfoot/src/main/java/greenfoot/sound/SoundClip.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundClip.java
@@ -142,6 +142,7 @@ public class SoundClip implements Sound, LineListener
         DataLine.Info info = new DataLine.Info(Clip.class, format);
 
         Mixer mixer = SoundUtils.loadMixer(false);
+        // Use the specific mixer from the preferences if it is available (i.e. non-null):
         // getLine throws illegal argument exception if it can't find a line.
         soundClip = (Clip) (mixer == null ? AudioSystem.getLine(info) : mixer.getLine(info));
         soundClip.open(stream);

--- a/greenfoot/src/main/java/greenfoot/sound/SoundClip.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundClip.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2011,2012,2013  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2011,2012,2013,2023  Poul Henriksen and Michael Kolling 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -93,7 +93,7 @@ public class SoundClip implements Sound, LineListener
     /**
      * Creates a new sound clip
      */
-    public SoundClip(String name, URL url, SoundPlaybackListener listener)
+    public SoundClip(URL url, SoundPlaybackListener listener)
     {
         this.url = url;
         playbackListener = listener;

--- a/greenfoot/src/main/java/greenfoot/sound/SoundFactory.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundFactory.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2011,2012  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2011,2012,2023  Poul Henriksen and Michael Kolling 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -113,7 +113,7 @@ public class SoundFactory
             } 
             else {
                 // The sound is small enough to be loaded into memory as a clip.
-                return new SoundClip(file, url, soundCollection);
+                return new SoundClip(url, soundCollection);
             }
         } catch (IOException e) {
             if (! quiet) {

--- a/greenfoot/src/main/java/greenfoot/sound/SoundPreferencePanel.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundPreferencePanel.java
@@ -112,7 +112,7 @@ public class SoundPreferencePanel extends GridPane implements MiscPrefPanelItem
             @Override
             public String toString(Mixer object)
             {
-                return object == null ? "Default" : object.getMixerInfo().getName();
+                return object == null ? Config.getString("greenfoot.sound.device.default") : object.getMixerInfo().getName();
             }
 
             @Override

--- a/greenfoot/src/main/java/greenfoot/sound/SoundPreferencePanel.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundPreferencePanel.java
@@ -1,0 +1,166 @@
+/*
+ This file is part of the Greenfoot program. 
+ Copyright (C) 2023  Poul Henriksen and Michael Kolling 
+ 
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+ 
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+ 
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+ 
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package greenfoot.sound;
+
+import bluej.Config;
+import bluej.pkgmgr.Project;
+import bluej.prefmgr.MiscPrefPanelItem;
+import bluej.prefmgr.PrefMgr;
+import javafx.scene.Node;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.util.StringConverter;
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Mixer;
+import javax.sound.sampled.SourceDataLine;
+import javax.sound.sampled.TargetDataLine;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * A GUI preference panel allowing selection of recording and playback device.
+ * 
+ * The identifier is saved as a String.  If we can't find it on load, we treat
+ * it as the default device (which is stored as null here, and the empty string in a file)
+ */
+@OnThread(Tag.FXPlatform)
+public class SoundPreferencePanel extends GridPane implements MiscPrefPanelItem
+{
+    private final ComboBox<Mixer> inputDevice = new ComboBox<>();
+    private final ComboBox<Mixer> outputDevice = new ComboBox<>();
+    
+    public SoundPreferencePanel()
+    {
+        // Initialise available items first:
+        
+        // This is the right way round; target lines are input devices, source lines are output devices:
+        initialize(inputDevice, true, mixer -> Arrays.stream(mixer.getTargetLineInfo()).anyMatch(i -> i.getLineClass().equals(TargetDataLine.class)));
+        initialize(outputDevice, false, mixer -> Arrays.stream(mixer.getSourceLineInfo()).anyMatch(i -> i.getLineClass().equals(SourceDataLine.class)));
+        
+        Label inputLabel = new Label(Config.getString("greenfoot.sound.input"));
+        add(inputLabel, 0, 0);
+        add(inputDevice, 1, 0);
+        Label outputLabel = new Label(Config.getString("greenfoot.sound.output"));
+        add(outputLabel, 0, 1);
+        add(outputDevice, 1, 1);
+        Label warning = new Label(Config.getString("greenfoot.sound.warning"));
+        warning.setWrapText(true);
+        add(warning, 0, 2);
+        setColumnSpan(warning, 2);
+        setVgap(7);
+        setHgap(5);
+        ColumnConstraints cc0 = new ColumnConstraints();
+        cc0.setMinWidth(GridPane.USE_PREF_SIZE);
+        cc0.setHgrow(Priority.ALWAYS);
+        ColumnConstraints cc1 = new ColumnConstraints();
+        cc1.setMinWidth(GridPane.USE_PREF_SIZE);
+        getColumnConstraints().addAll(cc0, cc1);
+    }
+
+    /**
+     * Initialize the given combo box with the list of available mixers
+     * 
+     * @param audioDropdown The combo box to add the items to.  The selection will be loaded from the preferences file, or system default if blank
+     * @param input Whether this an input device (true) or output device (false)
+     * @param valid The test for whether the mixer is a valid option to add.  Some mixers are things like volume controls, not actual input or output devices.
+     */
+    private static void initialize(ComboBox<Mixer> audioDropdown, boolean input, Predicate<Mixer> valid)
+    {
+        audioDropdown.getItems().clear();
+        // We always add null, which is the system default:
+        audioDropdown.getItems().add(null);
+        for (Mixer.Info mixerInfo : AudioSystem.getMixerInfo())
+        {
+            Mixer mixer = AudioSystem.getMixer(mixerInfo);
+            if (valid.test(mixer))
+            {
+                audioDropdown.getItems().add(mixer);
+            }
+        }
+        
+        // Load item from preferences file:
+        audioDropdown.getSelectionModel().select(SoundUtils.loadMixer(audioDropdown.getItems(), input));
+
+        audioDropdown.setConverter(new StringConverter<Mixer>()
+        {
+            @Override
+            public String toString(Mixer object)
+            {
+                return object == null ? "Default" : object.getMixerInfo().getName();
+            }
+
+            @Override
+            public Mixer fromString(String string)
+            {
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Gets the selected input mixer from the combo box, or null if the default should be used.
+     */
+    public Mixer getInputMixer()
+    {
+        return inputDevice.getValue();
+    }
+
+    @Override
+    @OnThread(Tag.FXPlatform)
+    public void beginEditing(Project project)
+    {
+        inputDevice.getSelectionModel().select(SoundUtils.loadMixer(inputDevice.getItems(), true));
+        outputDevice.getSelectionModel().select(SoundUtils.loadMixer(outputDevice.getItems(), false));
+    }
+
+    @Override
+    @OnThread(Tag.FXPlatform)
+    public void commitEditing(Project project)
+    {
+        Config.putPropString(PrefMgr.GREENFOOT_SOUND_INPUT_DEVICE, inputDevice.getValue() == null ? "" : inputDevice.getValue().getMixerInfo().toString());
+        Config.putPropString(PrefMgr.GREENFOOT_SOUND_OUTPUT_DEVICE, outputDevice.getValue() == null ? "" : outputDevice.getValue().getMixerInfo().toString());
+    }
+
+    @Override
+    public void revertEditing(Project project)
+    {
+    }
+    
+    @Override
+    public List<Node> getMiscPanelContents()
+    {
+        return List.of(this);
+    }
+
+    @Override
+    public String getMiscPanelTitle()
+    {
+        return Config.getString("greenfoot.sound.prefs");
+    }
+}

--- a/greenfoot/src/main/java/greenfoot/sound/SoundRecorder.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundRecorder.java
@@ -37,7 +37,9 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.DataLine;
+import javax.sound.sampled.DataLine.Info;
 import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.Mixer;
 import javax.sound.sampled.TargetDataLine;
 
 import bluej.utility.Debug;
@@ -77,11 +79,22 @@ public class SoundRecorder
      * The reference should be updated roughly every half-second.
      * 
      * When the recording has finished, null will be put into the reference.
+     * 
+     * @param mixer The mixer to use, pass null to use the system default device.
      */
-    public AtomicReference<List<byte[]>> startRecording()
+    public AtomicReference<List<byte[]>> startRecording(Mixer mixer)
     {
-        try {
-            line = (TargetDataLine)AudioSystem.getLine(new DataLine.Info(TargetDataLine.class, format));
+        try
+        {
+            Info lineInfo = new Info(TargetDataLine.class, format);
+            if (mixer != null)
+            {
+                line = (TargetDataLine)mixer.getLine(lineInfo);
+            }
+            else
+            {
+                line = (TargetDataLine)AudioSystem.getLine(lineInfo);
+            }
             line.open();
             if (!line.getFormat().equals(format))
                 Debug.message("Format is not as expected" + line.getFormat().toString());

--- a/greenfoot/src/main/java/greenfoot/sound/SoundStream.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundStream.java
@@ -435,7 +435,8 @@ public class SoundStream implements Sound, Runnable
     {
         // Load mixer from the preferences:
         Mixer mixer = SoundUtils.loadMixer(false);
-        
+
+        // Use the specific mixer from the preferences if it is available (i.e. non-null):
         //Throws IllegalArgumentException if it can't find a line
         SourceDataLine l = (SourceDataLine)(mixer == null ? AudioSystem.getLine(info) : mixer.getLine(info));
         printDebug("buffer size: " + l.getBufferSize());

--- a/greenfoot/src/main/java/greenfoot/sound/SoundStream.java
+++ b/greenfoot/src/main/java/greenfoot/sound/SoundStream.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2011,2012  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2011,2012,2023  Poul Henriksen and Michael Kolling 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -27,6 +27,7 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.DataLine;
 import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.Mixer;
 import javax.sound.sampled.SourceDataLine;
 import javax.sound.sampled.UnsupportedAudioFileException;
 import javax.sound.sampled.DataLine.Info;
@@ -432,8 +433,11 @@ public class SoundStream implements Sound, Runnable
     private AudioLine initialiseLine(DataLine.Info info, AudioFormat format)
             throws LineUnavailableException, IllegalArgumentException
     {
+        // Load mixer from the preferences:
+        Mixer mixer = SoundUtils.loadMixer(false);
+        
         //Throws IllegalArgumentException if it can't find a line
-        SourceDataLine l = (SourceDataLine) AudioSystem.getLine(info);
+        SourceDataLine l = (SourceDataLine)(mixer == null ? AudioSystem.getLine(info) : mixer.getLine(info));
         printDebug("buffer size: " + l.getBufferSize());
         return new AudioLine(l, format);
     }


### PR DESCRIPTION
This adds an option in the sound recorder window and the general preferences to select an audio device for input and output (independently).  This is then saved into the local preferences so that it persists across sessions.

Fixes #2244 
Fixes #2245 