### PR TITLE
Fix existing switch parsing

### DIFF
--- a/bluej/src/main/java/bluej/parser/JavaParser.java
+++ b/bluej/src/main/java/bluej/parser/JavaParser.java
@@ -1139,8 +1139,8 @@ public class JavaParser extends JavaParserCallbacks
             case 10: // LITERAL_default
                 gotSwitchDefault();
                 token = nextToken();
-                if (token.getType() != JavaTokenTypes.COLON) {
-                    error("Expecting ':' at end of case expression");
+                if (token.getType() != JavaTokenTypes.COLON && token.getType() != JavaTokenTypes.LAMBDA) {
+                    error("Expecting ':' or '->' at end of case expression");
                     tokenStream.pushBack(token);
                     return null;
                 }

--- a/bluej/src/main/java/bluej/parser/JavaParser.java
+++ b/bluej/src/main/java/bluej/parser/JavaParser.java
@@ -2899,8 +2899,7 @@ public class JavaParser extends JavaParserCallbacks
             case 31: // LITERAL_switch
                 // Switch expression
                 parseSwitchExpression(token);
-                token = nextToken();
-                continue exprLoop;                
+                break;
             default:
                 tokenStream.pushBack(token);
                 error("Invalid expression token: " + token.getText());

--- a/bluej/src/test/java/bluej/parser/BasicParseTest.java
+++ b/bluej/src/test/java/bluej/parser/BasicParseTest.java
@@ -832,6 +832,27 @@ public class BasicParseTest
         assertFalse(info.isEnum());
     }
 
+    @Test
+    public void testNewSwitch1()
+    {
+        String aSrc =
+                """
+                class Foo
+                {
+                    {
+                        switch ("hi") {
+                            case "bye" -> System.out.println("Error");
+                            default -> System.out.println("Expected");
+                        }
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
 
     // Examples mostly from https://openjdk.org/jeps/409
     @Test

--- a/bluej/src/test/java/bluej/parser/BasicParseTest.java
+++ b/bluej/src/test/java/bluej/parser/BasicParseTest.java
@@ -853,6 +853,53 @@ public class BasicParseTest
         assertFalse(info.hadParseError());
     }
 
+    @Test
+    public void testSwitchExpression1()
+    {
+        String aSrc =
+                """
+                class Foo
+                {
+                    public int bar()
+                    {
+                        return switch ("hi") {
+                            case "bye" -> -1;
+                            default -> 0;
+                        };
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testSwitchExpression2()
+    {
+        String aSrc =
+                """
+                class Foo
+                {
+                    public int bar()
+                    {
+                        return switch ("hi") {
+                            case "bye" -> -1;
+                            default -> 0;
+                        } + switch ("bye") {
+                            case "hi" -> -1;
+                            default -> 0;
+                        };
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
 
     // Examples mostly from https://openjdk.org/jeps/409
     @Test


### PR DESCRIPTION
In looking at the parsing for the new Java 21 features, I discovered a couple of cases where the parser is not handling existing Java 17 features correctly, so this is a small change to fix those (which I'm sending first, to avoid getting confused with the support for the new features).