### PR TITLE
Fix JavaFX path location on Windows

### DIFF
--- a/boot/src/main/java/bluej/Boot.java
+++ b/boot/src/main/java/bluej/Boot.java
@@ -216,18 +216,17 @@ public class Boot
     public File getJavaFXLibDir()
     {
         String javafxPathProp = commandLineProps.getProperty("javafxpath", null);
-        File javafxPath;
         if (javafxPathProp != null)
         {
-            javafxPath = new File(javafxPathProp);
+            return new File(new File(javafxPathProp), "lib");
         }
         else
         {
             // If no javafxpath property passed, assume JavaFX is bundled
-            javafxPath = new File(getBluejLibDir(), "javafx");
+            return new File(getBluejLibDir(), "javafx");
         }
 
-        return new File(javafxPath, "lib");
+
     }
 
     /**

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=2
 bluej_release=1
 bluej_suffix=
-bluej_rcnumber=2
+bluej_rcnumber=3
 
 greenfoot_major=3
 greenfoot_minor=8


### PR DESCRIPTION
In fixing the generic installer JavaFX path, I broke the Windows JavaFX path location.  Ubuntu was unaffected because it lists the JARs individually, and Mac was unaffected because it uses appbundler and uses javafx-*.jar.