### PR TITLE
Small BlueJ bug fixes

### DIFF
--- a/bluej/package/build.xml
+++ b/bluej/package/build.xml
@@ -31,6 +31,7 @@
 
     <patternset id="bluej.libdirs">
         <exclude name="**/.#*" />
+        <include name="lib/buildid.txt" />
         <include name="lib/images/*.gif" />
         <include name="lib/images/*.png" />
         <include name="lib/images/*.jpg" />

--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -24,11 +24,13 @@
         <include name="lib/greenfoot.defs" />
         <include name="lib/moe.defs" />
         <include name="lib/userlib/README.TXT" />
+        <include name="lib/buildid.txt" />
         <include name="lib/windowtofront.js" />
     </patternset>
 
     <patternset id="bluej.libdirs">
         <exclude name="**/.#*" />
+        <include name="lib/buildid.txt" />
         <include name="lib/images/*.gif" />
         <include name="lib/images/*.png" />
         <include name="lib/images/*.jpg" />

--- a/bluej/src/main/java/bluej/parser/ParseUtils.java
+++ b/bluej/src/main/java/bluej/parser/ParseUtils.java
@@ -39,6 +39,7 @@ import bluej.parser.symtab.ClassInfo;
 import bluej.pkgmgr.Package;
 import bluej.pkgmgr.target.role.Kind;
 import bluej.stride.framedjava.frames.LocalCompletion;
+import bluej.utility.Debug;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 import bluej.debugger.gentype.FieldReflective;
@@ -130,10 +131,20 @@ public class ParseUtils
                     for(File innerClassFile : ct.getInnerClassFiles())
                     {
                         Class<?> c = pkg.getProject().loadClass(innerClassFile.getName().replaceFirst("\\.class$",""));
-                        // If simple name is empty, it's an anonymous class, so we don't want code completions for those:
-                        if (c != null && !c.getSimpleName().isEmpty())
+                        try
                         {
-                           nestedTypes.add(new AssistContentThreadSafe(new ImportedTypeCompletion(c, pkg.getProject().getJavadocResolver())));
+                            // If simple name is empty, it's an anonymous class, so we don't want code completions for those:
+                            if (c != null && !c.getSimpleName().isEmpty())
+                            {
+                                nestedTypes.add(new AssistContentThreadSafe(new ImportedTypeCompletion(c, pkg.getProject().getJavadocResolver())));
+                            }
+                        }
+                        catch (Throwable t)
+                        {
+                            // It is possible that getSimpleName throws an error (which inherits from Throwable, not Exception)
+                            // so we must guard against that.  We don't need to do anything, we just won't add it as a completion.
+                            // We may as well log the error, though:
+                            Debug.reportError(t);
                         }
                     }
                 }

--- a/bluej/src/main/java/bluej/pkgmgr/Package.java
+++ b/bluej/src/main/java/bluej/pkgmgr/Package.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2023 Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2023,2024 Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -2732,8 +2732,15 @@ public final class Package
                 {
                     targetsToAnalyse.add(t);
                 }
-                else
+                else if (!successful)
                 {
+                    // Note: it's important to have the !successful check above.  Without this, we can
+                    // end up in this branch for empty .java files.  Empty files are a weird case because
+                    // they "compile" successfully (javac reports success) but they don't generate a .class file,
+                    // so our checks generally indicate they are not compiled.  Combined with the code below,
+                    // we used to end up in a loop of infinitely compiling them to see if they could be compiled
+                    // on their own, but they never actually end up in the compiled state because there's no class generated.
+                    
                     // To prevent an issue that may happen when classes are batched in one compile job
                     // and an error in one may prevent others being compiled even though they could be 
                     // compiled separately, we check for all the classes that can be compiled and have

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=3
 bluej_release=0
 bluej_suffix=
-bluej_rcnumber=1
+bluej_rcnumber=2
 
 greenfoot_major=3
 greenfoot_minor=8


### PR DESCRIPTION
Several separate bug fixes for BlueJ.  The main two are an issue (reported in the Blueroom) with old inner classes causing an uncaught exception, and the issue observed in Blackbox where empty files could be recompiled endlessly.