### PR TITLE
Add support for permits dependencies

### DIFF
--- a/bluej/src/main/java/bluej/parser/InfoParser.java
+++ b/bluej/src/main/java/bluej/parser/InfoParser.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -94,6 +95,7 @@ public class InfoParser extends EditorParser
     
     private List<JavaEntity> interfaceEntities;
     //private List<Selection> interfaceSelections;
+    private List<JavaEntity> permitsEntities;
     
     /** Represents a method description */
     class MethodDesc
@@ -318,6 +320,19 @@ public class InfoParser extends EditorParser
                 info.addImplements(""); // gap filler
             }
         }
+        if (permitsEntities != null && !permitsEntities.isEmpty()) {
+            for (JavaEntity permitsEnt : permitsEntities) {
+                TypeEntity iEnt = permitsEnt.resolveAsType();
+                if (iEnt != null) {
+                    GenTypeClass iType = iEnt.getType().asClass();
+                    if (iType != null) {
+                        info.addPermits(iType.getReflective().getName());
+                        continue;
+                    }
+                }
+                info.addPermits(""); // gap filler
+            }
+        }
     }
     
     /**
@@ -458,6 +473,13 @@ public class InfoParser extends EditorParser
                     info.setExtendsInsertSelection(new Selection(interfaceSel.getEndLine(),
                             interfaceSel.getEndColumn()));
                 }
+            }
+        }
+        else if (gotPermits)
+        {
+            JavaEntity permitsEnt = ParseUtils.getTypeEntity(scopeStack.get(0), null, tokens);
+            if (permitsEnt != null) {
+                permitsEntities.add(permitsEnt);
             }
         }
     }
@@ -700,6 +722,7 @@ public class InfoParser extends EditorParser
         gotExtends = false;
         gotImplements = false;
         gotPermits = true;
+        permitsEntities = new ArrayList<>();
     }
 
     @Override

--- a/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
+++ b/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
@@ -55,7 +55,6 @@ public final class ClassInfo
     private String superclass;
 
     private List<String> implemented = new ArrayList<String>();
-    private List<String> imported = new ArrayList<String>();
     private List<String> used = new ArrayList<String>();
     private List<SavedComment> comments = new LinkedList<SavedComment>();
     

--- a/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
+++ b/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
@@ -56,6 +56,8 @@ public final class ClassInfo
 
     private List<String> implemented = new ArrayList<String>();
     private List<String> used = new ArrayList<String>();
+    
+    private List<String> permits = new ArrayList<>();
     private List<SavedComment> comments = new LinkedList<SavedComment>();
     
     private List<String> typeParameterTexts = new ArrayList<String>();
@@ -155,6 +157,17 @@ public final class ClassInfo
 
         if(!implemented.contains(name)) {
             implemented.add(name);
+        }
+    }
+
+    public void addPermits(String name)
+    {
+        if(name.equals(this.name)) {
+            return;
+        }
+
+        if(!permits.contains(name)) {
+            permits.add(name);
         }
     }
     
@@ -463,6 +476,15 @@ public final class ClassInfo
     public List<String> getUsed()
     {
         return used;
+    }
+
+    /**
+     * Get the list of classes in the permits clause, if any (a list of String).
+     * Returns an empty list if there are none.
+     */
+    public List<String> getPermits()
+    {
+        return permits;
     }
 
     public Properties getComments()

--- a/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
+++ b/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2013,2014,2016  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2013,2014,2016,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -159,17 +159,6 @@ public final class ClassInfo
         }
     }
     
-    public void addImported(String name)
-    {
-        if(name.equals(this.name)) {
-            return;
-        }
-    
-        if(!imported.contains(name)) {
-            imported.add(name);
-        }
-    }
-
     public void addUsed(String name)
     {
         if(name.equals(this.name)) {
@@ -518,32 +507,5 @@ public final class ClassInfo
     public boolean hadParseError()
     {
         return hadParseError;
-    }
-
-    public void print()
-    {
-        System.out.println();
-        System.out.println("superclass: " + superclass);
-
-        System.out.println();
-        System.out.println("implements:");
-        Iterator<String> it = implemented.iterator();
-        while(it.hasNext()) {
-            System.out.println("   " + it.next());
-        }
-
-        System.out.println();
-        System.out.println("uses:");
-        it = used.iterator();
-        while(it.hasNext()) {
-            System.out.println("   " + it.next());
-        }
-
-        System.out.println();
-        System.out.println("imports:");
-        it = imported.iterator();
-        while(it.hasNext()) {
-            System.out.println("   " + it.next());
-        }
     }
 }

--- a/bluej/src/main/java/bluej/pkgmgr/Package.java
+++ b/bluej/src/main/java/bluej/pkgmgr/Package.java
@@ -1723,16 +1723,15 @@ public final class Package
             while (! queue.isEmpty()) {
                 ClassTarget head = queue.remove(0);
 
-                for (Dependency d : head.dependencies()) {
-                    if (!(d.getTo() instanceof ClassTarget)) {
-                        continue;
-                    }
-
-                    ClassTarget to = (ClassTarget) d.getTo();
-                    if (!to.isCompiled() && ! to.isQueued() && toCompile.add(to)) {
-                        to.ensureSaved();
-                        to.setQueued(true);
-                        queue.add(to);
+                for (DependentTarget dependency : head.dependencies())
+                {
+                    if (dependency instanceof ClassTarget to)
+                    {
+                        if (!to.isCompiled() && ! to.isQueued() && toCompile.add(to)) {
+                            to.ensureSaved();
+                            to.setQueued(true);
+                            queue.add(to);
+                        }
                     }
                 }
             }
@@ -3040,9 +3039,9 @@ public final class Package
         while (!toCalculate.isEmpty())
         {
             ClassTarget t = toCalculate.removeFirst();
-            for (Dependency d : t.dependencies())
+            for (DependentTarget dependency : t.dependencies())
             {
-                ClassTarget to = (ClassTarget) d.getTo();
+                ClassTarget to = (ClassTarget) dependency;
                 // If it's a dependency we haven't encountered before, we'll also
                 // need to calculate its dependencies:
                 if (dependencies.add(to))

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/Dependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/Dependency.java
@@ -70,7 +70,9 @@ public abstract class Dependency
         /** Represents an extends-dependency */
         EXTENDS,
         /** Represents an implements-dependency */
-        IMPLEMENTS;
+        IMPLEMENTS,
+        /** Represents a permits-dependency */
+        PERMITS;
     }
 
     @OnThread(Tag.Any)

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/Dependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/Dependency.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2013,2015,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2013,2015,2016,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -22,20 +22,15 @@
 package bluej.pkgmgr.dependency;
 
 import bluej.Config;
-import bluej.extensions2.ExtensionBridge;
-import bluej.extmgr.ExtensionsManager;
 import bluej.pkgmgr.Package;
 import bluej.pkgmgr.target.DependentTarget;
 import bluej.pkgmgr.target.Target;
-import javafx.application.Platform;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
 import java.util.Properties;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * A dependency between two targets in a package.
@@ -84,12 +79,6 @@ public abstract class Dependency
         this.from = from;
         this.to = to;
         this.pkg = pkg;
-    }
-
-    @OnThread(Tag.Any)
-    public Dependency(Package pkg)
-    {
-        this(pkg, (DependentTarget)null, null);
     }
 
     @Override

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/ExtendsDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/ExtendsDependency.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2015,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2015,2016,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -40,11 +40,6 @@ public class ExtendsDependency extends Dependency
     public ExtendsDependency(Package pkg, DependentTarget from, DependentTarget to)
     {
         super(pkg, from, to);
-    }
-
-    public ExtendsDependency(Package pkg)
-    {
-        this(pkg, null, null);
     }
 
     @OnThread(Tag.FXPlatform)

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/ImplementsDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/ImplementsDependency.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2015,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2015,2016,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -40,11 +40,6 @@ public class ImplementsDependency extends Dependency
     public ImplementsDependency(Package pkg, DependentTarget from, DependentTarget to)
     {
         super(pkg, from, to);
-    }
-
-    public ImplementsDependency(Package pkg)
-    {
-        this(pkg, null, null);
     }
 
     @OnThread(Tag.FXPlatform)

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/PermitsDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/PermitsDependency.java
@@ -1,0 +1,73 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2023  Michael Kolling and John Rosenberg
+ 
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+ 
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+ 
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+ 
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.pkgmgr.dependency;
+
+import bluej.pkgmgr.Package;
+import bluej.pkgmgr.target.DependentTarget;
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A permits dependency.
+ * 
+ * Permits dependencies are a little odd.  Let's imagine we have:
+ *   sealed class Parent permits Child
+ *   final class Child extends Parent
+ * We will have an ExtendsDependency from Child to Parent, and a
+ * PermitsDependency from Parent to Child.  Despite going in opposite directions, 
+ * both will have the same effect: when Parent gets marked as needing 
+ * recompile, Child will be a dependent and also get marked.
+ * 
+ * So, why need both?  Is Extends not enough?  The reason is that it is possible
+ * to be in this state:
+ *   sealed class Parent permits Child
+ *   final class Child
+ * In this case, changing Parent should require compiling Child (which needs
+ * to fix up its dependencies) but without the ExtendsDependency, Child will not
+ * get recompiled.  So we use the PermitsDependency to make sure Child is compiled too.
+ */
+public class PermitsDependency extends Dependency
+{
+    public PermitsDependency(Package pkg, DependentTarget sealedParent, DependentTarget permittedChild)
+    {
+        super(pkg, sealedParent, permittedChild);
+    }
+
+    @Override
+    @OnThread(Tag.Any)
+    public Type getType()
+    {
+        return Type.PERMITS;
+    }
+
+    @Override
+    public void remove()
+    {
+        // We don't show arrows for this dependency, so nothing to do.
+    }
+
+    @Override
+    public boolean isRemovable()
+    {
+        return false;
+    }
+}

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/UsesDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/UsesDependency.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2015,2016,2017,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2015,2016,2017,2019,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -47,12 +47,6 @@ public class UsesDependency extends Dependency
     public UsesDependency(Package pkg, DependentTarget from, DependentTarget to)
     {
         super(pkg, from, to);
-    }
-
-    @OnThread(Tag.Any)
-    public UsesDependency(Package pkg)
-    {
-        this(pkg, (DependentTarget)null, null);
     }
 
     @OnThread(Tag.Any)

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/package-info.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/package-info.java
@@ -1,4 +1,4 @@
-@OnThread(Tag.Swing)
+@OnThread(Tag.FXPlatform)
 package bluej.pkgmgr.dependency;
 import threadchecker.OnThread;
 import threadchecker.Tag;

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -54,6 +54,7 @@ import bluej.pkgmgr.*;
 import bluej.pkgmgr.dependency.Dependency;
 import bluej.pkgmgr.dependency.ExtendsDependency;
 import bluej.pkgmgr.dependency.ImplementsDependency;
+import bluej.pkgmgr.dependency.PermitsDependency;
 import bluej.pkgmgr.dependency.UsesDependency;
 import bluej.pkgmgr.target.actions.*;
 import bluej.pkgmgr.target.role.AbstractClassRole;
@@ -1840,6 +1841,17 @@ public class ClassTarget extends DependentTarget
             {
                 UsesDependency dependency = new UsesDependency(getPackage(), this, used);
                 getPackage().addDependency(dependency);
+            }
+        }
+
+        // handle permits classes
+        vect = info.getPermits();
+        for (Iterator<String> it = vect.iterator(); it.hasNext();) {
+            String name = it.next();
+            DependentTarget permits = getPackage().getDependentTarget(name);
+            if (permits != null)
+            {
+                getPackage().addDependency(new PermitsDependency(getPackage(), this, permits));
             }
         }
     }

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -1004,9 +1004,9 @@ public class ClassTarget extends DependentTarget
         
         alreadyInvalidated.add(this);
         
-        for (Dependency d : dependents())
+        for (DependentTarget d : dependents())
         {
-            ClassTarget dependent = (ClassTarget) d.getFrom();
+            ClassTarget dependent = (ClassTarget) d;
             
             if (dependent.hasSourceCode() && !alreadyInvalidated.contains(dependent))
             {

--- a/bluej/src/main/java/bluej/pkgmgr/target/DependentTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/DependentTarget.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2016,2017,2019,2020,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2016,2017,2019,2020,2021,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -24,6 +24,8 @@ package bluej.pkgmgr.target;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import bluej.pkgmgr.*;
 import bluej.pkgmgr.Package;
@@ -205,22 +207,29 @@ public abstract class DependentTarget extends EditableTarget
         }
     }
 
+    /**
+     * Returns the collection of all classes that this class is dependent upon.
+     * For example, if this class has a field of type Foo, Foo will be in this list.
+     */
     @OnThread(Tag.Any)
-    public synchronized Collection<Dependency> dependencies()
+    public final synchronized Collection<DependentTarget> dependencies()
     {
-        List<Dependency> d = new ArrayList<>();
-        d.addAll(parents);
-        d.addAll(outUses);
-        return d;
+        return Stream.concat(parents.stream(), outUses.stream())
+            .map(Dependency::getTo)
+            .collect(Collectors.toList());
     }
 
+    /**
+     * Returns the collection of all classes that depend on this class.
+     * For example, if a class Foo has a field of the type of this class,
+     * Foo will be in the list.
+     */
     @OnThread(Tag.Any)
-    public synchronized Collection<Dependency> dependents()
+    public final synchronized Collection<DependentTarget> dependents()
     {
-        List<Dependency> d = new ArrayList<>();
-        d.addAll(children);
-        d.addAll(inUses);
-        return d;
+        return Stream.concat(children.stream(), inUses.stream())
+            .map(Dependency::getFrom)
+            .collect(Collectors.toList());
     }
     
     /**

--- a/version.properties
+++ b/version.properties
@@ -11,7 +11,7 @@ greenfoot_major=3
 greenfoot_minor=8
 greenfoot_release=0
 greenfoot_suffix=
-greenfoot_rcnumber=3
+greenfoot_rcnumber=4
 
 # Change when API has changed in a way that is likely to break some scenarios. 
 # A warning will be shown to the user - update the greenfoot-labels file to


### PR DESCRIPTION
This mainly adds support for permits dependencies in the 4th and 5th commit, but first it does some tidy-up in the 1st to 3rd commits for preparation.  As mentioned, this doesn't actually seem to solve the issue with the compiler error appearing in the wrong place but I think it's probably still worth including for when the JDK behaves more sensibly.  I'll then build the next (and hopefully final!) Greenfoot RC.  And I'll see if I can make an easy small example of the JDK putting the error in the wrong place.