### PR TITLE
Added missing image to generic Greenfoot installer.

### DIFF
--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -152,6 +152,7 @@
 
         <!-- Copy other files needed by the installer -->
         <copy todir="install_tmp" file="greenfoot-dist.jar" />
+        <copy todir="install_tmp" file="../../greenfoot/resources/images/greenfoot-splash.png" />
 
         <!-- compile the installer -->
         <!-- Note: can't use compile task here because we are setting source 6 -->


### PR DESCRIPTION
Image was not being included in the JAR, which caused an error when you tried to run it.