### PR TITLE
Behaviour change in deleting a joint frame with backspace

### DIFF
--- a/bluej/src/main/java/bluej/stride/framedjava/frames/TryFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/TryFrame.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2021,2023 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2021,2023,2024 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -140,9 +140,14 @@ public class TryFrame extends SandwichCanvasesFrame
             // "try" section
             text = " in the 'try' section,";
         }
+        else if(c == ((TryFrame)(c.getParent())).getTailCanvas())
+        {
+            // "finally" section
+            text = " in the 'finally' section,";
+        }
         else
         {
-            // "catch" section
+            // a "catch" section
             text = " in the 'catch' section with parameter " + catchVars.get(sectionIndex-1) + " of type " + catchTypes.get(sectionIndex-1) + ",";
         }
         text += " in a 'try-catch' frame,";

--- a/bluej/src/main/java/bluej/stride/framedjava/frames/TryFrame.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/TryFrame.java
@@ -140,7 +140,7 @@ public class TryFrame extends SandwichCanvasesFrame
             // "try" section
             text = " in the 'try' section,";
         }
-        else if(c == ((TryFrame)(c.getParent())).getTailCanvas())
+        else if(c == this.getTailCanvas())
         {
             // "finally" section
             text = " in the 'finally' section,";

--- a/bluej/src/main/java/bluej/stride/generic/FrameCursor.java
+++ b/bluej/src/main/java/bluej/stride/generic/FrameCursor.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2020,2021,2022 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2020,2021,2022,2024 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -402,11 +402,27 @@ public class FrameCursor implements RecallableFocus
                 Frame target = parentCanvas.getFrameBefore(FrameCursor.this);
                 if (target != null)
                 {
+                    final boolean isDeletingJointFrame = (target instanceof MultiCanvasFrame) && target.getCanvases().count() > 1;
                     editor.beginRecordingState(FrameCursor.this);
-                    FrameCursor cursorBeforeTarget = parentCanvas.getCursorBefore(target);
+                    FrameCursor cursorBeforeTarget = (isDeletingJointFrame) ? FrameCursor.this : parentCanvas.getCursorBefore(target);
                     editor.recordEdits(StrideEditReason.FLUSH);
-                    editor.showUndoDeleteBanner(target.calculateEffort());
-                    parentCanvas.removeBlock(target);
+                    final int deleteEffort;
+                    if(isDeletingJointFrame)
+                    {
+                        // In the case of backspace being hit below a "joint" frame (that is, a multicanvas frame with
+                        // more elements than only the root), we do not delete the complete frame but only remove the last joint.
+                        final FrameCanvas lastJointCanvas =  ((MultiCanvasFrame)target).getLastCanvas();
+                        deleteEffort = lastJointCanvas.getBlockContents().stream()
+                            .map((frame) -> frame.calculateEffort())
+                            .reduce(0, (subTotal, effort) -> subTotal + effort);
+                        ((MultiCanvasFrame)target).removeCanvas(lastJointCanvas);
+                    }
+                    else
+                    {
+                        deleteEffort = target.calculateEffort();
+                        parentCanvas.removeBlock(target);
+                    }           
+                    editor.showUndoDeleteBanner(deleteEffort);      
                     editor.recordEdits(StrideEditReason.DELETE_FRAMES_KEY_BKSP);
                     editor.modifiedFrame(target, false);
                     cursorBeforeTarget.requestFocus();

--- a/bluej/src/main/java/bluej/stride/generic/FrameCursor.java
+++ b/bluej/src/main/java/bluej/stride/generic/FrameCursor.java
@@ -413,8 +413,8 @@ public class FrameCursor implements RecallableFocus
                         // more elements than only the root), we do not delete the complete frame but only remove the last joint.
                         final FrameCanvas lastJointCanvas =  ((MultiCanvasFrame)target).getLastCanvas();
                         deleteEffort = lastJointCanvas.getBlockContents().stream()
-                            .map((frame) -> frame.calculateEffort())
-                            .reduce(0, (subTotal, effort) -> subTotal + effort);
+                            .mapToInt(frame -> frame.calculateEffort())
+                            .sum();
                         ((MultiCanvasFrame)target).removeCanvas(lastJointCanvas);
                     }
                     else


### PR DESCRIPTION
To match the change done in Strype, we change the behaviour of deleting a joint frame (multicanvas frame with more than the root) when hitting the backspace key and being below the structure. Instead of deleting the complete structure, we now delete the last joint frame of that structure.

This pull request also contains a fix in the location description for finally (of try frames) used for the accessibility.
