### PR TITLE
Do not bundle JavaFX JARs into the generic installer

### DIFF
--- a/bluej/package/build.xml
+++ b/bluej/package/build.xml
@@ -117,6 +117,15 @@
         </fixcrlf>
         
         <chmod dir="install_tmp" perm="a+r"/>
+
+        <!-- Don't bundle JavaFX, user will need to install it themselves: -->
+        <delete>
+            <fileset dir="install_tmp/lib">
+                <include name="javafx*.jar"/>
+            </fileset>
+        </delete>
+
+
         <!-- jar the entire distribution into one jar file            -->
         <!-- (use zip instead of jar to avoid generation of manifest) -->
         <zip zipfile="${dist.jar}"

--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -113,7 +113,14 @@
             
         <copy tofile="install_tmp/README.TXT"
             file="${greenfoot_home}/doc/Greenfoot-README.txt" />
-        
+
+        <!-- Don't bundle JavaFX, user will need to install it themselves: -->
+        <delete>
+            <fileset dir="install_tmp/lib">
+                <include name="javafx*.jar"/>
+            </fileset>
+        </delete>
+
         <!-- jar the entire distribution into one jar file            -->
         <!-- (use zip instead of jar to avoid generation of manifest) -->
         <zip zipfile="greenfoot-dist.jar"


### PR DESCRIPTION
It turns out this was an additional problem with the generic installer; we were bundling JavaFX into the generic installer, which happened to include the Linux JARs.  This would actually work fine on x64 Linux, but if you try to install on Mac, it picks up the Linux ones and you get an error.  Instead we should just not bundle them at all.