### PR TITLE
Fix IME entry in Stride

### DIFF
--- a/bluej/src/main/java/bluej/parser/TextParser.java
+++ b/bluej/src/main/java/bluej/parser/TextParser.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2019,2020,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2019,2020,2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -359,7 +359,7 @@ public class TextParser extends JavaParser
     }
 
     @OnThread(Tag.FXPlatform)
-    private strictfp void doCast()
+    private void doCast()
     {
         // Conversions allowed are specified in JLS 3rd ed. 5.5.
         // But see: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7029688
@@ -1012,7 +1012,7 @@ public class TextParser extends JavaParser
      * Process an operator which performs binary numeric promotion and which allows
      * the result to be a constant expression.
      */
-    private strictfp void doBnpOp(Operator op, ValueEntity arg1, ValueEntity arg2)
+    private void doBnpOp(Operator op, ValueEntity arg1, ValueEntity arg2)
     {
         JavaType a1type = arg1.getType();
         JavaType a2type = arg2.getType();

--- a/bluej/src/main/java/bluej/stride/framedjava/slots/StructuredSlot.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/slots/StructuredSlot.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2021,2024 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -554,7 +554,7 @@ public abstract class StructuredSlot<SLOT_FRAGMENT extends StructuredSlotFragmen
             topLevel.blank(token);
             if (!"".equals(text))
             {
-                topLevel.insert(topLevel.getFirstField(), 0, text);
+                topLevel.insert(topLevel.getFirstField(), 0, 0, text);
             }
         });
     }

--- a/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
+++ b/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
@@ -455,9 +455,11 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
                 return;
             }
 
-            // If this is the first part of a composed text, set imstart:
+            // If this is the first part of a composed text, set imstart,
+            // and delete any existing selection:
             if (imStart == -1)
             {
+                delegate.deleteSelection();
                 imStart = this.getCaretPosition();
             }
             // Work out the full composed text:

--- a/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
+++ b/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
@@ -22,20 +22,29 @@
 package bluej.utility.javafx;
 
 import java.util.List;
+
+import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
 import javafx.beans.binding.DoubleBinding;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.css.CssMetaData;
 import javafx.css.SimpleStyleableDoubleProperty;
 import javafx.css.Styleable;
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Scene;
 import javafx.scene.control.IndexRange;
 import javafx.scene.control.TextField;
+import javafx.scene.control.skin.TextFieldSkin;
 import javafx.scene.input.Clipboard;
+import javafx.scene.input.InputMethodEvent;
+import javafx.scene.input.InputMethodTextRun;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Region;
 
+import javafx.stage.Window;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
@@ -63,18 +72,40 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
 
     private final TextFieldDelegate<DELEGATE_IDENT> delegate;
     private final DELEGATE_IDENT delegateId;
+
+    // Keep track of InputMethod (IM) positions, e.g. for entering Chinese with
+    // the on-screen IME keyboard.  imStart is the start of the current sequence of
+    // "composing" characters that could end up staying as English or transformed into
+    // a related Chinese (or other language) string.  imLength is the length (starting at
+    // imStart) of this portion.  When there is no current IM entry, imStart is set to -1
+    // and imLength is set to 0.
+    private int imStart = -1;
+    private int imLength;
     
     @Override
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void insertText(int index, String text)
     {
+        nonIMEdit();
         delegate.insert(delegateId, index, index, text);
     }
-    
+
+    /**
+     * Called whenever the content of the field, or the position of the caret, has been changed
+     * by an action *other* than an InputMethodEvent.  So we need to call this method at the start of
+     * just about every other method in this class.
+     */
+    private void nonIMEdit()
+    {
+        imStart = -1;
+        imLength = 0;
+    }
+
     @Override
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public boolean deletePreviousChar()
     {
+        nonIMEdit();
         if (delegate.deleteSelection() || delegate.deletePrevious(delegateId, getCaretPosition(), getCaretPosition() == 0))
         {
             return true;
@@ -89,6 +120,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public boolean deleteNextChar()
     {
+        nonIMEdit();
         if (delegate.deleteSelection() ||
                 delegate.deleteNext(delegateId, getCaretPosition(), getCaretPosition() == getLength()))
         {
@@ -104,6 +136,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void previousWord()
     {
+        nonIMEdit();
         if (!delegate.previousWord(delegateId, getCaretPosition() == 0))
             super.previousWord();
     }
@@ -112,6 +145,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void nextWord()
     {
+        nonIMEdit();
         if (!delegate.nextWord(delegateId, getCaretPosition() == getLength()))
         {
             inNextWord = true;
@@ -124,6 +158,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void endOfNextWord()
     {
+        nonIMEdit();
         if (!delegate.endOfNextWord(delegateId, getCaretPosition() == getLength()))
         {
             super.endOfNextWord();
@@ -134,6 +169,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void backward()
     {
+        nonIMEdit();
         delegate.deselect();
         if (getCaretPosition() == 0)
         {
@@ -149,6 +185,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void cut()
     {
+        nonIMEdit();
         if (!delegate.cut())
             super.cut();
     }
@@ -165,6 +202,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void forward()
     {
+        nonIMEdit();
         delegate.deselect();
         if (getCaretPosition() == getText().length())
             delegate.forwardAtEnd(delegateId);
@@ -176,6 +214,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void appendText(String text)
     {
+        nonIMEdit();
         insertText(getText().length(), text);
     }
 
@@ -183,6 +222,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void replaceText(IndexRange range, String text)
     {
+        nonIMEdit();
         replaceText(range.getStart(), range.getEnd(), text);
     }
 
@@ -195,6 +235,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
         // We need to pass the range though, because if user is entering
         // foreign characters (e.g. Chinese) we may need to replace the
         // earlier QWERTY characters with the target character:
+        nonIMEdit();
         delegate.insert(delegateId, start, end, text);
 
     }
@@ -203,6 +244,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void deleteText(IndexRange range)
     {
+        nonIMEdit();
         super.deleteText(range.getStart(), range.getEnd());
     }
 
@@ -210,6 +252,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void deleteText(int start, int end)
     {
+        nonIMEdit();
         delegate.delete(delegateId, start, end);
         positionCaret(start);
     }
@@ -218,6 +261,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectBackward()
     {
+        nonIMEdit();
         if (!delegate.selectBackward(delegateId, getCaretPosition())) {
             super.selectBackward();
         }
@@ -226,6 +270,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @Override
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void deselect() {
+        nonIMEdit();
         delegate.deselect();
         super.deselect();
     }
@@ -234,6 +279,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectForward()
     {
+        nonIMEdit();
         if (!delegate.selectForward(delegateId, getCaretPosition(), getCaretPosition() == getLength()))
             super.selectForward();
     }
@@ -243,6 +289,68 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
         super(content);
         this.delegate = delegate;
         this.delegateId = ident;
+        // Important to set this before the skin gets set, as this prevents the skin setting the default handler:
+        setOnInputMethodTextChanged(this::handleInputMethodEvent);
+        // This implementation has been copied from TextInputControlSkin but it's important
+        // to copy it because it uses our imStart/imLength fields.
+        setInputMethodRequests(new ExtendedInputMethodRequests() {
+            @Override public Point2D getTextLocation(int offset) {
+                Scene scene = getScene();
+                Window window = scene != null ? scene.getWindow() : null;
+                if (window == null) {
+                    return new Point2D(0, 0);
+                }
+                // Don't use imstart here because it isn't initialized yet.
+                Rectangle2D characterBounds = ((TextFieldSkin)getSkin()).getCharacterBounds(getSelection().getStart() + offset);
+                Point2D p = localToScene(characterBounds.getMinX(), characterBounds.getMaxY());
+                Point2D location = new Point2D(window.getX() + scene.getX() + p.getX(),
+                        window.getY() + scene.getY() + p.getY());
+                return location;
+            }
+
+            @Override public int getLocationOffset(int x, int y) {
+                return 0;
+            }
+
+            @Override public void cancelLatestCommittedText() {
+                nonIMEdit();
+            }
+
+            @Override public String getSelectedText() {
+                IndexRange selection = getSelection();
+                return getText(selection.getStart(), selection.getEnd());
+            }
+
+            @Override public int getInsertPositionOffset() {
+                int caretPosition = getCaretPosition();
+                if (caretPosition < imStart) {
+                    return caretPosition;
+                } else if (caretPosition < imStart + imLength) {
+                    return imStart;
+                } else {
+                    return caretPosition - imLength;
+                }
+            }
+
+            @Override public String getCommittedText(int begin, int end) {
+                if (begin < imStart) {
+                    if (end <= imStart) {
+                        return getText(begin, end);
+                    } else {
+                        return getText(begin, imStart) + getText(imStart + imLength, end + imLength);
+                    }
+                } else {
+                    return getText(begin + imLength, end + imLength);
+                }
+            }
+
+            @Override public int getCommittedTextLength() {
+                return getText().length() - imLength;
+            }
+        });
+
+
+
         JavaFXUtil.addStyleClass(this, "delegable-scalable-text-field");
         setMinWidth(Region.USE_PREF_SIZE);
         prefWidthProperty().bind(new DoubleBinding() {
@@ -282,6 +390,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
         setOnMousePressed(e -> { 
             if (e.getButton() == MouseButton.PRIMARY && e.getClickCount() == 1) // Double and triple clicks will be handled by the field.
             {
+                nonIMEdit();
                 delegate.clicked();
                 delegate.moveTo(e.getSceneX(), e.getSceneY(), true);
                 e.consume();
@@ -291,6 +400,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
         setOnMouseDragged(e -> {
             if (e.getButton() == MouseButton.PRIMARY)
             {
+                nonIMEdit();
                 delegate.selectTo(e.getSceneX(), e.getSceneY());
                 e.consume();
             }
@@ -298,6 +408,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
         setOnMouseReleased(e -> {
             if (e.getButton() == MouseButton.PRIMARY)
             {
+                nonIMEdit();
                 delegate.selected();
                 e.consume();
             }
@@ -319,11 +430,54 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
         addEventHandler(KeyEvent.KEY_PRESSED, e -> { if (e.getCode() == KeyCode.ESCAPE) delegate.escape(); });
         
     }
+
+    @OnThread(Tag.FXPlatform)
+    private void handleInputMethodEvent(InputMethodEvent event) {
+        // This is adapted from the default handler in TextInputControlSkin.  That handler
+        // uses selection to keep track of some things.  We keep track manually here but
+        // there is not currently a visual representation of the highlight.
+
+        // Check we're in an editable state:
+        if (this.isEditable() && !this.textProperty().isBound() && !this.isDisabled()) {
+
+            // Committed text is the final bit that the user might select from the on-screen IME keyboard,
+            // or the plain English bit by pressing a key.
+            // Insert committed text
+            if (event.getCommitted().length() != 0) {
+                final int start = imStart;
+                final int end = imStart + imLength;
+                // Must call super so we don't do any extra Stride processing:
+                super.replaceText(start, end, event.getCommitted());
+                // Set imstart and imlength back to having no selection:
+                imStart = -1;
+                imLength = 0;
+                // I don't think committed and composed can both be there in one event, so return:
+                return;
+            }
+
+            // If this is the first part of a composed text, set imstart:
+            if (imStart == -1)
+            {
+                imStart = this.getCaretPosition();
+            }
+            // Work out the full composed text:
+            StringBuilder composed = new StringBuilder();
+            for (InputMethodTextRun run : event.getComposed()) {
+                composed.append(run.getText());
+            }
+            // Replace the IM section with the latest text:
+            // Must call super so we don't do any extra Stride processing:
+            super.replaceText(imStart, imStart + imLength, composed.toString());
+            // Update imlength to the new composed length:
+            imLength = composed.length();
+        }
+    }
     
     @Override
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectNextWord()
     {
+        nonIMEdit();
         if (!delegate.selectNextWord(delegateId))
             super.selectNextWord();
     }
@@ -332,6 +486,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectEndOfNextWord()
     {
+        nonIMEdit();
         if (!delegate.selectNextWord(delegateId))
             super.selectEndOfNextWord();
     }
@@ -340,6 +495,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectPreviousWord()
     {
+        nonIMEdit();
         if (!delegate.selectPreviousWord(delegateId))
             super.selectPreviousWord();
     }
@@ -348,6 +504,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectAll()
     {
+        nonIMEdit();
         if (!delegate.selectAll(delegateId))
             super.selectAll();
     }
@@ -356,6 +513,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void home()
     {
+        nonIMEdit();
         delegate.deselect();
         if (!delegate.home(delegateId))
             super.home();
@@ -365,6 +523,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void end()
     {
+        nonIMEdit();
         delegate.deselect();
         if (!delegate.end(delegateId, inNextWord))
             super.end();
@@ -374,6 +533,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectHome()
     {
+        nonIMEdit();
         if (!delegate.selectHome(delegateId, getCaretPosition()))
             super.selectHome();
     }
@@ -382,6 +542,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void selectEnd()
     {
+        nonIMEdit();
         if (!delegate.selectEnd(delegateId, getCaretPosition()))
             super.selectEnd();
     }
@@ -393,6 +554,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
         Clipboard clipboard = Clipboard.getSystemClipboard();
         if (clipboard.hasString())
         {
+            nonIMEdit();
             delegate.deleteSelection();
             insertText(getCaretPosition(), clipboard.getString());
         }

--- a/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
+++ b/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
@@ -73,12 +73,14 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     private final TextFieldDelegate<DELEGATE_IDENT> delegate;
     private final DELEGATE_IDENT delegateId;
 
-    // Keep track of InputMethod (IM) positions, e.g. for entering Chinese with
-    // the on-screen IME keyboard.  imStart is the start of the current sequence of
+    // Keep track of InputMethod (IM) character positions within this field,
+    // e.g. for entering Chinese with the on-screen IME keyboard.
+    // imStart is the start of the current sequence within this field of
     // "composing" characters that could end up staying as English or transformed into
     // a related Chinese (or other language) string.  imLength is the length (starting at
     // imStart) of this portion.  When there is no current IM entry, imStart is set to -1
-    // and imLength is set to 0.
+    // and imLength is set to 0.  These are constrained to this field; they cannot extend
+    // outside the field or across fields.
     private int imStart = -1;
     private int imLength;
     

--- a/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
+++ b/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2018 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2018,2024 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -39,7 +39,7 @@ import javafx.scene.layout.Region;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
-public class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHeightTextField
+public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHeightTextField
 {
     private final SimpleStyleableDoubleProperty bjMinWidthProperty = new SimpleStyleableDoubleProperty(BJ_MIN_WIDTH_META_DATA);
     /**
@@ -68,7 +68,7 @@ public class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHeightTe
     @OnThread(value = Tag.FXPlatform, ignoreParent = true)
     public void insertText(int index, String text)
     {
-        delegate.insert(delegateId, index, text);
+        delegate.insert(delegateId, index, index, text);
     }
     
     @Override
@@ -192,7 +192,11 @@ public class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHeightTe
     {
         // Do not delete, we'll handle case there is a selection:
         //deleteText(start, end);
-        insertText(start, text);
+        // We need to pass the range though, because if user is entering
+        // foreign characters (e.g. Chinese) we may need to replace the
+        // earlier QWERTY characters with the target character:
+        delegate.insert(delegateId, start, end, text);
+
     }
 
     @Override

--- a/bluej/src/main/java/bluej/utility/javafx/TextFieldDelegate.java
+++ b/bluej/src/main/java/bluej/utility/javafx/TextFieldDelegate.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2018 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2018,2024 Michael Kölling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -27,7 +27,22 @@ import threadchecker.Tag;
 @OnThread(Tag.FXPlatform)
 public interface TextFieldDelegate<IDENTIFIER>
 {
-    void insert(IDENTIFIER id, int index, String text);
+    /**
+     * Note that there are really two cases for index and end:
+     *  1. index==end; the insertion is just a character typed at the cursor
+     *  2. index and end are different; this does NOT relate to selection
+     *     because we track selection ourselves so there should never be a selection
+     *     in the field according to JavaFX.  Thus they are only different when
+     *     we are replacing characters as part of foreign character entry,
+     *     e.g. in Chinese replacing QWERTY characters with the destination
+     *     Chinese character.
+     *
+     * @param id The identifier of the field
+     * @param index One end of the position of the text to replace with the insertion
+     * @param end The other end of the position of the text to replace with the insertion
+     * @param text The text  to insert
+     */
+    void insert(IDENTIFIER id, int index, int end, String text);
 
     // This will be called speculatively by deletePrevious and deleteNext, in case
     // there is a selection.  It should return false if there is no selection (but not give an exception)


### PR DESCRIPTION
We discovered that IME wasn't working in Stride, because we process edit events differently there, and it was interfering with how IME works.  This change handles IME events ourselves so that we can separate it from all of Stride's unique processing of edits.

Fixes #2335 