### PR TITLE
Added delete-next-word action. Deletes word to the right of the cursor.

### DIFF
--- a/bluej/lib/english/moe.help
+++ b/bluej/lib/english/moe.help
@@ -8,6 +8,8 @@
 
 delete-previous=\n Delete the character before the caret.
 delete-next=\n Delete the character after the caret.
+delete-previous-word=\n Delete the word before the caret.
+delete-next-word=\n Delete the word after the caret.
 copy-to-clipboard=\n Copy the selected text to the clipboard. From there, it can be\n pasted somewhere else later (see paste-from-clipboard).
 cut-to-clipboard= Cut the selection from the text and move it to the clipboard.\n From there, it can be pasted somewhere else later (see\n paste-from-clipboard).
 copy-line=\n Copy the current line to the clipboard. Successive \n copy operations add to the clipbord.

--- a/bluej/lib/german/moe.help
+++ b/bluej/lib/german/moe.help
@@ -8,6 +8,8 @@
 
 delete-previous=\n Zeichen vor dem Cursor l\u00f6schen.
 delete-next=\n Zeichen nach dem Cursor l\u00f6schen.
+delete-previous-word=\n Wort vor dem Cursor l\u00f6schen.
+delete-next-word=\n Wort nach dem Cursor l\u00f6schen.
 copy-to-clipboard=\n Ausgew\u00e4hlten Text in die Zwischenablage kopieren. Von dort kann er\n woanders eingef\u00fcgt werden (vgl. paste-from-clipboard).
 cut-to-clipboard=\n Ausgew\u00e4hlten Text in die Zwischenablage ausschneiden. Von dort kann\n er woanders eingef\u00fcgt werden (vgl. paste-from-clipboard).
 copy-line=\n Aktuelle Zeile in die Zwischenablage kopieren.\n Danach Kopiertes wird an die Zwischenablage angef\u00fcgt.

--- a/bluej/src/main/java/bluej/editor/flow/FlowActions.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowActions.java
@@ -890,7 +890,8 @@ public final class FlowActions
                 new DeletePrevCharAction(),
                 new DeleteNextCharAction(),
 
-                deleteWordAction(),
+                deletePreviousWordAction(),
+                deleteNextWordAction(),
                 selectWordAction(),
                 saveAction(),
                 printAction(),
@@ -2051,13 +2052,25 @@ public final class FlowActions
         }
     }
 
-    private FlowAbstractAction deleteWordAction()
+    private FlowAbstractAction deletePreviousWordAction()
     {
         return action("delete-previous-word", Category.EDIT, () -> {
             FlowEditorPane c = getTextComponent();
             FlowAbstractAction prevWordAct = actions.get("caret-previous-word");
             int end = c.getCaretPosition();
             prevWordAct.actionPerformed(false);
+            c.positionAnchor(end);
+            c.replaceSelection("");
+        });
+    }
+
+    private FlowAbstractAction deleteNextWordAction()
+    {
+        return action("delete-next-word", Category.EDIT, () -> {
+            FlowEditorPane c = getTextComponent();
+            FlowAbstractAction nextWordAct = actions.get("caret-next-word");
+            int end = c.getCaretPosition();
+            nextWordAct.actionPerformed(false);
             c.positionAnchor(end);
             c.replaceSelection("");
         });


### PR DESCRIPTION
You can now configure a shortcut to remove the word to the right of the cursor in the editor. Has the functionality like pressing ctrl+del. 

Also added a description with the corresponding German translation for the settings page for the delete-next-word and delete-previous-word action. 