### PR TITLE
Added the Korean translators in About + removed table columns preferred widths

### DIFF
--- a/bluej/src/main/java/bluej/pkgmgr/AboutDialogTemplate.java
+++ b/bluej/src/main/java/bluej/pkgmgr/AboutDialogTemplate.java
@@ -227,19 +227,11 @@ public class AboutDialogTemplate extends Dialog<Void>
             tableView.getStyleClass().add("about-translators-table");
             tableView.setEditable(false);
 
-            // The width properties add up to 97% and not 100% to forbid the scroll from appearing,
-            // as there is no API, currently, to achieve this
             TableColumn<Pair<String, String>, String> languageColumn = new TableColumn<>();
             languageColumn.setCellValueFactory(param -> new ReadOnlyStringWrapper(param.getValue().getKey()));
 
             TableColumn<Pair<String, String>, String> nameColumn = new TableColumn<>();
             nameColumn.setCellValueFactory(param -> new ReadOnlyStringWrapper(param.getValue().getValue()));
-            
-            JavaFXUtil.addChangeListenerAndCallNow(tableView.widthProperty(), newVal -> 
-            {
-                languageColumn.setPrefWidth(newVal.doubleValue() * 0.17);
-                nameColumn. setPrefWidth(newVal.doubleValue() * 0.80);
-            });
 
             tableView.getColumns().setAll(languageColumn, nameColumn);
             vbox.getChildren().add(tableView);

--- a/bluej/src/main/java/bluej/pkgmgr/PkgMgrFrame.java
+++ b/bluej/src/main/java/bluej/pkgmgr/PkgMgrFrame.java
@@ -1961,6 +1961,7 @@ public class PkgMgrFrame
                 "Greek",        "Ioannis G. Baltopoulos",
                 "Hindi",        "Tajvir Singh",
                 "Italian",      "Angelo Papadia and Luzio Menna",
+                "Korean",       "Suk-Hyung Hwang, Juwon Hwang, and other members of the Korean BlueJ Users Group (KBUG)",
                 "Montenegrin",  "Omer Djokic",
                 "Persian",      "M. Shahdoost",
                 "Portuguese",   "Marco Aurelio Souza Mangan, Fabio Hedayioglu, and Fred Guedes Pereira",


### PR DESCRIPTION
For the translators TableView, the columns' preferred width being set was supposed to avoid showing a scrollbar, but it shows anyway, and adding the Korean translators made the content even larger; so we now let JavaFX handle it.