### PR TITLE
Add autocomplete support for local variables

### DIFF
--- a/bluej/lib/tutorial/package.bluej
+++ b/bluej/lib/tutorial/package.bluej
@@ -43,3 +43,4 @@ target2.typeParameters=
 target2.width=80
 target2.x=390
 target2.y=210
+project.invoke.thread=FX

--- a/bluej/src/main/java/bluej/editor/fixes/SuggestionList.java
+++ b/bluej/src/main/java/bluej/editor/fixes/SuggestionList.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2018,2019,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2018,2019,2020,2021,2024 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/editor/fixes/SuggestionList.java
+++ b/bluej/src/main/java/bluej/editor/fixes/SuggestionList.java
@@ -1180,7 +1180,7 @@ public class SuggestionList
         {
             JavaReflective greenfootClassRef = new JavaReflective(pkg.loadClass("greenfoot.Greenfoot"));
             ExpressionTypeInfo greenfootClass = new ExpressionTypeInfo(new GenTypeClass(greenfootClassRef), null, null, true, false);
-            AssistContent[] greenfootStatic = ParseUtils.getPossibleCompletions(greenfootClass, javadocResolver, null, null);
+            AssistContent[] greenfootStatic = ParseUtils.getPossibleCompletions(greenfootClass, javadocResolver, null, null, -1);
             Arrays.stream(greenfootStatic)
                 .filter(ac -> ac.getKind() == AssistContent.CompletionKind.METHOD)
                 .forEach(ac -> completionCandidates.add(new PrefixCompletionWrapper(ac, "Greenfoot.")));
@@ -1190,7 +1190,7 @@ public class SuggestionList
         // to facilitate the very common "System.out.println()" for example.
         JavaReflective systemClassRef = new JavaReflective(pkg.loadClass("java.lang.System"));
         ExpressionTypeInfo systemClass = new ExpressionTypeInfo(new GenTypeClass(systemClassRef), null, null, true, false);
-        AssistContent[] systemStatic = ParseUtils.getPossibleCompletions(systemClass, javadocResolver, null, null);
+        AssistContent[] systemStatic = ParseUtils.getPossibleCompletions(systemClass, javadocResolver, null, null, -1);
         Arrays.stream(systemStatic)
             .filter(ac -> (ac.getName().equals("out") || ac.getName().equals("err") || ac.getName().equals("in")))
             .forEach(ac -> completionCandidates.add(new PrefixCompletionWrapper(ac, "System.")));

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2019,2020,2021,2022,2023  Michael Kolling and John Rosenberg
+ Copyright (C) 2019,2020,2021,2022,2023,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -3205,7 +3205,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
         
          
             LocatableToken suggestToken = suggests.getSuggestionToken();
-            AssistContent[] possibleCompletions = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, parser.getContainingMethodOrClassNode(flowEditorPane.getCaretPosition()));
+            AssistContent[] possibleCompletions = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, parser.getContainingMethodOrClassNode(flowEditorPane.getCaretPosition()) instanceof MethodNode m ? m : null);
             if (possibleCompletions != null)
             {
                 Arrays.sort(possibleCompletions, AssistContent.getComparator());

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -3205,7 +3205,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
         
          
             LocatableToken suggestToken = suggests.getSuggestionToken();
-            AssistContent[] possibleCompletions = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, parser.getContainingMethodOrClassNode(flowEditorPane.getCaretPosition()) instanceof MethodNode m ? m : null);
+            AssistContent[] possibleCompletions = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, parser.getContainingMethodOrClassNode(flowEditorPane.getCaretPosition()) instanceof MethodNode m ? m : null, flowEditorPane.getCaretPosition());
             if (possibleCompletions != null)
             {
                 Arrays.sort(possibleCompletions, AssistContent.getComparator());

--- a/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
@@ -954,7 +954,7 @@ public class FlowErrorManager implements ErrorQuery
             else if (positionNode instanceof MethodNode m)
             {
                 // for local variables, we only look up directly into the method node
-                return ParseUtils.findLocalVariables(m, -1).stream().distinct().map(FieldNode::getName).map(SimpleCorrectionInfo::new);
+                return ParseUtils.findLocalVariables(ParseUtils.findInnerMostNode(startPos, m), m, -1).stream().distinct().map(VariableDeclaration::getName).map(SimpleCorrectionInfo::new);
             }
             else
             {

--- a/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
@@ -939,7 +939,7 @@ public class FlowErrorManager implements ErrorQuery
                 if (editor.getProject() == null)
                     return null;
 
-                AssistContent[] values = ParseUtils.getPossibleCompletions(suggests, editor.getProject().getJavadocResolver(), null, positionNode);
+                AssistContent[] values = ParseUtils.getPossibleCompletions(suggests, editor.getProject().getJavadocResolver(), null, positionNode instanceof MethodNode m ? m : null);
                 if (values == null)
                     return null;
 

--- a/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2019,2020,2021,2022,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -60,7 +60,6 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -952,35 +951,14 @@ public class FlowErrorManager implements ErrorQuery
                         .distinct()
                         .map(SimpleCorrectionInfo::new);
             }
-            else
+            else if (positionNode instanceof MethodNode m)
             {
                 // for local variables, we only look up directly into the method node
-                Iterator<NodeTree.NodeAndPosition<ParsedNode>> methodContentIterator = positionNode.getChildren(0);
-                while (methodContentIterator.hasNext())
-                {
-                    NodeTree.NodeAndPosition methodChild = methodContentIterator.next();
-                    if (methodChild.getNode() instanceof MethodBodyNode)
-                    {
-                        // the method should have a body: we look for the variables
-                        Iterator<NodeTree.NodeAndPosition<ParsedNode>> methodBodyIterator = ((MethodBodyNode) methodChild.getNode()).getChildren(0);
-                        List<String> varNameList = new ArrayList<>();
-                        while (methodBodyIterator.hasNext())
-                        {
-                            NodeTree.NodeAndPosition methodBodyChild = methodBodyIterator.next();
-                            // (Note: the FieldNode class actually covers both fields and variables objects)
-                            if (methodBodyChild.getNode() instanceof FieldNode)
-                            {
-                                varNameList.add(((FieldNode) methodBodyChild.getNode()).getName());
-                            }
-                        }
-                        //return the variables we found
-                        return varNameList.stream()
-                            .distinct()
-                            .map(SimpleCorrectionInfo::new);
-                    }
-                }
-                 // if we didn't find anything, then we return an empty stream.
-                 return Stream.empty();
+                return ParseUtils.findLocalVariables(m).stream().distinct().map(FieldNode::getName).map(SimpleCorrectionInfo::new);
+            }
+            else
+            {
+                return Stream.empty();
             }
         }
     }

--- a/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowErrorManager.java
@@ -939,7 +939,7 @@ public class FlowErrorManager implements ErrorQuery
                 if (editor.getProject() == null)
                     return null;
 
-                AssistContent[] values = ParseUtils.getPossibleCompletions(suggests, editor.getProject().getJavadocResolver(), null, positionNode instanceof MethodNode m ? m : null);
+                AssistContent[] values = ParseUtils.getPossibleCompletions(suggests, editor.getProject().getJavadocResolver(), null, positionNode instanceof MethodNode m ? m : null, -1);
                 if (values == null)
                     return null;
 
@@ -954,7 +954,7 @@ public class FlowErrorManager implements ErrorQuery
             else if (positionNode instanceof MethodNode m)
             {
                 // for local variables, we only look up directly into the method node
-                return ParseUtils.findLocalVariables(m).stream().distinct().map(FieldNode::getName).map(SimpleCorrectionInfo::new);
+                return ParseUtils.findLocalVariables(m, -1).stream().distinct().map(FieldNode::getName).map(SimpleCorrectionInfo::new);
             }
             else
             {

--- a/bluej/src/main/java/bluej/editor/stride/FrameEditor.java
+++ b/bluej/src/main/java/bluej/editor/stride/FrameEditor.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021,2022 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021,2022,2024 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/editor/stride/FrameEditor.java
+++ b/bluej/src/main/java/bluej/editor/stride/FrameEditor.java
@@ -1259,7 +1259,7 @@ public class FrameEditor implements Editor
         ArrayList<AssistContent> joined = new ArrayList<>();
         if (suggests != null)
         {
-            AssistContent[] assists = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, null);
+            AssistContent[] assists = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, null, -1);
             if (assists != null)
                 joined.addAll(Arrays.asList(assists));
         }
@@ -1296,11 +1296,11 @@ public class FrameEditor implements Editor
         {
             members = new ArrayList<>();
             // Add it whether overridden or not:
-            ParseUtils.getPossibleCompletions(suggests, javadocResolver, (ac, isOverridden) -> members.add(ac), null);
+            ParseUtils.getPossibleCompletions(suggests, javadocResolver, (ac, isOverridden) -> members.add(ac), null, -1);
         }
         else
         {
-            AssistContent[] result = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, null);
+            AssistContent[] result = ParseUtils.getPossibleCompletions(suggests, javadocResolver, null, null, -1);
             if (result == null)
                 members = Collections.emptyList();
             else

--- a/bluej/src/main/java/bluej/parser/EditorParser.java
+++ b/bluej/src/main/java/bluej/parser/EditorParser.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2010,2011,2012,2013,2014,2016,2017,2019,2021,2022,2023  Michael Kolling and John Rosenberg 
+ Copyright (C) 2010,2011,2012,2013,2014,2016,2017,2019,2021,2022,2023,2024  Michael Kolling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -1426,7 +1426,8 @@ public class EditorParser extends JavaParser
         JavaEntity fieldType = ParseUtils.getTypeEntity(resolver, currentQuerySource(), lastTypeSpec);
         arrayDecls = 0;
         
-        int finalPos = scopeStack.get(targetIndex + 1).getOffsetFromParent();//insPos - curOffset;
+        final int finalAbsPos = scopeStack.get(targetIndex + 1).getAbsoluteEditorPosition();
+        final int finalOffsetFromParent = scopeStack.get(targetIndex + 1).getOffsetFromParent();//insPos - curOffset;
         int modifiers = currentModifiers;
         scopeStack.get(targetIndex).insertInstanceofVar(
                 new VariableDeclaration()
@@ -1446,13 +1447,25 @@ public class EditorParser extends JavaParser
                     @Override
                     public int getOffsetFromParent()
                     {
-                        return finalPos;
+                        return finalOffsetFromParent;
+                    }
+
+                    @Override
+                    public int getAbsoluteEditorPosition()
+                    {
+                        return finalAbsPos;
                     }
 
                     @Override
                     public int getModifiers()
                     {
                         return modifiers;
+                    }
+
+                    @Override
+                    public String getFieldTypeAsPlainString()
+                    {
+                        return fieldType.getName();
                     }
                 });
     }

--- a/bluej/src/main/java/bluej/parser/ParseUtils.java
+++ b/bluej/src/main/java/bluej/parser/ParseUtils.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2013,2014,2015,2017,2018,2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2013,2014,2015,2017,2018,2019,2020,2021,2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -28,7 +28,9 @@ import java.util.stream.Stream;
 
 import bluej.parser.entity.*;
 import bluej.parser.nodes.FieldNode;
+import bluej.parser.nodes.MethodBodyNode;
 import bluej.parser.nodes.MethodNode;
+import bluej.parser.nodes.NodeTree.NodeAndPosition;
 import bluej.parser.nodes.ParsedNode;
 import bluej.parser.nodes.VariableDeclaration;
 import bluej.parser.symtab.ClassInfo;
@@ -656,4 +658,37 @@ public class ParseUtils
         }
         return base.setTypeArgs(taList);
     }
+
+    /**
+     * Find all the local variables declared in the given method node.
+     * @param positionNode The method node to look in
+     * @return The list of all local variables declared in that method.
+     */
+    public static List<FieldNode> findLocalVariables(MethodNode positionNode)
+    {
+        Iterator<NodeAndPosition<ParsedNode>> methodContentIterator = positionNode.getChildren(0);
+        while (methodContentIterator.hasNext())
+        {
+            NodeAndPosition methodChild = methodContentIterator.next();
+            if (methodChild.getNode() instanceof MethodBodyNode)
+            {
+                // the method should have a body: we look for the variables
+                Iterator<NodeAndPosition<ParsedNode>> methodBodyIterator = ((MethodBodyNode) methodChild.getNode()).getChildren(0);
+                List<FieldNode> fieldList = new ArrayList<>();
+                while (methodBodyIterator.hasNext())
+                {
+                    NodeAndPosition methodBodyChild = methodBodyIterator.next();
+                    // (Note: the FieldNode class actually covers both fields and variables objects)
+                    if (methodBodyChild.getNode() instanceof FieldNode f)
+                    {
+                        fieldList.add(f);
+                    }
+                }
+                //return the variables we found
+                return fieldList;
+            }
+        }
+        // if we didn't find anything, then we return an empty list.
+        return List.of();
+    }    
 }

--- a/bluej/src/main/java/bluej/parser/nodes/FieldNode.java
+++ b/bluej/src/main/java/bluej/parser/nodes/FieldNode.java
@@ -225,7 +225,7 @@ public class FieldNode extends JavaParentNode implements VariableDeclaration
         }
         else if (fieldType != null)
         {
-            return fieldType.getName();
+            return fieldType.getName() + "[]".repeat(arrayDecls);
         }
         
         return "";

--- a/bluej/src/main/java/bluej/parser/nodes/FieldNode.java
+++ b/bluej/src/main/java/bluej/parser/nodes/FieldNode.java
@@ -209,6 +209,27 @@ public class FieldNode extends JavaParentNode implements VariableDeclaration
         }
         return ftype;
     }
+
+    /**
+     * Get the type of the field as a simple plain string (does not include any generic parts).
+     */
+    public String getFieldTypeAsPlainString()
+    {
+        if (isVarType)
+        {
+            return "var";
+        }
+        else if (firstNode != null)
+        {
+            return firstNode.getFieldTypeAsPlainString();
+        }
+        else if (fieldType != null)
+        {
+            return fieldType.getName();
+        }
+        
+        return "";
+    }
     
     /**
      * Get the modifiers of this field 

--- a/bluej/src/main/java/bluej/parser/nodes/FieldNode.java
+++ b/bluej/src/main/java/bluej/parser/nodes/FieldNode.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2019,2020,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2019,2020,2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/parser/nodes/JavaParentNode.java
+++ b/bluej/src/main/java/bluej/parser/nodes/JavaParentNode.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2011,2012,2014,2016,2017,2019,2021,2022,2023  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2011,2012,2014,2016,2017,2019,2021,2022,2023,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -565,4 +565,13 @@ public abstract class JavaParentNode extends ParentParsedNode
         token.next = new Token(0, TokenType.END);
         return dummyTok.next;
     }
+
+    /**
+     * Gets the local variables of this item
+     */
+    public Map<String, Set<VariableDeclaration>> getLocVarNodes()
+    {
+        return Map.copyOf(variables);
+    }
+    
 }

--- a/bluej/src/main/java/bluej/parser/nodes/MethodNode.java
+++ b/bluej/src/main/java/bluej/parser/nodes/MethodNode.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2011,2019,2020,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2011,2019,2020,2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -266,24 +266,5 @@ public class MethodNode extends JavaParentNode
             }
         }
         return super.getExpressionType(pos, nodePos, defaultType, document, null);
-    }
-
-    /**
-     * Gets the local variables nodes of a method.
-     *
-     * @return a Map object containing the local variables nodes of that method.
-     */
-    public Map<String, Set<VariableDeclaration>> getLocVarNodes()
-    {
-        Iterator<NodeAndPosition<ParsedNode>> children = getChildren(0);
-        while (children.hasNext())
-        {
-            NodeAndPosition<ParsedNode> child = children.next();
-            if (child.getNode() instanceof MethodBodyNode)
-            {
-                return ((MethodBodyNode) child.getNode()).variables;
-            }
-        }
-        return null;
     }
 }

--- a/bluej/src/main/java/bluej/parser/nodes/VariableDeclaration.java
+++ b/bluej/src/main/java/bluej/parser/nodes/VariableDeclaration.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2022  Michael Kolling and John Rosenberg 
+ Copyright (C) 2022,2024  Michael Kolling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -45,7 +45,18 @@ public interface VariableDeclaration
     int getOffsetFromParent();
 
     /**
+     * The absolute position in the file as a whole
+     */
+    int getAbsoluteEditorPosition();
+
+    /**
      * The OR-ed together modifiers for the variable (final, volatile, etc)
      */
     int getModifiers();
+
+    /**
+     * Gets the field type as a plain string, for displaying in the autocomplete
+     */
+    public String getFieldTypeAsPlainString();
+
 }

--- a/bluej/src/test/java/bluej/parser/CompletionTest.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest.java
@@ -43,6 +43,7 @@ import bluej.parser.entity.JavaEntity;
 import bluej.parser.entity.PackageResolver;
 import bluej.parser.entity.TypeEntity;
 import bluej.parser.lexer.LocatableToken;
+import bluej.parser.nodes.MethodNode;
 import bluej.parser.nodes.ParsedCUNode;
 import bluej.pkgmgr.JavadocResolver;
 import bluej.utility.JavaReflective;
@@ -959,7 +960,7 @@ public class CompletionTest
                 throw new RuntimeException("Not implemented in test stub.");
             }
             
-        }, null, aNode.getContainingMethodOrClassNode(98));
+        }, null, (MethodNode)aNode.getContainingMethodOrClassNode(98));
         
         for (AssistContent assist : assists) {
             assist.getJavadoc();
@@ -1044,7 +1045,7 @@ public class CompletionTest
             {
                 throw new RuntimeException("Not implemented in test stub.");
             }
-        }, null, aNode.getContainingMethodOrClassNode(57));
+        }, null, (MethodNode)aNode.getContainingMethodOrClassNode(57));
         
         assertNotNull(acontent);
     }

--- a/bluej/src/test/java/bluej/parser/CompletionTest.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest.java
@@ -960,7 +960,7 @@ public class CompletionTest
                 throw new RuntimeException("Not implemented in test stub.");
             }
             
-        }, null, (MethodNode)aNode.getContainingMethodOrClassNode(98));
+        }, null, (MethodNode)aNode.getContainingMethodOrClassNode(98), -1);
         
         for (AssistContent assist : assists) {
             assist.getJavadoc();
@@ -1045,7 +1045,7 @@ public class CompletionTest
             {
                 throw new RuntimeException("Not implemented in test stub.");
             }
-        }, null, (MethodNode)aNode.getContainingMethodOrClassNode(57));
+        }, null, (MethodNode)aNode.getContainingMethodOrClassNode(57), -1);
         
         assertNotNull(acontent);
     }

--- a/bluej/src/test/java/bluej/parser/CompletionTest3.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest3.java
@@ -117,7 +117,7 @@ public class CompletionTest3
         resolver.addCompilationUnit("", p.node());
 
         int pos = p.positionStart("A");
-        AssistContent[] results = ParseUtils.getPossibleCompletions(p.node().getExpressionType(pos, p.doc()), dummyJavadocResolver, null, p.node().getContainingMethodOrClassNode(pos) instanceof MethodNode m ? m : null);
+        AssistContent[] results = ParseUtils.getPossibleCompletions(p.node().getExpressionType(pos, p.doc()), dummyJavadocResolver, null, p.node().getContainingMethodOrClassNode(pos) instanceof MethodNode m ? m : null, pos);
         List<AC> acs = Arrays.stream(results).map(AC::new).collect(Collectors.toList());
         List<String> namesOnly = Arrays.stream(results).map(AssistContent::getName).collect(Collectors.toList());
 

--- a/bluej/src/test/java/bluej/parser/CompletionTest3.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest3.java
@@ -281,4 +281,28 @@ public class CompletionTest3
                 }
                 """);
     }
+
+    @Test
+    public void testVarRelativePositionAndNested()
+    {
+        assertNamesAtA(List.of("int var1", "int var2", "String var3"), List.of("var2b", "var4"), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        int var1, var2;
+                        if (true)
+                        {
+                            int var2b;
+                        }
+                        if (true)
+                        {
+                            String var3;
+                            /*A*/
+                            List<String> var4;
+                        }
+                    }
+                }
+                """);
+    }
 }

--- a/bluej/src/test/java/bluej/parser/CompletionTest3.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest3.java
@@ -1,0 +1,126 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2024  Michael Kolling and John Rosenberg
+ 
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+ 
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+ 
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+ 
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.parser;
+
+import bluej.JavaFXThreadingRule;
+import bluej.debugger.gentype.Reflective;
+import bluej.parser.ParseUtility.StartEnd;
+import bluej.parser.entity.ClassLoaderResolver;
+import bluej.pkgmgr.JavadocResolver;
+import bluej.utility.Debug;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import static bluej.parser.ParseUtility.Parsed;
+import static bluej.parser.ParseUtility.parse;
+import static org.junit.Assert.*;
+
+/**
+ * Test for code completion, especially around local variables.
+ */
+public class CompletionTest3
+{
+    @Rule
+    public JavaFXThreadingRule javafxRule = new JavaFXThreadingRule();
+
+    @BeforeClass
+    public static void initConfig()
+    {
+        InitConfig.init();
+    }
+
+    private JavadocResolver dummyJavadocResolver = new JavadocResolver()
+    {
+        @Override
+        public void getJavadoc(Reflective declType, Collection<? extends ConstructorOrMethodReflective> methods)
+        {
+        }
+
+        @Override
+        public String getJavadoc(String moduleName, String typeName)
+        {
+            return "";
+        }
+
+        @Override
+        public boolean getJavadocAsync(ConstructorOrMethodReflective method, AsyncCallback callback, Executor executor)
+        {
+            return false;
+        }
+    };
+
+    private TestEntityResolver resolver;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        Debug.setDebugStream(new OutputStreamWriter(System.out));
+        resolver = new TestEntityResolver(new ClassLoaderResolver(this.getClass().getClassLoader()));
+    }
+
+    /**
+     * Asserts that the given names are/aren't available for autocomplete
+     * at position "A" in the source, i.e. where
+     * / * A * / (without spaces) occurs in the source.
+     * @param namesShouldBeAvailable A list of names which should be available.
+     * @param namesShouldNotBeAvailable A list of names which should not be available
+     * @param javaSrc The Java source code                        
+     */
+    private void assertNamesAtA(List<String> namesShouldBeAvailable, List<String> namesShouldNotBeAvailable, String javaSrc)
+    {
+        Parsed p = parse(javaSrc, resolver);
+        resolver.addCompilationUnit("", p.node());
+
+        int pos = p.positionStart("A");
+        AssistContent[] results = ParseUtils.getPossibleCompletions(p.node().getExpressionType(pos, p.doc()), dummyJavadocResolver, null, p.node().getContainingMethodOrClassNode(pos));
+        List<String> names = Arrays.stream(results).map(AssistContent::getName).collect(Collectors.toList());
+
+        MatcherAssert.assertThat(names, Matchers.hasItems(namesShouldBeAvailable.toArray(String[]::new)));
+        MatcherAssert.assertThat(names, Matchers.not(Matchers.hasItems(namesShouldNotBeAvailable.toArray(String[]::new))));
+    }
+
+    @Test
+    public void testFieldsInInitialiser()
+    {
+        assertNamesAtA(List.of("field1", "field2"), List.of("field3"), """
+                class Foo
+                {
+                    int field1, field2;
+                    {
+                        /*A*/
+                    }
+                }
+                """);
+    }
+}

--- a/bluej/src/test/java/bluej/parser/CompletionTest3.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest3.java
@@ -211,4 +211,74 @@ public class CompletionTest3
                 }
                 """);
     }
+
+    @Test
+    public void testArrayTypes()
+    {
+        assertNamesAtA(List.of("int[] arr1", "int[][] arr2", "List param1"), List.of(), """
+                class Foo
+                {
+                    <T> void foo(List<T> param1)
+                    {
+                        int[] arr1;
+                        int[][] arr2;
+                        /*A*/
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testLoopVars()
+    {
+        assertNamesAtA(List.of("int i", "String s"), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        for (int i = 0;i < 10; i++)
+                        {
+                            for (String s : myList)
+                            {
+                                /*A*/
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testInstanceofVar()
+    {
+        assertNamesAtA(List.of("String s"), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        if ("hi" instanceof String s)
+                        {
+                            /*A*/
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testVarRelativePosition()
+    {
+        assertNamesAtA(List.of("int var1", "int var2", "String var3"), List.of("var4"), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        int var1, var2;
+                        String var3;
+                        /*A*/
+                        List<String> var4;
+                    }
+                }
+                """);
+    }
 }


### PR DESCRIPTION
Add support in the Java autocomplete for locally declared variables (including parameters, local variables, for-loop and for-each loop variables, and instanceof variables).

Fixes #2303 