### PR TITLE
Removed the last parts of AWT/Swing code from the Greenfoot server VM…

### DIFF
--- a/bluej/src/main/java/bluej/debugger/jdi/VMEventHandler.java
+++ b/bluej/src/main/java/bluej/debugger/jdi/VMEventHandler.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2014,2019,2020,2021  Michael Kolling and John Rosenberg 
+ Copyright (C) 1999-2009,2012,2014,2019,2020,2021,2023  Michael Kolling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -21,17 +21,9 @@
  */
 package bluej.debugger.jdi;
 
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import bluej.debugger.Debugger.EventHandlerRunnable;
-import bluej.utility.Debug;
-import threadchecker.OnThread;
-import threadchecker.Tag;
 import bluej.debugger.DebuggerEvent;
-
+import bluej.utility.Debug;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.VirtualMachine;
@@ -39,7 +31,6 @@ import com.sun.jdi.event.BreakpointEvent;
 import com.sun.jdi.event.ClassPrepareEvent;
 import com.sun.jdi.event.Event;
 import com.sun.jdi.event.EventIterator;
-import com.sun.jdi.event.EventQueue;
 import com.sun.jdi.event.EventSet;
 import com.sun.jdi.event.ExceptionEvent;
 import com.sun.jdi.event.LocatableEvent;
@@ -51,6 +42,11 @@ import com.sun.jdi.event.VMDisconnectEvent;
 import com.sun.jdi.event.VMStartEvent;
 import com.sun.jdi.request.EventRequest;
 import com.sun.jdi.request.StepRequest;
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Event handler class to handle events coming from the remote VM.

--- a/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
+++ b/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
@@ -79,7 +79,6 @@ import javafx.util.Duration;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/greenfoot/build.gradle
+++ b/greenfoot/build.gradle
@@ -11,10 +11,12 @@ dependencies {
     implementation project(':boot')
 
     implementation 'au.com.bytecode:opencsv:2.4'
-    implementation 'org.apache.httpcomponents:httpclient:4.1.1'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.httpcomponents:httpmime:4.1.1'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'javazoom:jlayer:1.0.1'
+    implementation 'org.glavo:simple-png:0.2.0'
+    implementation 'org.glavo:simple-png-javafx:0.2.0'
 
     testCompileOnly project(':anns-threadchecker')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'

--- a/greenfoot/src/main/java/greenfoot/export/Exporter.java
+++ b/greenfoot/src/main/java/greenfoot/export/Exporter.java
@@ -34,7 +34,6 @@ import greenfoot.guifx.export.ExportDialog;
 import greenfoot.guifx.export.ProxyAuthDialog;
 import greenfoot.util.GreenfootUtil;
 
-import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -47,8 +46,7 @@ import javafx.application.Platform;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Dimension2D;
 
-import javax.imageio.ImageIO;
-
+import org.glavo.png.javafx.PNGJavaFXUtils;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
@@ -261,8 +259,8 @@ public class Exporter implements PublishListener
             String formatName = "png";
             try {
                 tmpImgFile = File.createTempFile("greenfoot", "." + formatName, null);
-                BufferedImage bufferedImage = SwingFXUtils.fromFXImage(scenarioInfo.getImage(), null);
-                ImageIO.write(bufferedImage, formatName, tmpImgFile);
+                PNGJavaFXUtils.writeImage(scenarioInfo.getImage(), tmpImgFile.toPath());
+                
                 // make sure it is deleted on exit (should be deleted right after
                 // the publish finish - but just in case...)
                 tmpImgFile.deleteOnExit();              

--- a/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
@@ -70,11 +70,10 @@ import bluej.utility.javafx.UnfocusableScrollPane;
 import bluej.views.CallableView;
 import bluej.views.ConstructorView;
 import bluej.views.MethodView;
-
 import greenfoot.Actor;
 import greenfoot.core.ProjectManager;
-import greenfoot.export.mygame.ScenarioInfo;
 import greenfoot.export.ScenarioSaver;
+import greenfoot.export.mygame.ScenarioInfo;
 import greenfoot.guifx.ControlPanel.ControlPanelListener;
 import greenfoot.guifx.classes.GClassDiagram;
 import greenfoot.guifx.classes.GClassDiagram.GClassType;
@@ -90,7 +89,6 @@ import greenfoot.sound.SoundPreferencePanel;
 import greenfoot.util.GreenfootUtil;
 import greenfoot.vmcomm.GreenfootDebugHandler;
 import greenfoot.vmcomm.GreenfootDebugHandler.SimulationStateListener;
-
 import greenfoot.vmcomm.VMCommsMain;
 import javafx.animation.AnimationTimer;
 import javafx.application.Platform;
@@ -105,7 +103,16 @@ import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
 import javafx.scene.CacheHint;
 import javafx.scene.Scene;
-import javafx.scene.control.*;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -131,15 +138,19 @@ import javafx.util.Duration;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import java.awt.EventQueue;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.IntBuffer;
-import java.util.*;
-import java.util.function.Consumer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Properties;
+import java.util.Queue;
 
 import static bluej.pkgmgr.target.EditableTarget.MENU_STYLE_INBUILT;
 import static greenfoot.vmcomm.Command.*;
@@ -1073,11 +1084,11 @@ public class GreenfootStage extends Stage implements FXCompileObserver,
      */
     private static void openWebBrowser(String url)
     {
-        EventQueue.invokeLater(() -> {
+        JavaFXUtil.runAfterCurrent(() -> {
             boolean success = Utility.openWebBrowser(url);
             if (! success)
             {
-                Platform.runLater(() -> DialogManager.showErrorFX(null, "cannot-open-browser"));
+                DialogManager.showErrorFX(null, "cannot-open-browser");
             }
         });
     }

--- a/greenfoot/src/main/java/greenfoot/guifx/PastedImageNameDialog.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/PastedImageNameDialog.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program.
- Copyright (C) 2014,2016,2017,2018  Poul Henriksen and Michael Kolling
+ Copyright (C) 2014,2016,2017,2018,2023  Poul Henriksen and Michael Kolling
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -37,10 +37,10 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+import org.glavo.png.javafx.PNGJavaFXUtils;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
 
@@ -147,16 +147,13 @@ public class PastedImageNameDialog extends FXCustomizedDialog<File>
     {
         try
         {
-            if (ImageIO.write(SwingFXUtils.fromFXImage(image, null), "png", file))
-            {
-                return true;
-            }
+            PNGJavaFXUtils.writeImage(image, file.toPath());
+            return true;
         }
         catch (IOException ex)
         {
-            // No need to repeat the error message here and in case writing the image returned false.
+            DialogManager.showErrorFX(asWindow(), "imagelib-writing-image-failed");
+            return false;
         }
-        DialogManager.showErrorFX(asWindow(), "imagelib-writing-image-failed");
-        return false;
     }
 }

--- a/greenfoot/src/main/java/greenfoot/guifx/classes/ImportClassDialog.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/classes/ImportClassDialog.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2018,2019  Poul Henriksen and Michael Kolling
+ Copyright (C) 2018,2019,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -37,7 +37,6 @@ import javafx.stage.Modality;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.FileFilter;
 import java.net.MalformedURLException;
@@ -199,7 +198,7 @@ public class ImportClassDialog extends Dialog<File>
      */
     public static File findImage(File classFile)
     {
-        String[] extensions = ImageIO.getReaderFileSuffixes();
+        String[] extensions = new String[]{"png", "jpg", "jpeg", "gif", "bmp", "tiff"};
 
         File directory = classFile.getAbsoluteFile().getParentFile();
         String stemName = GreenfootUtil.removeExtension(classFile.getAbsoluteFile().getName());

--- a/greenfoot/src/main/java/greenfoot/guifx/export/ExportAppTab.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/export/ExportAppTab.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2011,2013,2015,2018,2019  Poul Henriksen and Michael Kolling
+ Copyright (C) 2005-2009,2011,2013,2015,2018,2019,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -26,6 +26,7 @@ import static greenfoot.export.Exporter.ExportFunction;
 import bluej.Boot;
 import bluej.Config;
 import bluej.utility.Utility;
+import bluej.utility.javafx.JavaFXUtil;
 import greenfoot.export.mygame.ExportInfo;
 import greenfoot.export.mygame.ScenarioInfo;
 
@@ -49,8 +50,6 @@ import javafx.stage.Window;
 
 import threadchecker.OnThread;
 import threadchecker.Tag;
-
-import javax.swing.SwingUtilities;
 
 /**
  * Export dialog's tab for exporting to a standalone application.
@@ -91,7 +90,7 @@ public class ExportAppTab extends ExportLocalTab
         String javaAndClasspathAfter = /*"\" --module-path \"" + Boot.getInstance().getJavaFXLibDir() + "\" --add-modules=ALL-MODULE-PATH */ " greenfoot.export.GreenfootScenarioApplication";
 
         Hyperlink moreInfo = new Hyperlink(Config.getString("export.app.more"));
-        moreInfo.setOnAction(event -> SwingUtilities.invokeLater(() -> Utility.openWebBrowser("https://www.greenfoot.org/doc/run_standalone")));
+        moreInfo.setOnAction(event -> JavaFXUtil.runAfterCurrent(() -> Utility.openWebBrowser("https://www.greenfoot.org/doc/run_standalone")));
 
         Label commandLineExplanation = new Label("Command to run scenario on this machine:");
 

--- a/greenfoot/src/main/java/greenfoot/guifx/export/ExportDialog.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/export/ExportDialog.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2011,2013,2016,2018,2021  Poul Henriksen and Michael Kolling
+ Copyright (C) 2005-2009,2011,2013,2016,2018,2021,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -58,8 +58,6 @@ import javafx.stage.Window;
 
 import threadchecker.OnThread;
 import threadchecker.Tag;
-
-import javax.swing.*;
 
 /**
  * A dialog allowing the user to export a scenario in a variety of ways.
@@ -378,7 +376,7 @@ public class ExportDialog extends FXCustomizedDialog<Void>
         setProgress(false, msg);
         if (success)
         {
-            SwingUtilities.invokeLater(() -> Utility.openWebBrowser(Config.getPropString("greenfoot.gameserver.address") + "/home"));
+            JavaFXUtil.runAfterCurrent(() -> Utility.openWebBrowser(Config.getPropString("greenfoot.gameserver.address") + "/home"));
         }
     }
     

--- a/greenfoot/src/main/java/greenfoot/guifx/export/ExportPublishTab.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/export/ExportPublishTab.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2010,2011,2012,2013,2017,2018,2022  Poul Henriksen and Michael Kolling
+ Copyright (C) 2005-2009,2010,2011,2012,2013,2017,2018,2022,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -64,8 +64,6 @@ import javafx.scene.layout.VBox;
 import org.apache.http.conn.ConnectTimeoutException;
 import threadchecker.OnThread;
 import threadchecker.Tag;
-
-import javax.swing.*;
 
 /**
  * Pane used for exporting to Greenfoot Gallery
@@ -336,7 +334,7 @@ public class ExportPublishTab extends ExportTab
 
         Hyperlink createAccountLabel = new Hyperlink(Config.getString("export.publish.createAccount"));
         createAccountLabel.getStyleClass().add("create-account-label");
-        createAccountLabel.setOnAction(event -> SwingUtilities.invokeLater(() -> Utility.openWebBrowser(createAccountUrl)));
+        createAccountLabel.setOnAction(event -> JavaFXUtil.runAfterCurrent(() -> Utility.openWebBrowser(createAccountUrl)));
 
         HBox loginPane = new HBox(loginLabel,
                 usernameLabel, userNameField,
@@ -353,7 +351,7 @@ public class ExportPublishTab extends ExportTab
     private Pane getHelpBox()
     {
         Hyperlink serverLink = new Hyperlink(serverURL);
-        serverLink.setOnAction(event -> SwingUtilities.invokeLater(() -> Utility.openWebBrowser(serverURL)));
+        serverLink.setOnAction(event -> JavaFXUtil.runAfterCurrent(() -> Utility.openWebBrowser(serverURL)));
 
         HBox helpBox = new HBox(new Label(helpLine + " ("), serverLink, new Label(")"));
         helpBox.getStyleClass().add("help-box");

--- a/greenfoot/src/main/java/greenfoot/guifx/images/ImageLibPane.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/images/ImageLibPane.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program.
- Copyright (C) 2005-2009,2010,2014,2015,2016,2017,2018,2019  Poul Henriksen and Michael Kolling
+ Copyright (C) 2005-2009,2010,2014,2015,2016,2017,2018,2019,2023  Poul Henriksen and Michael Kolling
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -56,8 +56,6 @@ import javafx.stage.Window;
 import javafx.util.Duration;
 import threadchecker.OnThread;
 import threadchecker.Tag;
-
-import javax.swing.*;
 
 /**
  * A Pane for selecting a class image. The image can be selected from either the
@@ -433,7 +431,7 @@ class ImageLibPane extends VBox
     private void editImage(ImageListEntry entry)
     {
         File file = entry.getImageFile();
-        SwingUtilities.invokeLater(() -> ExternalAppLauncher.editImage(file));
+        JavaFXUtil.runAfterCurrent(() -> ExternalAppLauncher.editImage(file));
     }
 
     private void pasteImage()

--- a/greenfoot/src/main/java/greenfoot/guifx/images/NewImageDialog.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/images/NewImageDialog.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program.
- Copyright (C) 2009,2010,2016,2018  Poul Henriksen and Michael Kolling
+ Copyright (C) 2009,2010,2016,2018,2023  Poul Henriksen and Michael Kolling
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -24,26 +24,25 @@ package greenfoot.guifx.images;
 import bluej.Config;
 import bluej.utility.DialogManager;
 import bluej.utility.javafx.FXCustomizedDialog;
+import bluej.utility.javafx.JavaFXUtil;
 import greenfoot.util.ExternalAppLauncher;
-
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.TextField;
+import javafx.scene.image.WritableImage;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+import org.glavo.png.javafx.PNGJavaFXUtils;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import javax.imageio.ImageIO;
-import javax.swing.*;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
 import java.io.File;
+import java.io.IOException;
 
 /**
  * A new image dialog, used for specifying the properties of an image before its
@@ -152,20 +151,17 @@ public class NewImageDialog extends FXCustomizedDialog<File>
      */
     private boolean writeImageAndEdit(File file)
     {
-        BufferedImage im = new BufferedImage((Integer) width.getValue(), (Integer) height.getValue(), BufferedImage.TYPE_INT_ARGB);
         try
         {
-            if (ImageIO.write(im, "png", file))
-            {
-                SwingUtilities.invokeLater(() -> ExternalAppLauncher.editImage(file));
-                return true;
-            }
+            PNGJavaFXUtils.writeImage(new WritableImage((Integer) width.getValue(), (Integer) height.getValue()), file.toPath());
+            // If no exception, edit it:
+            JavaFXUtil.runAfterCurrent(() -> ExternalAppLauncher.editImage(file));
+            return true;
         }
         catch (IOException ex)
         {
-            // No need to repeat the error message here and in case writing the image returned false.
+            DialogManager.showErrorFX(asWindow(), "imagelib-writing-image-failed");
+            return false;
         }
-        DialogManager.showErrorFX(asWindow(), "imagelib-writing-image-failed");
-        return false;
     }
 }

--- a/greenfoot/src/main/java/greenfoot/platforms/GreenfootUtilDelegate.java
+++ b/greenfoot/src/main/java/greenfoot/platforms/GreenfootUtilDelegate.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2010,2011,2012,2018  Poul Henriksen and Michael Kolling
+ Copyright (C) 2005-2009,2010,2011,2012,2018,2023  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -26,7 +26,6 @@ import greenfoot.UserInfo;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import java.awt.Component;
 import java.net.URL;
 import java.util.List;
 

--- a/greenfoot/src/main/java/greenfoot/platforms/ide/WorldHandlerDelegateIDE.java
+++ b/greenfoot/src/main/java/greenfoot/platforms/ide/WorldHandlerDelegateIDE.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2010,2011,2012,2013,2014,2015,2016,2018  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2010,2011,2012,2013,2014,2015,2016,2018,2023  Poul Henriksen and Michael Kolling 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -35,7 +35,6 @@ import greenfoot.util.GreenfootUtil;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-import java.awt.Color;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -50,8 +49,6 @@ import java.util.List;
 public class WorldHandlerDelegateIDE
     implements WorldHandlerDelegate
 {
-    protected final Color envOpColour = new Color(152,32,32);
-    
     private final VMCommsSimulation vmCommsSimulation;
     
     private boolean worldInitialising;


### PR DESCRIPTION
… (some remains in the debug VM, which is fine).  The problem is that any AWT code that runs on the server VM initialises the AWT toolkit, which replaces the default about/file-open handles on Mac, which makes some functionality (the about dialog, file opening) not work after that point.