### PR TITLE
Fix issues with Terminal scope display

### DIFF
--- a/bluej/lib/english/labels
+++ b/bluej/lib/english/labels
@@ -140,6 +140,8 @@ prefmgr.interface.language.restart=You will need to restart $APPNAME for the lan
 prefmgr.interface.text.restart=You will need to restart $APPNAME for the setting to take effect.
 prefmgr.accessibility.title=Accessibility
 prefmgr.accessibility.support=Accessibility Mode [only for use with screen readers]
+prefmgr.terminal.title=Terminal
+prefmgr.terminal.scopes=Show Terminal execution scopes
 
 # Extensions Manager Help panel
 extmgr.title=BlueJ:  Installed Extensions

--- a/bluej/src/main/java/bluej/prefmgr/InterfacePanel.java
+++ b/bluej/src/main/java/bluej/prefmgr/InterfacePanel.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2012,2013,2014,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 2012,2013,2014,2016,2019,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -50,7 +50,9 @@ public class InterfacePanel extends VBox
 {
     private ArrayList<String> allLangsInternal;
     private ComboBox langDropdown;
-    
+
+    private CheckBox terminalScopes;
+
     private CheckBox accessibility;
     
     private CheckBox toggleTestNewsMode;
@@ -108,8 +110,11 @@ public class InterfacePanel extends VBox
             Label t = new Label(Config.getString("prefmgr.interface.language.restart"));
             langPanel.add(t);
         }
-        getChildren().add(PrefMgrDialog.headedVBox("prefmgr.interface.language.title", langPanel));        
-        
+        getChildren().add(PrefMgrDialog.headedVBox("prefmgr.interface.language.title", langPanel));
+
+        terminalScopes = new CheckBox(Config.getString("prefmgr.terminal.scopes"));
+        getChildren().add(PrefMgrDialog.headedVBox("prefmgr.terminal.title", Arrays.asList(terminalScopes)));
+
         accessibility = new CheckBox(Config.getString("prefmgr.accessibility.support"));
         getChildren().add(PrefMgrDialog.headedVBox("prefmgr.accessibility.title", Arrays.asList(accessibility)));
         
@@ -134,6 +139,8 @@ public class InterfacePanel extends VBox
             curLangIndex = 0;
         }
         langDropdown.getSelectionModel().select(curLangIndex);
+
+        terminalScopes.setSelected(PrefMgr.getFlag(PrefMgr.SHOW_TERMINAL_SCOPES));
         
         accessibility.setSelected(PrefMgr.getFlag(PrefMgr.ACCESSIBILITY_SUPPORT));
         
@@ -149,7 +156,11 @@ public class InterfacePanel extends VBox
     public void commitEditing(Project project)
     {
         Config.putPropString("bluej.language", allLangsInternal.get(langDropdown.getSelectionModel().getSelectedIndex()));
-        
+
+        PrefMgr.setFlag(PrefMgr.SHOW_TERMINAL_SCOPES, terminalScopes.isSelected());
+        // Re-render the terminal in case things changed:
+        project.getTerminal().rerenderStdout();
+
         PrefMgr.setFlag(PrefMgr.ACCESSIBILITY_SUPPORT, accessibility.isSelected());
 
         // Only counts as selected if selected and visible:

--- a/bluej/src/main/java/bluej/prefmgr/PrefMgr.java
+++ b/bluej/src/main/java/bluej/prefmgr/PrefMgr.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2023  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2023,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -67,6 +67,7 @@ public class PrefMgr
     public static final String SHOW_UNCHECKED = "bluej.compiler.showunchecked";
     public static final String SCOPE_HIGHLIGHTING_STRENGTH = "bluej.editor.scopeHilightingStrength";
     public static final String NAVIVIEW_EXPANDED="bluej.naviviewExpanded.default";
+    public static final String SHOW_TERMINAL_SCOPES = "bluej.terminal.showScopes";
     public static final String ACCESSIBILITY_SUPPORT = "bluej.accessibility.support";
     public static final String NEWS_TESTING = "bluej.news.testing";
     public static final String START_WITH_SUDO = "bluej.startWithSudo";
@@ -443,6 +444,7 @@ public class PrefMgr
         flags.put(SHOW_TEAM_TOOLS, Config.getPropString(SHOW_TEAM_TOOLS, "false"));
         flags.put(SHOW_TEXT_EVAL, Config.getPropString(SHOW_TEXT_EVAL, "false"));
         flags.put(SHOW_UNCHECKED, Config.getPropString(SHOW_UNCHECKED, "true"));
+        flags.put(SHOW_TERMINAL_SCOPES, Config.getPropString(SHOW_TERMINAL_SCOPES, "true"));
         flags.put(ACCESSIBILITY_SUPPORT, Config.getPropString(ACCESSIBILITY_SUPPORT, "false"));
         flags.put(START_WITH_SUDO, Config.getPropString(START_WITH_SUDO, "true"));
         flags.put(STRIDE_SIDEBAR_SHOWING, Config.getPropString(STRIDE_SIDEBAR_SHOWING, "true"));

--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -436,6 +436,12 @@ public final class Terminal
         }
     }
 
+    // Rerenders the stdout pane.
+    public void rerenderStdout()
+    {
+        text.updateRender(false);
+    }
+
     enum PaneType { STDOUT, STDERR }
 
     /**

--- a/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
+++ b/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
@@ -28,6 +28,7 @@ import bluej.editor.base.EditorPosition;
 import bluej.editor.base.TextLine.StyledSegment;
 import bluej.prefmgr.PrefMgr;
 import bluej.utility.Debug;
+import bluej.utility.Utility;
 import bluej.utility.javafx.FXPlatformRunnable;
 import bluej.utility.javafx.JavaFXUtil;
 import com.google.common.collect.ImmutableList;
@@ -38,6 +39,9 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.DataFormat;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
@@ -46,6 +50,9 @@ import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
+import org.fxmisc.wellbehaved.event.EventPattern;
+import org.fxmisc.wellbehaved.event.InputMap;
+import org.fxmisc.wellbehaved.event.Nodes;
 
 import javax.tools.Tool;
 import java.util.ArrayList;
@@ -199,6 +206,13 @@ public abstract class TerminalTextPane extends BaseEditorPane
         });
         // Set the content to be empty on construction:
         clear();
+
+        // Add shortcuts to allow changing font size:
+        Nodes.addInputMap(this, InputMap.sequence(
+                InputMap.consume(EventPattern.keyPressed(new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.SHORTCUT_DOWN)), e -> Utility.increaseFontSize(PrefMgr.getEditorFontSize())),
+                InputMap.consume(EventPattern.keyPressed(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN)), e -> Utility.decreaseFontSize(PrefMgr.getEditorFontSize())),
+                InputMap.consume(EventPattern.keyPressed(new KeyCodeCombination(KeyCode.DIGIT0, KeyCombination.SHORTCUT_DOWN)), e -> PrefMgr.getEditorFontSize().set(PrefMgr.DEFAULT_JAVA_FONT_SIZE))
+        ));
     }
 
     @Override

--- a/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
+++ b/bluej/src/main/java/bluej/terminal/TerminalTextPane.java
@@ -213,6 +213,10 @@ public abstract class TerminalTextPane extends BaseEditorPane
                 InputMap.consume(EventPattern.keyPressed(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN)), e -> Utility.decreaseFontSize(PrefMgr.getEditorFontSize())),
                 InputMap.consume(EventPattern.keyPressed(new KeyCodeCombination(KeyCode.DIGIT0, KeyCombination.SHORTCUT_DOWN)), e -> PrefMgr.getEditorFontSize().set(PrefMgr.DEFAULT_JAVA_FONT_SIZE))
         ));
+
+        JavaFXUtil.addChangeListenerPlatform(PrefMgr.getEditorFontSize(), s -> {
+            lineDisplay.fontSizeChanged();
+        });
     }
 
     @Override


### PR DESCRIPTION
As discussed in the meeting:
 - Remove the pop-up that tells you where the terminal output came from (too invasive)
 - Allow turning the terminal scope highlighting on/off in the preferences window (and save this setting)
 - Fix the terminal to re-render properly when font size is changed
 - Allow pressing ctrl/cmd-{+,-,0} to change the font size when focus is in the terminal output panes (found this wasn't working, while doing the others)