### PR TITLE
Allow extensions to add Java editor context menu items

### DIFF
--- a/bluej/src/main/java/bluej/editor/EditorWatcher.java
+++ b/bluej/src/main/java/bluej/editor/EditorWatcher.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2013,2014,2016,2017,2018,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2013,2014,2016,2017,2018,2020,2021,2022,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/editor/EditorWatcher.java
+++ b/bluej/src/main/java/bluej/editor/EditorWatcher.java
@@ -31,6 +31,7 @@ import bluej.compiler.CompileType;
 import bluej.editor.stride.FrameCatalogue;
 import bluej.pkgmgr.Package;
 import bluej.stride.generic.Frame;
+import javafx.scene.control.ContextMenu;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
@@ -201,4 +202,9 @@ public interface EditorWatcher
      * If in doubt, pass 0.
      */
     void showPreferences(int paneIndex);
+
+    default void addExtensionContextMenuItemsToJavaEditor(ContextMenu contextMenu)
+    {
+        // Default is to do nothing with the menu.  This is overridden by subclasses.
+    }
 }

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -549,7 +549,11 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
             getActions().getActionByName("copy-to-clipboard").makeContextMenuItem(Config.getString("editor.copyLabel")),
             getActions().getActionByName("paste-from-clipboard").makeContextMenuItem(Config.getString("editor.pasteLabel"))
         );
-        watcher.addExtensionContextMenuItemsToJavaEditor(this.editorContextMenu);
+        // watcher is null for plain text files, and during testing:
+        if (watcher != null)
+        {
+            watcher.addExtensionContextMenuItemsToJavaEditor(this.editorContextMenu);
+        }
 
         JavaFXUtil.addChangeListenerPlatform(PrefMgr.getEditorFontSize(), s -> {
             javaSyntaxView.fontSizeChanged();

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -549,6 +549,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
             getActions().getActionByName("copy-to-clipboard").makeContextMenuItem(Config.getString("editor.copyLabel")),
             getActions().getActionByName("paste-from-clipboard").makeContextMenuItem(Config.getString("editor.pasteLabel"))
         );
+        watcher.addExtensionContextMenuItemsToJavaEditor(this.editorContextMenu);
 
         JavaFXUtil.addChangeListenerPlatform(PrefMgr.getEditorFontSize(), s -> {
             javaSyntaxView.fontSizeChanged();

--- a/bluej/src/main/java/bluej/extensions2/BlueJ.java
+++ b/bluej/src/main/java/bluej/extensions2/BlueJ.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2013,2014,2016,2018,2019,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2013,2014,2016,2018,2019,2021,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -850,23 +850,20 @@ public final class BlueJ
     }
 
     /**
-     * Calls the extension to get the right menu item.
+     * Calls the extension to get the right menu item(s).
      * This is already wrapped for errors in the caller.
-     * It is right for it to create a new wrapped object each time.
-     * Extensions do not to share objects.
-     * It is here since it can access all constructors directly.
      *
      * @param  attachedObject  an {@link ExtensionMenu} object that will contain the generated {@link MenuItem}.
-     * @return                 The generated {@link MenuItem}, <code>null</code> if the extension has not installed any {@link MenuGenerator},
+     * @return                 The generated {@link MenuItem}s, <code>null</code> if the extension has not installed any {@link MenuGenerator},
      *                          or if the argument <code>attachedObject</code> is <code>null</code>.
      */
-    MenuItem getMenuItem(ExtensionMenu attachedObject)
+    List<MenuItem> getMenuItems(ExtensionMenu attachedObject)
     {
         if ((currentMenuGen == null) || (attachedObject == null)) {
             return null;
         }
 
-        return attachedObject.getMenuItem(currentMenuGen);
+        return attachedObject.getMenuItems(currentMenuGen);
     }
 
 
@@ -874,12 +871,12 @@ public final class BlueJ
      * Posts a notification of a menu going to be displayed
      *
      * @param  attachedObject  an {@link ExtensionMenu} object that contains extension generated {@link MenuItem} object.
-     * @param  onThisItem  an {@link MenuItem} object that triggered a call to this method.
+     * @param  onTheseItems  a list of {@link MenuItem} objects that are associated with this extension, that triggered a call to this method.
      */
-    void postMenuItem(ExtensionMenu attachedObject, MenuItem onThisItem)
+    void postMenuItem(ExtensionMenu attachedObject, List<MenuItem> onTheseItems)
     {
         if ((currentMenuGen != null) && (attachedObject != null)) {
-            attachedObject.postMenuItem(currentMenuGen, onThisItem);
+            attachedObject.postMenuItems(currentMenuGen, onTheseItems);
         }
     }
 

--- a/bluej/src/main/java/bluej/extensions2/Extension.java
+++ b/bluej/src/main/java/bluej/extensions2/Extension.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2012,2014,2019,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2012,2014,2019,2021,2022,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/extensions2/Extension.java
+++ b/bluej/src/main/java/bluej/extensions2/Extension.java
@@ -57,11 +57,11 @@ public abstract class Extension
     /**
      * Obtains the minor version of the Extensions API.
      *
-     * @return An integer indicating the minor version of the Extensions API. Currently 3.
+     * @return An integer indicating the minor version of the Extensions API. Currently 4.
      */
     protected static final int getExtensionsAPIVersionMinor()
     {
-        return 3;
+        return 4;
     }
 
     /**

--- a/bluej/src/main/java/bluej/extensions2/ExtensionBridge.java
+++ b/bluej/src/main/java/bluej/extensions2/ExtensionBridge.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2011,2012,2013,2014,2016,2019,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2011,2012,2013,2014,2016,2019,2021,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -89,15 +89,15 @@ public final class ExtensionBridge
         bClass.nameChanged(newName);
     }
 
-    public static MenuItem getMenuItem(BlueJ aBluej, ExtensionMenu attachedObject)
+    public static List<MenuItem> getMenuItems(BlueJ aBluej, ExtensionMenu attachedObject)
     {
-        return aBluej.getMenuItem(attachedObject);
+        return aBluej.getMenuItems(attachedObject);
     }
 
-    public static void postMenuItem(BlueJ aBluej, ExtensionMenu attachedObject,
-                                    MenuItem onThisItem)
+    public static void postMenuItems(BlueJ aBluej, ExtensionMenu attachedObject,
+                                     List<MenuItem> onTheseItems)
     {
-        aBluej.postMenuItem(attachedObject, onThisItem);
+        aBluej.postMenuItem(attachedObject, onTheseItems);
     }
 
     public static Project getProject(BProject bProject) throws ProjectNotOpenException

--- a/bluej/src/main/java/bluej/extensions2/MenuGenerator.java
+++ b/bluej/src/main/java/bluej/extensions2/MenuGenerator.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program.
- Copyright (C) 1999-2009,2012,2018,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2018,2019,2023  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -22,6 +22,9 @@
 package bluej.extensions2;
 
 import javafx.scene.control.MenuItem;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Extensions which wish to add a menu item to BlueJ's menus should register an
@@ -66,7 +69,7 @@ public class MenuGenerator
      * should not retain references to the menu items created.
      *
      * @param bPackage a {@link BPackage} object wrapping the BlueJ package with which this menu item will be associated.
-     * @return This method should return a {@link MenuItem} object to be added to the Ppackage menu for this extensions, <code>null</code> is returned by default.
+     * @return This method should return a {@link MenuItem} object to be added to the Package menu for this extensions, <code>null</code> is returned by default.
      */
     public MenuItem getPackageMenuItem(BPackage bPackage)
     {
@@ -93,6 +96,17 @@ public class MenuGenerator
     public MenuItem getObjectMenuItem(BObject bObject)
     {
         return null;
+    }
+
+    /**
+     * Returns the list of MenuItem to be added to the context menu in the Java editor.
+     * @param bClass The class being edited (which will be a Java class, at least when this method is called -- users can convert classes to Stride if they want, but the context menu will no longer show in the editor in that case).
+     * @return A list of 0, 1, or more MenuItem to be added to the context menu.  If you have many items, it may be better interface design to use a sub-menu (i.e. an instance of Menu).
+     * @since Extensions API 3.4 (BlueJ 5.2.1)
+     */
+    public List<MenuItem> getJavaEditorContextMenuItems(BClass bClass)
+    {
+        return Collections.emptyList();
     }
 
     /**
@@ -148,4 +162,16 @@ public class MenuGenerator
         return;
     }
 
+    /**
+     * Called by BlueJ when a Java editor context menu with items added by an extension is about to
+     * be displayed. An extension can use this notification to decide whether
+     * to enable/disable menu items and so on.
+     * @param bClass a {@link Class} object wrapping the Java class for which this menu is to be displayed.
+     * @param menuItems a list of {@link MenuItem} objects associated with this extension that are about to be be displayed (as provided by the
+     * extension in a previous call to {@link #getJavaEditorContextMenuItems(BClass)} for this class).
+     * @since Extensions API 3.4 (BlueJ 5.2.1)
+     */
+    public void notifyPostJavaEditorContextMenu(BClass bClass, List<MenuItem> menuItems)
+    {
+    }
 }

--- a/bluej/src/main/java/bluej/extmgr/ClassExtensionMenu.java
+++ b/bluej/src/main/java/bluej/extmgr/ClassExtensionMenu.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2012,2013,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 2012,2013,2016,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -35,7 +35,7 @@ import threadchecker.Tag;
  * 
  * @author Simon Gerlach
  */
-public class ClassExtensionMenu implements ExtensionMenu
+public class ClassExtensionMenu implements ExtensionMenuSingle
 {
     private final ClassTarget classTarget;
 

--- a/bluej/src/main/java/bluej/extmgr/ExtensionMenu.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionMenu.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2012,2013,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 2012,2013,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -24,6 +24,8 @@ package bluej.extmgr;
 import bluej.extensions2.MenuGenerator;
 import javafx.scene.control.MenuItem;
 
+import java.util.List;
+
 /**
  * This interface provides methods for retrieving custom menu entries of an
  * extension and to notify it if a menu is about to show. Implementations of
@@ -34,14 +36,14 @@ import javafx.scene.control.MenuItem;
 public interface ExtensionMenu
 {
     /**
-     * Calls the extension to get a menu item.
+     * Calls the extension to get a list of menu items.
      * 
      * @param menuGenerator
      *            The {@link MenuGenerator} which creates the menu.
-     * @return The {@link MenuItem} the extension provides or <code>null</code>
+     * @return The {@link MenuItem}s the extension provides or empty list
      *         if it does not provide a menu entry.
      */
-    MenuItem getMenuItem(MenuGenerator menuGenerator);
+    List<MenuItem> getMenuItems(MenuGenerator menuGenerator);
 
     /**
      * Post a notification about a menu going to be displayed.
@@ -49,7 +51,7 @@ public interface ExtensionMenu
      * @param menuGenerator
      *            The {@link MenuGenerator} which creates the menu.
      * @param onThisItem
-     *            The {@link MenuItem} which is about to show.
+     *            The list of {@link MenuItem}s which are about to show, as previously returned by getMenuItems (it may not be the same list instance exactly, but it will have the same content in the same order).
      */
-    void postMenuItem(MenuGenerator menuGenerator, MenuItem onThisItem);
+    void postMenuItems(MenuGenerator menuGenerator, List<MenuItem> onThisItem);
 }

--- a/bluej/src/main/java/bluej/extmgr/ExtensionMenuSingle.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionMenuSingle.java
@@ -1,0 +1,68 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2023  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.extmgr;
+
+import bluej.extensions2.MenuGenerator;
+import javafx.scene.control.MenuItem;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An adaptation of ExtensionMenu that only supports single menu items
+ */
+public interface ExtensionMenuSingle extends ExtensionMenu
+{
+    /**
+     * Calls the extension to get a menu item.
+     *
+     * @param menuGenerator
+     *            The {@link MenuGenerator} which creates the menu.
+     * @return The {@link MenuItem} the extension provides or <code>null</code>
+     *         if it does not provide a menu entry.
+     */
+    MenuItem getMenuItem(MenuGenerator menuGenerator);
+
+    /**
+     * Post a notification about a menu going to be displayed.
+     *
+     * @param menuGenerator
+     *            The {@link MenuGenerator} which creates the menu.
+     * @param onThisItem
+     *            The {@link MenuItem} which is about to show.
+     */
+    void postMenuItem(MenuGenerator menuGenerator, MenuItem onThisItem);
+
+    // Default implementation to work with a single menu item.  Do not override.
+    @Override
+    default List<MenuItem> getMenuItems(MenuGenerator menuGenerator)
+    {
+        return Collections.singletonList(getMenuItem(menuGenerator));
+    }
+
+    // Default implementation to work with a single menu item.  Do not override.
+    @Override
+    default void postMenuItems(MenuGenerator menuGenerator, List<MenuItem> onThisItem)
+    {
+        postMenuItem(menuGenerator, onThisItem.get(0));
+    }
+}

--- a/bluej/src/main/java/bluej/extmgr/ExtensionWrapper.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionWrapper.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2012,2013,2014,2016,2018,2019,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2012,2013,2014,2016,2018,2019,2021,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -642,13 +642,14 @@ public class ExtensionWrapper
     /**
      *  Calls the EXTENSION getMenuItem in a safe way
      */
-    public MenuItem safeGetMenuItem(ExtensionMenu attachedObject)
+    public List<MenuItem> safeGetMenuItems(ExtensionMenu attachedObject)
     {
         if (extensionBluej == null) 
             return null;
 
         try {
-            return ExtensionBridge.getMenuItem(extensionBluej, attachedObject);
+            List<MenuItem> menuItems = ExtensionBridge.getMenuItems(extensionBluej, attachedObject);
+            return menuItems == null ? Collections.emptyList() : menuItems;
         }
         catch (Throwable exc) {
             Debug.message("ExtensionWrapper.safeMenuGenGetMenuItem: Class="+getExtensionClassName()+" Exception="+exc.getMessage());
@@ -660,13 +661,13 @@ public class ExtensionWrapper
     /**
      *  Calls the EXTENSION postMenuItem in a safe way
      */
-    public void safePostMenuItem(ExtensionMenu attachedObject, MenuItem onThisItem)
+    public void safePostMenuItems(ExtensionMenu attachedObject, List<MenuItem> onTheseItems)
     {
         if (extensionBluej == null) 
             return;
 
         try {
-            ExtensionBridge.postMenuItem(extensionBluej, attachedObject, onThisItem );
+            ExtensionBridge.postMenuItems(extensionBluej, attachedObject, onTheseItems);
         }
         catch (Throwable exc) {
             Debug.message("ExtensionWrapper.safePostGenGetMenuItem: Class="+getExtensionClassName()+" Exception="+exc.getMessage());

--- a/bluej/src/main/java/bluej/extmgr/ExtensionsManager.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionsManager.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2012,2013,2016,2019,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2012,2013,2016,2019,2021,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -359,14 +359,16 @@ public class ExtensionsManager
                     continue;
                 }
     
-                MenuItem anItem = aWrapper.safeGetMenuItem(attachedObject);
-                if (anItem == null) {
+                List<MenuItem> items = aWrapper.safeGetMenuItems(attachedObject);
+                if (items == null || items.isEmpty()) {
                     continue;
                 }
-    
-                anItem.getProperties().put("bluej.extmgr.ExtensionWrapper", aWrapper);
-    
-                menuItems.add(anItem);
+
+                for (MenuItem item : items)
+                {
+                    item.getProperties().put("bluej.extmgr.ExtensionWrapper", aWrapper);
+                    menuItems.add(item);
+                }
             }
         }
 

--- a/bluej/src/main/java/bluej/extmgr/ExtensionsMenuManager.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionsMenuManager.java
@@ -134,12 +134,6 @@ public final class ExtensionsMenuManager
         }
     }
 
-    @OnThread(Tag.Any)
-    private FXPlatformRunnable supplierToRunnable(FXPlatformSupplier<Menu> menuFXSupplier)
-    {
-        return () -> {menuFXSupplier.get();};
-    }
-
     private ObservableList<MenuItem> getItems()
     {
         if (popupMenu != null)

--- a/bluej/src/main/java/bluej/extmgr/ExtensionsMenuManager.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionsMenuManager.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2012,2013,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2012,2013,2016,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -22,9 +22,6 @@
 package bluej.extmgr;
 
 import bluej.pkgmgr.Project;
-import bluej.utility.javafx.FXPlatformRunnable;
-import bluej.utility.javafx.FXPlatformSupplier;
-import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.event.Event;
 import javafx.scene.control.ContextMenu;
@@ -35,6 +32,7 @@ import threadchecker.OnThread;
 import threadchecker.Tag;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 
 
@@ -154,9 +152,10 @@ public final class ExtensionsMenuManager
         // Take copy to iterate because we're doing removal:
         final ObservableList<MenuItem> items = getItems();
         ArrayList<MenuItem> popupMenuItems = new ArrayList<>(items);
-        for (MenuItem aComponent : popupMenuItems) {
+        IdentityHashMap<ExtensionWrapper, ArrayList<MenuItem>> itemsByExtension = new IdentityHashMap<>();
+        for (MenuItem menuItem : popupMenuItems) {
 
-            ExtensionWrapper aWrapper = (ExtensionWrapper) aComponent.getProperties().get(
+            ExtensionWrapper aWrapper = (ExtensionWrapper) menuItem.getProperties().get(
                     "bluej.extmgr.ExtensionWrapper");
 
             if (aWrapper == null) {
@@ -165,17 +164,21 @@ public final class ExtensionsMenuManager
 
             if (!aWrapper.isValid())
             {
-                items.remove(aComponent);
+                items.remove(menuItem);
             }
             else
             {
-                synchronized (this)
-                {
-                    aWrapper.safePostMenuItem(menuGenerator, aComponent);
-                }
+                itemsByExtension.computeIfAbsent(aWrapper, x -> new ArrayList<>()).add(menuItem);
             }
             itemsCount++;
         }
+
+        itemsByExtension.forEach((aWrapper, menuItems) -> {
+            synchronized (this)
+            {
+                aWrapper.safePostMenuItems(menuGenerator, menuItems);
+            }
+        });
 
         if (itemsCount <= 0) {
             items.remove(menuSeparator);

--- a/bluej/src/main/java/bluej/extmgr/ObjectExtensionMenu.java
+++ b/bluej/src/main/java/bluej/extmgr/ObjectExtensionMenu.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2012,2013,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 2012,2013,2016,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -34,7 +34,7 @@ import threadchecker.Tag;
  * 
  * @author Simon Gerlach
  */
-public class ObjectExtensionMenu implements ExtensionMenu
+public class ObjectExtensionMenu implements ExtensionMenuSingle
 {
     private ObjectWrapper objectWrapper;
 

--- a/bluej/src/main/java/bluej/extmgr/PackageExtensionMenu.java
+++ b/bluej/src/main/java/bluej/extmgr/PackageExtensionMenu.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2012,2013,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 2012,2013,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -33,7 +33,7 @@ import javafx.scene.control.MenuItem;
  * 
  * @author Simon Gerlach
  */
-public class PackageExtensionMenu implements ExtensionMenu
+public class PackageExtensionMenu implements ExtensionMenuSingle
 {
     private Package bluejPackage;
 

--- a/bluej/src/main/java/bluej/extmgr/ToolsExtensionMenu.java
+++ b/bluej/src/main/java/bluej/extmgr/ToolsExtensionMenu.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2012,2013,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 2012,2013,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -32,7 +32,7 @@ import javafx.scene.control.MenuItem;
  * 
  * @author Simon Gerlach
  */
-public class ToolsExtensionMenu implements ExtensionMenu
+public class ToolsExtensionMenu implements ExtensionMenuSingle
 {
     private Package bluejPackage;
     

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -40,7 +40,9 @@ import bluej.editor.stride.FrameCatalogue;
 import bluej.editor.stride.FrameEditor;
 import bluej.extensions2.*;
 import bluej.extensions2.event.ClassEvent;
+import bluej.extmgr.ExtensionMenu;
 import bluej.extmgr.ExtensionsManager;
+import bluej.extmgr.ExtensionsMenuManager;
 import bluej.parser.ParseFailure;
 import bluej.parser.entity.EntityResolver;
 import bluej.parser.entity.PackageResolver;
@@ -80,7 +82,9 @@ import javafx.application.Platform;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
@@ -2732,6 +2736,28 @@ public class ClassTarget extends DependentTarget
     public void showingInterface(boolean showing)
     {
         this.showingInterface = showing;
+    }
+
+    @Override
+    public void addExtensionContextMenuItemsToJavaEditor(ContextMenu contextMenu)
+    {
+        if (getBClass() == null)
+            return; // Can't do anything if no class
+        new ExtensionsMenuManager(contextMenu, ExtensionsManager.getInstance(), new ExtensionMenu()
+        {
+            @Override
+            public List<MenuItem> getMenuItems(MenuGenerator menuGenerator)
+            {
+                List<MenuItem> editorContextMenuItems = menuGenerator.getJavaEditorContextMenuItems(getBClass());
+                return editorContextMenuItems == null || editorContextMenuItems.isEmpty() ? Collections.emptyList() : new ArrayList<>(editorContextMenuItems);
+            }
+
+            @Override
+            public void postMenuItems(MenuGenerator menuGenerator, List<MenuItem> onThisItem)
+            {
+                menuGenerator.notifyPostJavaEditorContextMenu(getBClass(), onThisItem);
+            }
+        }).addExtensionMenu(getPackage().getProject());
     }
 
     @Override


### PR DESCRIPTION
The main change here is really to add a new method that allows BlueJ extensions to add one *or more* menu items to the Java editor context menu (when the user right clicks in the Java editor).  This involved a bit more changes than it first appears, because the existing infrastructure for menu items in extensions only supported a single menu item.  So I generalised it to support multiple items, then added a helper class to support all the existing single-item methods in the extensions.  You can see this more easily if you break it down by commit.