### PR TITLE
Updated minimum installer version to Java 8

### DIFF
--- a/bluej/package/build.xml
+++ b/bluej/package/build.xml
@@ -184,8 +184,8 @@
                includes="Installer.java"
                debug="true"
         >
-            <compilerarg line="-source 7"/>
-            <compilerarg line="-target 7"/>
+            <compilerarg line="-source 8"/>
+            <compilerarg line="-target 8"/>
         </javac>
 
         <!-- bundle the resulting class into the final distribution jar file -->

--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -206,8 +206,8 @@
                includeantruntime="false"
                debug="true"
         >
-            <compilerarg line="-source 7" />
-            <compilerarg line="-target 7" />
+            <compilerarg line="-source 8" />
+            <compilerarg line="-target 8" />
         </javac>
 
         <!-- bundle the resulting class into the final distribution jar file -->


### PR DESCRIPTION
Java 7 is no longer supported as a target on JDK 21 (and 8 seems a reasonable baseline).