### PR TITLE
Add sections to BlueJ terminal to divide up different method calls

### DIFF
--- a/bluej/src/main/java/bluej/BlueJEvent.java
+++ b/bluej/src/main/java/bluej/BlueJEvent.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2014,2016,2019  Michael Kolling and John Rosenberg 
+ Copyright (C) 1999-2009,2010,2014,2016,2019,2024  Michael Kolling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -90,11 +90,7 @@ public class BlueJEvent
     @OnThread(Tag.FXPlatform)
     public static void raiseEvent(int eventId, Object arg)
     {
-        Object[] listenersCopy = listeners.toArray();
-        for (int i = listenersCopy.length - 1; i >= 0; i--) {
-            BlueJEventListener listener = (BlueJEventListener) listenersCopy[i];
-            listener.blueJEvent(eventId, arg, null);
-        }
+        raiseEvent(eventId, arg, null);
     }
 
     /**

--- a/bluej/src/main/java/bluej/debugmgr/ExecutionEvent.java
+++ b/bluej/src/main/java/bluej/debugmgr/ExecutionEvent.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2014  Michael Kolling and John Rosenberg 
+ Copyright (C) 1999-2009,2010,2014,2024  Michael Kolling and John Rosenberg 
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -37,26 +37,35 @@ import bluej.pkgmgr.Package;
 @OnThread(Tag.Any)
 public class ExecutionEvent
 {
-    /**
-     * The execution has finished normally;
-     */
-    public static final String NORMAL_EXIT = "Normal exit";
+    public static enum Result
+    {
+        /**
+         * The execution has finished normally;
+         */
+        NORMAL_EXIT("Normal exit"),
 
-    /**
-     * The execution has finished due to an exception
-     */
-    public static final String EXCEPTION_EXIT = "An exception occurred";
+        /**
+         * The execution has finished due to an exception
+         */
+        EXCEPTION_EXIT("An exception occurred"),
 
-    /**
-     * The execution has finished because the user has forcefully terminated it
-     */
-    public static final String TERMINATED_EXIT = "User terminated";
+        /**
+         * The execution has finished because the user has forcefully terminated it
+         */
+        TERMINATED_EXIT("User terminated");
+        
+        private final String text;
+        private Result(String text)
+        {
+            this.text = text;
+        }
+    }
     
     private String className, objectName;
     private String methodName;
     private JavaType[] signature;
     private String[] parameters;
-    private String result;
+    private Result result;
     private String command;
     private Package pkg;
     private DebuggerObject resultObject;   // If there is a result object it goes here.
@@ -109,11 +118,10 @@ public class ExecutionEvent
     /**
      * Set the result of the execution. This should be one of:
      * NORMAL_EXIT - the execution terminated successfully
-     * FORCED_EXIT - System.exit() was called
      * EXCEPTION_EXIT - the execution failed due to an exception
      * TERMINATED_EXIT - the user terminated the VM before execution completed
      */
-    public void setResult (String result)
+    public void setResult (Result result)
     {
         this.result = result;
     }
@@ -198,7 +206,7 @@ public class ExecutionEvent
      * EXCEPTION_EXIT - the execution failed due to an exception
      * TERMINATED_EXIT - the user terminated the VM before execution completed
      */
-    public String getResult()
+    public Result getResult()
     {
         return result;
     }

--- a/bluej/src/main/java/bluej/debugmgr/codepad/CodePad.java
+++ b/bluej/src/main/java/bluej/debugmgr/codepad/CodePad.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2011,2012,2013,2016,2017,2018,2019,2020,2021,2022,2023  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2011,2012,2013,2016,2017,2018,2019,2020,2021,2022,2023,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -857,7 +857,7 @@ public class CodePad extends VBox
 
             ExecutionEvent executionEvent = new ExecutionEvent(frame.getPackage());
             executionEvent.setCommand(command);
-            executionEvent.setResult(ExecutionEvent.NORMAL_EXIT);
+            executionEvent.setResult(ExecutionEvent.Result.NORMAL_EXIT);
             executionEvent.setResultObject(result);
             BlueJEvent.raiseEvent(BlueJEvent.EXECUTION_RESULT, executionEvent);
 
@@ -934,7 +934,7 @@ public class CodePad extends VBox
         {
             ExecutionEvent executionEvent = new ExecutionEvent(frame.getPackage());
             executionEvent.setCommand(command);
-            executionEvent.setResult(ExecutionEvent.EXCEPTION_EXIT);
+            executionEvent.setResult(ExecutionEvent.Result.EXCEPTION_EXIT);
             executionEvent.setException(exception);
             BlueJEvent.raiseEvent(BlueJEvent.EXECUTION_RESULT, executionEvent);
             updateInspectors();

--- a/bluej/src/main/java/bluej/debugmgr/objectbench/ResultWatcherBase.java
+++ b/bluej/src/main/java/bluej/debugmgr/objectbench/ResultWatcherBase.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2017,2018,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 2017,2018,2019,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -96,7 +96,7 @@ public abstract class ResultWatcherBase implements ResultWatcher
             executionEvent.setMethodName(mv.getName());
         }
         executionEvent.setParameters(method.getParamTypes(false), ir.getArgumentValues());
-        executionEvent.setResult(ExecutionEvent.NORMAL_EXIT);
+        executionEvent.setResult(ExecutionEvent.Result.NORMAL_EXIT);
         executionEvent.setResultObject(result);
         BlueJEvent.raiseEvent(BlueJEvent.EXECUTION_RESULT, executionEvent);
 
@@ -152,7 +152,7 @@ public abstract class ResultWatcherBase implements ResultWatcher
     {
         ExecutionEvent executionEvent = new ExecutionEvent(pkg, className, objInstanceName);
         executionEvent.setParameters(method.getParamTypes(false), ir.getArgumentValues());
-        executionEvent.setResult(ExecutionEvent.EXCEPTION_EXIT);
+        executionEvent.setResult(ExecutionEvent.Result.EXCEPTION_EXIT);
         executionEvent.setException(exception);
         BlueJEvent.raiseEvent(BlueJEvent.EXECUTION_RESULT, executionEvent);
 
@@ -165,7 +165,7 @@ public abstract class ResultWatcherBase implements ResultWatcher
     {
         ExecutionEvent executionEvent = new ExecutionEvent(pkg, className, objInstanceName);
         executionEvent.setParameters(method.getParamTypes(false), ir.getArgumentValues());
-        executionEvent.setResult(terminatedByUserCode ? ExecutionEvent.NORMAL_EXIT : ExecutionEvent.TERMINATED_EXIT);
+        executionEvent.setResult(terminatedByUserCode ? ExecutionEvent.Result.NORMAL_EXIT : ExecutionEvent.Result.TERMINATED_EXIT);
         BlueJEvent.raiseEvent(BlueJEvent.EXECUTION_RESULT, executionEvent);
     }
 }

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2019,2020,2021,2022,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
@@ -33,28 +33,21 @@ import bluej.editor.base.LineDisplay.LineDisplayListener;
 import bluej.editor.base.MarginAndTextLine.MarginDisplay;
 import bluej.editor.base.TextLine.HighlightType;
 import bluej.editor.base.TextLine.StyledSegment;
-import bluej.prefmgr.PrefMgr;
 import bluej.utility.javafx.JavaFXUtil;
-import javafx.collections.ObservableList;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.AccessibleAttribute;
-import javafx.scene.Node;
 import javafx.scene.control.IndexRange;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.Region;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 import javafx.scene.shape.PathElement;
-import javafx.scene.text.Font;
-import javafx.scene.text.Text;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
@@ -70,7 +63,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * A FlowEditorPane is a component with (optional) horizontal and vertical scroll bars.
@@ -515,31 +507,8 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
     static Optional<Double> getLeftEdgeX(int leftOfCharIndex, Document document, LineDisplay lineDisplay)
     {
         int lineIndex = document.getLineFromPosition(leftOfCharIndex);
-        if (lineDisplay.isLineVisible(lineIndex))
-        {
-            TextLine line = lineDisplay.getVisibleLine(lineIndex).textLine;
-            // If the line needs layout, the positions won't be accurate:
-            if (line.isNeedsLayout())
-                return Optional.empty();
-            // Sometimes, it seems that the line can have the CSS for the font,
-            // and claim it doesn't need layout, but the font on the Text items
-            // has not actually been switched to the right font.  In this case
-            // the positions will be inaccurate, so we should not calculate:
-            Font curFont = line.getChildren().stream().flatMap(n -> n instanceof Text ? Stream.of(((Text)n).getFont()) : Stream.empty()).findFirst().orElse(null);
-            if (curFont != null && !curFont.getFamily().equals(PrefMgr.getEditorFontFamily()))
-                return Optional.empty();
-            int posInLine = leftOfCharIndex - document.getLineStart(lineIndex);
-            PathElement[] elements = line.caretShape(posInLine, true);
-            Path path = new Path(elements);
-            Bounds bounds = path.getBoundsInLocal();
-            // If the bounds are at left edge but char is not, might not have laid out yet:
-            if (posInLine > 0 && bounds.getMaxX() < 2.0)
-            {
-                return Optional.empty();
-            }
-            return Optional.of((bounds.getMinX() + bounds.getMaxX()) / 2.0);
-        }
-        return Optional.empty();
+        int posInLine = leftOfCharIndex - document.getLineStart(lineIndex);
+        return lineDisplay.calculateLeftEdgeX(lineIndex, posInLine);
     }
 
     public Optional<Bounds> getCaretBoundsOnScreen(int position)

--- a/bluej/src/main/java/bluej/extensions2/DirectInvoker.java
+++ b/bluej/src/main/java/bluej/extensions2/DirectInvoker.java
@@ -25,6 +25,7 @@ import bluej.BlueJEvent;
 import bluej.debugger.DebuggerObject;
 import bluej.debugger.ExceptionDescription;
 import bluej.debugmgr.ExecutionEvent;
+import bluej.debugmgr.ExecutionEvent.Result;
 import bluej.debugmgr.Invoker;
 import bluej.debugmgr.ResultWatcher;
 import bluej.debugmgr.objectbench.ObjectWrapper;
@@ -106,7 +107,7 @@ class DirectInvoker
             DebuggerObject result = watcher.getResult();
 
             Platform.runLater(() -> {
-                String resultType = watcher.getResultType();
+                Result resultType = watcher.getResultType();
                 if (resultType != null)
                 {
                     ExecutionEvent ee = new ExecutionEvent(pkgFrame.getPackage(), callable.getClassName(), null);
@@ -199,7 +200,7 @@ class DirectInvoker
             DebuggerObject result = watcher.getResult();
     
             Platform.runLater(() -> {
-                String resultType = watcher.getResultType();
+                Result resultType = watcher.getResultType();
                 if (resultType != null)
                 {
                     ExecutionEvent ee = new ExecutionEvent(pkgFrame.getPackage(), callable.getClassName(),
@@ -228,15 +229,15 @@ class DirectInvoker
     private static void raiseEvent(ExecutionEvent event, CallableView callable, String [] argStrings, 
             DirectResultWatcher watcher, DebuggerObject result)
     {
-        String resultType = watcher.getResultType();
+        Result resultType = watcher.getResultType();
         
         event.setParameters(callable.getParamTypes(false), argStrings);
         event.setResult(resultType);
-        if (resultType == ExecutionEvent.NORMAL_EXIT) {
+        if (resultType == ExecutionEvent.Result.NORMAL_EXIT) {
             event.setResultObject(result);
             event.setObjectName(watcher.getResultName());
         }
-        else if (resultType == ExecutionEvent.EXCEPTION_EXIT) {
+        else if (resultType == ExecutionEvent.Result.EXCEPTION_EXIT) {
             event.setException(watcher.getException());
         }
         
@@ -364,7 +365,7 @@ class DirectInvoker
         private boolean resultReady;
         @OnThread(value = Tag.Any, requireSynchronized = true)
         private boolean isFailed;
-        private String resultType;
+        private ExecutionEvent.Result resultType;
 
         private DebuggerObject result;
         private ExceptionDescription exception;
@@ -454,7 +455,7 @@ class DirectInvoker
         public synchronized void putResult(DebuggerObject aResult, String anObjectName, InvokerRecord ir)
         {
             result = aResult;
-            resultType = ExecutionEvent.NORMAL_EXIT;
+            resultType = ExecutionEvent.Result.NORMAL_EXIT;
             resultName = anObjectName;
             resultReady = true;
             notifyAll();
@@ -482,7 +483,7 @@ class DirectInvoker
         public synchronized void putException(ExceptionDescription exception, InvokerRecord ir)
         {
             this.exception = exception;
-            resultType = ExecutionEvent.EXCEPTION_EXIT;
+            resultType = ExecutionEvent.Result.EXCEPTION_EXIT;
             putError(exception.getText(), ir);
         }
         
@@ -492,7 +493,7 @@ class DirectInvoker
          */
         public void putVMTerminated(InvokerRecord ir, boolean terminatedByUserCode)
         {
-            resultType = terminatedByUserCode ? ExecutionEvent.NORMAL_EXIT : ExecutionEvent.TERMINATED_EXIT;
+            resultType = terminatedByUserCode ? ExecutionEvent.Result.NORMAL_EXIT : ExecutionEvent.Result.TERMINATED_EXIT;
             putError("Terminated", ir);
         }
 
@@ -527,7 +528,7 @@ class DirectInvoker
          * ExecutionEvent.TERMINATED_EXIT if the user VM exited for any reason;<br>
          * null if compilation failure occurred.
          */
-        public String getResultType()
+        public ExecutionEvent.Result getResultType()
         {
             return resultType;
         }

--- a/bluej/src/main/java/bluej/extensions2/event/InvocationFinishedEvent.java
+++ b/bluej/src/main/java/bluej/extensions2/event/InvocationFinishedEvent.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2014,2019,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2014,2019,2021,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -25,6 +25,7 @@ import bluej.debugger.DebuggerObject;
 import bluej.debugger.gentype.JavaPrimitiveType;
 import bluej.debugger.gentype.JavaType;
 import bluej.debugmgr.ExecutionEvent;
+import bluej.debugmgr.ExecutionEvent.Result;
 import bluej.debugmgr.objectbench.ObjectWrapper;
 import bluej.extensions2.BPackage;
 import bluej.extensions2.ExtensionBridge;
@@ -95,16 +96,16 @@ public class InvocationFinishedEvent implements ExtensionEvent
     public InvocationFinishedEvent(ExecutionEvent exevent)
     {
         terminationType = EventType.UNKNOWN_EXIT;
-        String resultType = exevent.getResult();
+        Result resultType = exevent.getResult();
         switch (resultType)
         {
-            case ExecutionEvent.NORMAL_EXIT:
+            case NORMAL_EXIT:
                 terminationType = EventType.NORMAL_EXIT;
                 break;
-            case ExecutionEvent.EXCEPTION_EXIT:
+            case EXCEPTION_EXIT:
                 terminationType = EventType.EXCEPTION_EXIT;
                 break;
-            case ExecutionEvent.TERMINATED_EXIT:
+            case TERMINATED_EXIT:
                 terminationType = EventType.TERMINATED_EXIT;
                 break;
         }

--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -511,6 +511,8 @@ public final class Terminal
             clear();
         }
         text.markNewSection();
+        if (errorText != null)
+            errorText.clear();
         if(recordMethodCalls.get()) {
             text.append(new StyledSegment(STDOUT_METHOD_RECORDING, callString + "\n"));
         }
@@ -531,6 +533,9 @@ public final class Terminal
         if(clearOnMethodCall.get()) {
             clear();
         }
+        text.markNewSection();
+        if (errorText != null)
+            errorText.clear();
         if(recordMethodCalls.get()) {
             String callString = ir.getResultTypeString() + " " + ir.getResultName() + " = " + ir.toExpression() + ";";
             text.append(new StyledSegment(STDOUT_METHOD_RECORDING, callString + "\n"));

--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -510,7 +510,7 @@ public final class Terminal
         if(clearOnMethodCall.get()) {
             clear();
         }
-        text.markNewSection();
+        text.markNewSection(callString);
         if (errorText != null)
             errorText.clear();
         if(recordMethodCalls.get()) {
@@ -533,11 +533,11 @@ public final class Terminal
         if(clearOnMethodCall.get()) {
             clear();
         }
-        text.markNewSection();
+        String callString = ir.getResultTypeString() + " " + ir.getResultName() + " = " + ir.toExpression() + ";";
+        text.markNewSection(callString);
         if (errorText != null)
             errorText.clear();
         if(recordMethodCalls.get()) {
-            String callString = ir.getResultTypeString() + " " + ir.getResultName() + " = " + ir.toExpression() + ";";
             text.append(new StyledSegment(STDOUT_METHOD_RECORDING, callString + "\n"));
         }
         newMethodCall = true;

--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -914,6 +914,8 @@ public final class Terminal
     private class TerminalWriter extends Writer
     {
         private boolean isErrorOut;
+        // The number of pending writes (content that has been received on the
+        // IO thread, but not yet displayed in the terminal via the FX thread)
         private AtomicInteger pendingWrites = new AtomicInteger(0);
         
         TerminalWriter(boolean isError)

--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -31,6 +31,7 @@ import bluej.debugger.DebuggerField;
 import bluej.debugger.DebuggerObject;
 import bluej.debugger.DebuggerTerminal;
 import bluej.debugmgr.ExecutionEvent;
+import bluej.debugmgr.ExecutionEvent.Result;
 import bluej.editor.base.LineDisplay;
 import bluej.editor.base.TextLine;
 import bluej.editor.base.TextLine.StyledSegment;
@@ -539,9 +540,9 @@ public final class Terminal
     {
         if (recordMethodCalls.get()) {
             String result = null;
-            String resultType = event.getResult();
+            Result resultType = event.getResult();
             
-            if (resultType == ExecutionEvent.NORMAL_EXIT) {
+            if (resultType == ExecutionEvent.Result.NORMAL_EXIT) {
                 DebuggerObject object = event.getResultObject();
                 if (object != null) {
                     if (event.getClassName() != null && event.getMethodName() == null) {
@@ -563,10 +564,10 @@ public final class Terminal
                     }
                 }
             }
-            else if (resultType == ExecutionEvent.EXCEPTION_EXIT) {
+            else if (resultType == ExecutionEvent.Result.EXCEPTION_EXIT) {
                 result = "    Exception occurred.";
             }
-            else if (resultType == ExecutionEvent.TERMINATED_EXIT) {
+            else if (resultType == ExecutionEvent.Result.TERMINATED_EXIT) {
                 result = "    VM terminated.";
             }
             

--- a/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
+++ b/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2021,2022,2023  Michael Kolling and John Rosenberg
+ Copyright (C) 2021,2022,2023,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
+++ b/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
@@ -79,6 +79,7 @@ public abstract class TerminalTextPane extends BaseEditorPane
     private final Tooltip tooltip = new Tooltip();
     private EditorPosition lastMousePos;
     
+    // A record holding a location in the terminal window.
     // The line may be negative in some circumstances (see Section, below).
     // In this case, column should be ignored.  If the column is Integer.MAX_VALUE
     // it means to take the whole line as included, no matter how long.
@@ -114,7 +115,7 @@ public abstract class TerminalTextPane extends BaseEditorPane
     }
     
     // Get the current end position of the content as an end position
-    // This is different to getCurStart() because if the content ends if a newline
+    // This is different to getCurStart() because if the content ends in a newline
     // (the last content is a blank line), we take the end position as being the end
     // of the previous line, not the start of the new line (if there's no content on that line)
     private TerminalPos getCurEnd()

--- a/tools.properties
+++ b/tools.properties
@@ -1,4 +1,4 @@
-wix_bin=C:/Program Files (x86)/WiX Toolset v3.10/bin
-mingw_root=C:/mingw64/mingw64
+mingw_root=
+wix_bin=
 # If not on your PATH, supply the fully qualified path here:
-ant_exe=S:/apache-ant-1.9.4/bin/ant.bat
+ant_exe=ant

--- a/tools.properties
+++ b/tools.properties
@@ -1,4 +1,4 @@
-mingw_root=
-wix_bin=
+wix_bin=C:/Program Files (x86)/WiX Toolset v3.10/bin
+mingw_root=C:/mingw64/mingw64
 # If not on your PATH, supply the fully qualified path here:
-ant_exe=ant
+ant_exe=S:/apache-ant-1.9.4/bin/ant.bat


### PR DESCRIPTION
This adds a change recently discussed in the meeting/on the Blueroom.  It borrows BlueJ's scope highlighting mechanism to add grey section markers around each bit of output in the terminal, showing which method call it is from.  It also adds a tooltip on hover, which tells you what the method call was.  Finally, it clears the stderr pane on each method call (Michael requested this).