### PR TITLE
Fix BlueJ context menu and Stride accessibility bugs

### DIFF
--- a/bluej/src/main/java/bluej/editor/stride/FrameEditorTab.java
+++ b/bluej/src/main/java/bluej/editor/stride/FrameEditorTab.java
@@ -2355,7 +2355,6 @@ public class FrameEditorTab extends FXTab implements InteractionManager, Suggest
     @Override
     public ObservableStringValue nameProperty()
     {
-        Debug.printCallStack("Name for " + System.identityHashCode(this) + " is in property " + System.identityHashCode(nameProperty) + " with value " + nameProperty.get(), 3);
         // We don't just return the class frame's name property direct because
         // this method will get called by the constructor frame initialisation, before
         // the class frame has finished initialisation.  So nameProperty acts as a 

--- a/bluej/src/main/java/bluej/editor/stride/FrameEditorTab.java
+++ b/bluej/src/main/java/bluej/editor/stride/FrameEditorTab.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022,2023  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -260,7 +260,10 @@ public class FrameEditorTab extends FXTab implements InteractionManager, Suggest
 
         // We put all the info in the graphic, so that we can use the graphic as a drag target:
         setText("");
-        Label titleLabel = new Label(initialSource.getName());
+        Label titleLabel = new Label();
+        // nameProperty will be updated after load, but it will also be read
+        // during load, so important we set it as early as we can:
+        nameProperty.set(initialSource.getName());
         titleLabel.textProperty().bind(nameProperty);
         HBox tabHeader = new HBox(titleLabel, makeClassGraphicIcon(imageProperty, 16, false));
         tabHeader.setAlignment(Pos.CENTER);
@@ -2352,6 +2355,7 @@ public class FrameEditorTab extends FXTab implements InteractionManager, Suggest
     @Override
     public ObservableStringValue nameProperty()
     {
+        Debug.printCallStack("Name for " + System.identityHashCode(this) + " is in property " + System.identityHashCode(nameProperty) + " with value " + nameProperty.get(), 3);
         // We don't just return the class frame's name property direct because
         // this method will get called by the constructor frame initialisation, before
         // the class frame has finished initialisation.  So nameProperty acts as a 

--- a/bluej/src/main/java/bluej/extmgr/ExtensionMenuSingle.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionMenuSingle.java
@@ -56,7 +56,11 @@ public interface ExtensionMenuSingle extends ExtensionMenu
     @Override
     default List<MenuItem> getMenuItems(MenuGenerator menuGenerator)
     {
-        return Collections.singletonList(getMenuItem(menuGenerator));
+        MenuItem menuItem = getMenuItem(menuGenerator);
+        if (menuItem != null)
+            return Collections.singletonList(menuItem);
+        else
+            return Collections.emptyList();
     }
 
     // Default implementation to work with a single menu item.  Do not override.

--- a/bluej/src/main/java/bluej/extmgr/ExtensionWrapper.java
+++ b/bluej/src/main/java/bluej/extmgr/ExtensionWrapper.java
@@ -640,7 +640,8 @@ public class ExtensionWrapper
 
 
     /**
-     *  Calls the EXTENSION getMenuItem in a safe way
+     *  Calls the EXTENSION getMenuItem in a safe way.
+     *  All items in returned list will be non-null
      */
     public List<MenuItem> safeGetMenuItems(ExtensionMenu attachedObject)
     {
@@ -649,7 +650,16 @@ public class ExtensionWrapper
 
         try {
             List<MenuItem> menuItems = ExtensionBridge.getMenuItems(extensionBluej, attachedObject);
-            return menuItems == null ? Collections.emptyList() : menuItems;
+            if (menuItems == null)
+            {
+                return Collections.emptyList();
+            }
+            else
+            {
+                menuItems = new ArrayList<>(menuItems);
+                menuItems.removeIf(m -> m == null);
+                return menuItems;
+            }
         }
         catch (Throwable exc) {
             Debug.message("ExtensionWrapper.safeMenuGenGetMenuItem: Class="+getExtensionClassName()+" Exception="+exc.getMessage());

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/ClassFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/ClassFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021,2022 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021,2022,2023 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -195,7 +195,7 @@ public class ClassFrame extends TopLevelDocumentMultiCanvasFrame<ClassElement>
     //cherry
     public String getLocationDescription() {
         String text;
-        if (!nameProperty().get().isEmpty() && !nameProperty().get().equals("null")) {
+        if (nameProperty().get() != null && !nameProperty().get().isEmpty()) {
             text = " in the class " + nameProperty().get();
         }
         else {

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=2
 bluej_release=1
 bluej_suffix=
-bluej_rcnumber=1
+bluej_rcnumber=2
 
 greenfoot_major=3
 greenfoot_minor=8


### PR DESCRIPTION
I noticed a couple of bugs in BlueJ 5.2.1RC1.  The main one which has to be fixed is that the context menu was failing to show when you right-clicked a class in the diagram.  This was because of some incorrect logic in the change to the extensions API which interacted badly with the Submitter extension.  The other bug was that Stride was sometimes saying "you are in class null" for the accessibility code, which is a subtle fix where we need to set the property rather than the label.

After this I'll send out RC2.