### PR TITLE
Fix scope highlighting

### DIFF
--- a/bluej/src/main/java/bluej/editor/base/BackgroundItem.java
+++ b/bluej/src/main/java/bluej/editor/base/BackgroundItem.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2019,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 2019,2021,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -60,5 +60,13 @@ public class BackgroundItem extends Region
     public boolean sameAs(BackgroundItem o)
     {
         return o != null && x == o.x && width == o.width && Arrays.deepEquals(backgroundFills, o.backgroundFills);
+    }
+
+    /**
+     * Make an equivalent copy with the same properties
+     */
+    public BackgroundItem makeCopy()
+    {
+        return new BackgroundItem(x, width, backgroundFills.clone());
     }
 }

--- a/bluej/src/main/java/bluej/editor/base/TextLine.java
+++ b/bluej/src/main/java/bluej/editor/base/TextLine.java
@@ -28,6 +28,7 @@ import bluej.utility.javafx.ResizableRectangle;
 import com.google.common.collect.Lists;
 import javafx.beans.binding.StringExpression;
 import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.control.IndexRange;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.LineTo;
@@ -332,8 +333,18 @@ public class TextLine extends TextFlow
             if (!anyChanged)
                 return;
         }
-        
         this.backgroundNodes = new ArrayList<>(nodes);
+        // It is possible that some nodes will already be assigned to another line.
+        // For any nodes where that is the case, copy them:
+        for (int i = 0; i < this.backgroundNodes.size(); i++)
+        {
+            Parent curParent = this.backgroundNodes.get(i).getParent();
+            if (curParent != null && curParent != this)
+            {
+                this.backgroundNodes.set(i, this.backgroundNodes.get(i).makeCopy());
+            }
+        }
+
         int selectionIndex = getChildren().indexOf(bracketMatchShape);
         getChildren().remove(0, selectionIndex);
         getChildren().addAll(0, backgroundNodes);

--- a/bluej/src/main/java/bluej/editor/flow/JavaSyntaxView.java
+++ b/bluej/src/main/java/bluej/editor/flow/JavaSyntaxView.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2011,2014,2015,2016,2017,2018,2019,2020,2021,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2011,2014,2015,2016,2017,2018,2019,2020,2021,2022,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -1995,27 +1995,20 @@ public class JavaSyntaxView implements ReparseableDocument, LineDisplayListener
      * and thus the later items in the list overdraw the earlier ones.  Hence the earlier items in the list
      * are from the outermost scopes, and the latest items are the innermost scopes.
      */
-    private static class SingleNestedScope
-    {
-        private final ParsedNode lhsFrom;
+    private static record SingleNestedScope(
+        ParsedNode lhsFrom,
         // lhs and rhs are in pixels:
-        private final int lhs;
-        private final int rhs;
-        private final boolean starts;
-        private final boolean ends;
-        private final Color fillColor;
-        private final Color edgeColor;
+        int lhs,
+        int rhs,
+        boolean starts,
+        boolean ends,
+        Color fillColor,
+        Color edgeColor)
+    {
 
-        public SingleNestedScope(ParsedNode lhsFrom, int lhs, int rhs, boolean starts, boolean ends, Color fillColor, Color edgeColor)
+        public SingleNestedScope
         {
-            this.lhsFrom = lhsFrom;
-            lhs -= lhsFrom.isInner() ? LEFT_INNER_SCOPE_MARGIN : LEFT_OUTER_SCOPE_MARGIN;
-            this.lhs = Math.max(0, lhs);
-            this.rhs = rhs;
-            this.starts = starts;
-            this.ends = ends;
-            this.fillColor = fillColor;
-            this.edgeColor = edgeColor;
+            lhs = Math.max(0, lhs - (lhsFrom.isInner() ? LEFT_INNER_SCOPE_MARGIN : LEFT_OUTER_SCOPE_MARGIN));
         }
     }
 

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022,2023  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022,2023,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -263,12 +263,10 @@ public class ClassTarget extends DependentTarget
             }
         };
 
-        pane.setCenter(canvas);
-
         // We need to add label to the stack pane element
         // to be used later for visual indication that class lacks source
         noSourceLabel = new Label("");
-        StackPane stackPane = new StackPane(pane.getCenter(), noSourceLabel);
+        StackPane stackPane = new StackPane(canvas, noSourceLabel);
         StackPane.setAlignment(noSourceLabel, Pos.TOP_CENTER);
         StackPane.setAlignment(canvas, Pos.CENTER);
         pane.setCenter(stackPane);


### PR DESCRIPTION
Found the cause of Michael's scope highlighting bug.  From the commit: "Fixed a bug in the scope highlighting where we could try to set a scope box as a background item for two lines at once, which would result it being removed from the first line and added to the second.

We now detect this case and copy the box if we are trying to set it to a second place."

Plus two other small tidy-ups.