### PR TITLE
Fix a bug with the terminal tooltip causing the window to pop to the front if you mouse over it

### DIFF
--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -157,7 +157,8 @@ public final class Terminal
         this.project = project;
 
         buffer = new InputBuffer(65536);
-        text = new TerminalTextPane() {
+        window = new Stage();
+        text = new TerminalTextPane(window) {
             @Override
             public void focusPrevious()
             {
@@ -224,7 +225,6 @@ public final class Terminal
         mainPanel.setCenter(splitPane);
 
         mainPanel.setTop(makeMenuBar());
-        window = new Stage();
         window.setWidth(500);
         window.setHeight(500);
         BlueJTheme.setWindowIconFX(window);
@@ -764,7 +764,7 @@ public final class Terminal
         }
 
         if(errorText == null) {
-            errorText = new TerminalTextPane() {
+            errorText = new TerminalTextPane(window) {
                 @Override
                 public void focusPrevious()
                 {


### PR DESCRIPTION
During testing for BlueJ 5.3.0RC2 I noticed a weird behaviour where the terminal window would suddenly come to the front.  It took a while to work out the reason, but I happened across a tooltip bug report that explained that showing a tooltip in FX brings the window to the front.  So I've added some code that removes the tooltip when the window isn't focused to avoid this issue -- see also the long comment in the code.