### PR TITLE
Fix world save

### DIFF
--- a/greenfoot/build.gradle
+++ b/greenfoot/build.gradle
@@ -112,7 +112,7 @@ assemble.dependsOn copyToLib
 
 task runGreenfoot(type: JavaExec) {
     group = 'application'
-    classpath = files('build/resources/main/lib/boot.jar') + sourceSets.main.runtimeClasspath.filter { it.name.startsWith("javafx") }
+    classpath = files('build/resources/main/lib/boot.jar') + sourceSets.main.runtimeClasspath + files('build/resources/main/lib/greenfoot.jar')
     main = "bluej.Boot"
     args "-bluej.debug=true", "-greenfoot=true"
     

--- a/greenfoot/src/main/java/greenfoot/core/WorldHandler.java
+++ b/greenfoot/src/main/java/greenfoot/core/WorldHandler.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2010,2011,2012,2013,2014,2015,2016,2018  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2010,2011,2012,2013,2014,2015,2016,2018,2024  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -640,7 +640,7 @@ public class WorldHandler
      * Completes the current drag if it is the given drag ID
      */
     @OnThread(Tag.Any)
-    public void finishDrag(int dragId)
+    public void finishDrag(int dragId, int ax, int ay)
     {
         Simulation.getInstance().runLater(() -> {
             // if the operation was cancelled, add the object back into the
@@ -652,8 +652,7 @@ public class WorldHandler
                     // This makes sure that a single (final) setLocation
                     // call is received by the actor when dragging ends.
                     // This matters if the actor has overridden setLocation
-                    int ax = ActorVisitor.getX(dragActor);
-                    int ay = ActorVisitor.getY(dragActor);
+
                     // First we set the position to be the pre-drag position.
                     // This means that if the user overrides setLocation and
                     // chooses not to call the inherited setLocation, the position

--- a/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
@@ -1185,6 +1185,11 @@ public class GreenfootStage extends Stage implements FXCompileObserver,
                     {
                         DialogManager.showErrorFX(this, "cannot-save-world");
                     }
+                    else
+                    {
+                        this.project.scheduleCompilation(true, CompileReason.USER,
+                                CompileType.INDIRECT_USER_COMPILE, this.project.getUnnamedPackage());
+                    }
                 }, null),
                 JavaFXUtil.makeMenuItem(Config.getString("menu.tools.recompileAll"), () -> project.getUnnamedPackage().rebuild(), null),
                 JavaFXUtil.makeMenuItem("menu.tools.generateDoc",new KeyCodeCombination(KeyCode.G, KeyCombination.SHORTCUT_DOWN),
@@ -1884,6 +1889,11 @@ public class GreenfootStage extends Stage implements FXCompileObserver,
                             if (!saveTheWorldRecorder.writeCode(className -> ((ClassTarget) target).getEditor()))
                             {
                                 DialogManager.showErrorFX(this, "cannot-save-world");
+                            }
+                            else
+                            {
+                                this.project.scheduleCompilation(true, CompileReason.USER,
+                                        CompileType.INDIRECT_USER_COMPILE, this.project.getUnnamedPackage());
                             }
                         });
                         contextMenu.getItems().add(saveTheWorld);

--- a/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
@@ -1621,9 +1621,9 @@ public class GreenfootStage extends Stage implements FXCompileObserver,
                 // Finish any current drag:
                 if (curDragRequest != -1)
                 {
-                    debugHandler.getVmComms().endDrag(curDragRequest);
-                    curDragRequest = -1;
                     Point2D cellPos = pixelToCellCoordinates(worldPos);
+                    debugHandler.getVmComms().endDrag(curDragRequest, (int)cellPos.getX(), (int)cellPos.getY());
+                    curDragRequest = -1;
                     saveTheWorldRecorder.moveActor(draggedActor, (int)cellPos.getX(), (int)cellPos.getY());
                 }
             }

--- a/greenfoot/src/main/java/greenfoot/vmcomm/VMCommsMain.java
+++ b/greenfoot/src/main/java/greenfoot/vmcomm/VMCommsMain.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2018,2021 Poul Henriksen and Michael Kolling 
+ Copyright (C) 2018,2021,2024 Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -575,9 +575,9 @@ public class VMCommsMain implements Closeable
     /**
      * End a drag, identified by the given id.
      */
-    public synchronized void endDrag(int dragId)
+    public synchronized void endDrag(int dragId, int cellX, int cellY)
     {
-        pendingCommands.add(new Command(COMMAND_END_DRAG, dragId));
+        pendingCommands.add(new Command(COMMAND_END_DRAG, dragId, cellX, cellY));
     }
     
     /**

--- a/greenfoot/src/main/java/greenfoot/vmcomm/VMCommsSimulation.java
+++ b/greenfoot/src/main/java/greenfoot/vmcomm/VMCommsSimulation.java
@@ -540,7 +540,7 @@ public class VMCommsSimulation
                         WorldHandler.getInstance().continueDragging(data[1], data[2], data[3]);
                         break;
                     case Command.COMMAND_END_DRAG:
-                        // Will be drag-ID:
+                        // Will be drag-ID, cell X, cell Y:
                         WorldHandler.getInstance().finishDrag(data[1], data[2], data[3]);
                         break;
                     case Command.COMMAND_ANSWERED:

--- a/greenfoot/src/main/java/greenfoot/vmcomm/VMCommsSimulation.java
+++ b/greenfoot/src/main/java/greenfoot/vmcomm/VMCommsSimulation.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2005-2009,2010,2011,2012,2013,2014,2015,2016,2018,2019,2021  Poul Henriksen and Michael Kolling 
+ Copyright (C) 2005-2009,2010,2011,2012,2013,2014,2015,2016,2018,2019,2021,2024  Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -541,7 +541,7 @@ public class VMCommsSimulation
                         break;
                     case Command.COMMAND_END_DRAG:
                         // Will be drag-ID:
-                        WorldHandler.getInstance().finishDrag(data[1]);
+                        WorldHandler.getInstance().finishDrag(data[1], data[2], data[3]);
                         break;
                     case Command.COMMAND_ANSWERED:
                         // Store the codepoints we received:


### PR DESCRIPTION
As mentioned in the meeting, fixes two bugs:
 - Positions sometimes being a few pixels off when saving the world
 - Repeatedly saving the world causing an odd state until you defocused and focused the window.