### PR TITLE
Fix terminal display layout loop

### DIFF
--- a/bluej/src/main/java/bluej/editor/base/BackgroundItem.java
+++ b/bluej/src/main/java/bluej/editor/base/BackgroundItem.java
@@ -27,6 +27,8 @@ import javafx.scene.layout.Region;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
+import java.util.Arrays;
+
 /**
  * A background item on a TextLine, usually a scope background, but can also be
  * a marker for the current step line or a breakpoint line.
@@ -36,6 +38,7 @@ public class BackgroundItem extends Region
 {
     final double x;
     final double width;
+    private final BackgroundFill[] backgroundFills;
 
     /**
      * Create a background item with the given X position and width, and the given background fills.  This constructor sets the item to be unmanaged.
@@ -45,6 +48,17 @@ public class BackgroundItem extends Region
         this.x = x;
         this.width = width;
         setManaged(false);
+        this.backgroundFills = backgroundFills.clone();
         setBackground(new Background(backgroundFills));
+    }
+
+    /**
+     * Returns true if this background item is equivalent to the given parameter.
+     * This is like .equals() but I don't want to override that in case it messes
+     * with JavaFX (since we extend Region and go in the GUI).
+     */
+    public boolean sameAs(BackgroundItem o)
+    {
+        return o != null && x == o.x && width == o.width && Arrays.deepEquals(backgroundFills, o.backgroundFills);
     }
 }

--- a/bluej/src/main/java/bluej/editor/base/TextLine.java
+++ b/bluej/src/main/java/bluej/editor/base/TextLine.java
@@ -311,10 +311,27 @@ public class TextLine extends TextFlow
         errorUnderlineShape.setVisible(false);
     }
 
-    public void setScopeBackgrounds(Collection<BackgroundItem> nodes)
+    public void setScopeBackgrounds(List<BackgroundItem> nodes)
     {
         if (nodes == null)
             nodes = Collections.emptyList();
+
+        if (this.backgroundNodes.size() == nodes.size())
+        {
+            boolean anyChanged = false;
+            for (int i = 0; i < this.backgroundNodes.size(); i++)
+            {
+                if (!this.backgroundNodes.get(i).sameAs(nodes.get(i)))
+                {
+                    anyChanged = true;
+                    break;
+                }
+            }
+            // No need to change the JavaFX content and trigger a layout
+            // if the content is actually all equivalent:
+            if (!anyChanged)
+                return;
+        }
         
         this.backgroundNodes = new ArrayList<>(nodes);
         int selectionIndex = getChildren().indexOf(bracketMatchShape);

--- a/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
+++ b/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
@@ -376,6 +376,9 @@ public abstract class TerminalTextPane extends BaseEditorPane
         boolean reschedule = false;
         for (int i = 0; i < content.size(); i++)
         {
+            // Can't work it out for non visible lines:
+            if (!lineDisplay.isLineVisible(i))
+                break;
             for (Section s : currentSections)
             {
                 final double singleRadius = 5;


### PR DESCRIPTION
This fixes a bug I found in the recent terminal change, and adds an optimisation.

We were getting caught in a layout loop while trying to calculate backgrounds for terminal lines that were off-screen, which would cause a big slowdown.  I also realised we should not be trying to swap the backgrounds if they are the same, which will also reduce the number of layouts needed.