### PR TITLE
Greenfoot: fix common classes, add news, add sleepFor

### DIFF
--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -99,6 +99,8 @@
             <fileset dir="${bluej_home}/package">
                 <patternset refid="greenfoot.scenarios" />
             </fileset>
+            <fileset dir="${greenfoot_home}" includes="common/**">
+            </fileset>
         </copy>
         <copy todir="install_tmp/doc" preservelastmodified="true">
             <fileset dir="${greenfoot_home}/doc">

--- a/bluej/src/main/java/bluej/Main.java
+++ b/bluej/src/main/java/bluej/Main.java
@@ -81,8 +81,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class Main
 {
-    private static final String MESSAGE_ROOT = "https://www.bluej.org/message/";
-    private static final String TESTING_MESSAGE_ROOT = "https://www.bluej.org/message_test/";
+    private static final String BLUEJ_MESSAGE_ROOT = "https://www.bluej.org/message/";
+    private static final String BLUEJ_TESTING_MESSAGE_ROOT = "https://www.bluej.org/message_test/";
+
+    private static final String GREENFOOT_MESSAGE_ROOT = "https://www.greenfoot.org/message/";
+    private static final String GREENFOOT_TESTING_MESSAGE_ROOT = "https://www.greenfoot.org/message_test/";
+
 
     /**
      * Only used on Mac.  For some reason, executing the AppleJavaExtensions open
@@ -116,8 +120,13 @@ public class Main
 
         CompletableFuture<Stage> futureMainWindow = new CompletableFuture<>();
         // Must do this after Config initialisation:
-        if (!Config.isGreenfoot())
-            new Thread(() -> fetchAndShowCentralMsg(PrefMgr.getFlag(PrefMgr.NEWS_TESTING) ?  TESTING_MESSAGE_ROOT : MESSAGE_ROOT, futureMainWindow), "Fetching news message").start();
+        new Thread(() ->
+            fetchAndShowCentralMsg(
+                PrefMgr.getFlag(PrefMgr.NEWS_TESTING) ?
+                    (Config.isGreenfoot() ? GREENFOOT_TESTING_MESSAGE_ROOT : BLUEJ_TESTING_MESSAGE_ROOT)
+                    : (Config.isGreenfoot() ? GREENFOOT_MESSAGE_ROOT : BLUEJ_MESSAGE_ROOT), futureMainWindow),
+            "Fetching news message"
+        ).start();
 
         if (guiHandler == null)
         {

--- a/greenfoot/src/main/java/greenfoot/Actor.java
+++ b/greenfoot/src/main/java/greenfoot/Actor.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2010,2011,2013,2014,2015,2016,2018,2019,2021,2022  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2010,2011,2013,2014,2015,2016,2018,2019,2021,2022,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -111,6 +111,8 @@ public abstract class Actor
     private int imageWidth;
     /** Cached image hieght */
     private int imageHeight;
+    /** How many more act cycles the actor is sleeping for */
+    private int sleepingFor = 0;
 
     static {
         //Do this in a 'try' since a failure at this point will crash Greenfoot.
@@ -318,6 +320,31 @@ public abstract class Actor
     public void turn(int amount)
     {
         setRotation(rotation + amount);
+    }
+
+    /**
+     * Sets this actor to sleep for the given number of cycles.
+     *
+     * <p>A sleeping actor will not have act() called it on by the Greenfoot system as usual.
+     * So if you call sleepFor(1) then it will skip the next single act() call.  If you
+     * call sleepFor(3) then it will skip the next three, and so on.</p>
+     *
+     * <p>The actor can still be collided with, will still show in the world, and you can still
+     * manually call methods on it (including act(), if you wish, or sleepFor() if you wish
+     * to increase or cancel the sleep).</p>
+     *
+     * <p>If you call sleepFor() again, the latest value will replace the current one.
+     * So you can wake an actor up by calling sleepFor(0).  If you use a negative number such
+     * as -1, the actor will sleep indefinitely (unless sleepFor() is called again to replace
+     * the value).</p>
+     *
+     * @param sleepFor The number of future act cycles to skip acting, 0 to stop sleeping, or
+     *                 a negative number to sleep indefinitely.
+     * @since Greenfoot 3.8.1
+     */
+    public void sleepFor(int sleepFor)
+    {
+        setSleepingFor(sleepFor);
     }
     
     /**
@@ -1061,6 +1088,18 @@ public abstract class Actor
     final int getSequenceNumber()
     {
         return mySequenceNumber;
+    }
+
+    // package-visible, only to be called by ActorVisitor
+    final int getSleepingFor()
+    {
+        return sleepingFor;
+    }
+
+    // package-visible, only to be called by ActorVisitor
+    final void setSleepingFor(int sleepingFor)
+    {
+        this.sleepingFor = sleepingFor;
     }
 
     /**

--- a/greenfoot/src/main/java/greenfoot/ActorVisitor.java
+++ b/greenfoot/src/main/java/greenfoot/ActorVisitor.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2010  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2010,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -166,4 +166,22 @@ public class ActorVisitor
     {
         actor.setLastPaintSeqNum(num);
     }
+
+    /**
+     * Decrements the sleep counter if it is positive, and returns whether the actor was awake.
+     * @param actor The actor to change the sleep counter for.
+     * @return Whether the actor was awake (sleep count == 0) before this method was called.
+     */
+    public static boolean decrementSleepForIfPositive(Actor actor)
+    {
+        int s = actor.getSleepingFor();
+        if (s > 0)
+        {
+            s -= 1;
+            actor.setSleepingFor(s);
+        }
+        // Has to be exactly zero.  Positive means we were (and maybe still are) counting down, negative means we are sleeping indefinitely.
+        return s == 0;
+    }
+
 }

--- a/greenfoot/src/main/java/greenfoot/ActorVisitor.java
+++ b/greenfoot/src/main/java/greenfoot/ActorVisitor.java
@@ -174,11 +174,13 @@ public class ActorVisitor
      */
     public static boolean decrementSleepForIfPositive(Actor actor)
     {
+        // If sleepFor is 1 (or higher), we will decrement it to zero but remain asleep.
+        // If we are zero or lower we will not decrement.
         int s = actor.getSleepingFor();
         if (s > 0)
         {
-            s -= 1;
-            actor.setSleepingFor(s);
+            // Important that we don't change s here, we base our return on the value before the decrement, not after.
+            actor.setSleepingFor(s - 1);
         }
         // Has to be exactly zero.  Positive means we were (and maybe still are) counting down, negative means we are sleeping indefinitely.
         return s == 0;

--- a/version.properties
+++ b/version.properties
@@ -9,9 +9,9 @@ bluej_rcnumber=4
 
 greenfoot_major=3
 greenfoot_minor=8
-greenfoot_release=0
+greenfoot_release=1
 greenfoot_suffix=
-greenfoot_rcnumber=4
+greenfoot_rcnumber=1
 
 # Change when API has changed in a way that is likely to break some scenarios. 
 # A warning will be shown to the user - update the greenfoot-labels file to
@@ -23,7 +23,7 @@ greenfoot_api_breaking=3
 # Changing this number will stripe the user's classes and require a recompile.
 # Do not change this number if the changes cannot break older scenarios.
 # YOU SHOULD UPDATE THE GREENFOOT LABELS if you change this
-greenfoot_api_nonbreaking=0
+greenfoot_api_nonbreaking=1
 # Change when API has only changed internally and not in any way visible to the user. 
 # It should not be possible for this change to break existing scenarios.
 # Changing this number will NOT stripe the user's classes nor require a recompile.


### PR DESCRIPTION
This is three separate changes.  It fixes the common classes not being packaged (will need testing once Github builds an RC), adds support for the news mechanism and adds a new sleepFor method (both as discussed in the meeting yesterday).

Fixes #2273 