### PR TITLE
Add support for switch patterns

### DIFF
--- a/bluej/src/main/java/bluej/parser/JavaParser.java
+++ b/bluej/src/main/java/bluej/parser/JavaParser.java
@@ -1089,7 +1089,7 @@ public class JavaParser extends JavaParserCallbacks
                 return parseSwitchStatement(token);
             case 9: // LITERAL_case
             {
-                beginSwitchCase(token);
+                beginSwitchCase(tokenStream.LA(1));
                 boolean hadCommas = false;
                 // Special case: null, which can be followed by default:
                 if (tokenStream.LA(1).getType() == JavaTokenTypes.LITERAL_null)

--- a/bluej/src/main/java/bluej/parser/JavaParserCallbacks.java
+++ b/bluej/src/main/java/bluej/parser/JavaParserCallbacks.java
@@ -481,7 +481,11 @@ public class JavaParserCallbacks
     }
 
 
-    protected void gotSwitchCase() { }
+    protected void beginSwitchCase(LocatableToken token) { }
+
+    protected void gotSwitchCaseType(LocatableToken token, boolean isArrowSyntax) { }
+
+    protected void endSwitchCase(LocatableToken token, boolean wasArrowSyntax) { }
 
     protected void gotSwitchDefault() { }
 

--- a/bluej/src/main/java/bluej/parser/lexer/JavaLexer.java
+++ b/bluej/src/main/java/bluej/parser/lexer/JavaLexer.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2009,2010,2011,2012,2014,2016,2022  Michael Kolling and John Rosenberg 
+ Copyright (C) 2009,2010,2011,2012,2014,2016,2022,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -109,6 +109,7 @@ public final class JavaLexer implements TokenStream
         keywords.put("true", JavaTokenTypes.LITERAL_true);
         keywords.put("try", JavaTokenTypes.LITERAL_try);
         keywords.put("volatile", JavaTokenTypes.LITERAL_volatile);
+        keywords.put("when", JavaTokenTypes.LITERAL_when);
         keywords.put("while", JavaTokenTypes.LITERAL_while);
         keywords.put("void", JavaTokenTypes.LITERAL_void);
         keywords.put("yield", JavaTokenTypes.LITERAL_yield);

--- a/bluej/src/main/java/bluej/parser/lexer/JavaTokenTypes.java
+++ b/bluej/src/main/java/bluej/parser/lexer/JavaTokenTypes.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009, 2012,2014,2022  Michael Kolling and John Rosenberg 
+ Copyright (C) 1999-2009, 2012,2014,2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -145,7 +145,8 @@ public interface JavaTokenTypes
     int LITERAL_sealed = 177;
     int LITERAL_non_sealed = 178;
     int LITERAL_permits = 179;
+    int LITERAL_when = 180;
     
-    int INVALID = 180;
+    int INVALID = 181;
     
 }

--- a/bluej/src/main/java/bluej/stride/framedjava/convert/JavaStrideParser.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/convert/JavaStrideParser.java
@@ -1325,9 +1325,9 @@ public class JavaStrideParser extends JavaParser
     }
 
     @Override
-    protected void gotSwitchCase()
+    protected void beginSwitchCase(LocatableToken token)
     {
-        super.gotSwitchCase();
+        super.beginSwitchCase(token);
         withExpression(e -> switchHandlers.peek().gotCase(e));
     }
 

--- a/bluej/src/test/java/bluej/parser/BasicParseTest.java
+++ b/bluej/src/test/java/bluej/parser/BasicParseTest.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2011,2013,2014,2016,2019,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2011,2013,2014,2016,2019,2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -1120,5 +1120,243 @@ public class BasicParseTest
         ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
         assertNotNull(info);
         assertTrue(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof4()
+    {
+        String aSrc =
+                """
+                class A {
+                    static String formatterPatternSwitch(Object obj) {
+                        return switch (obj) {
+                            case Integer i -> String.format("int %d", i);
+                            case Long l    -> String.format("long %d", l);
+                            case Double d  -> String.format("double %f", d);
+                            case String s  -> String.format("String %s", s);
+                            default        -> obj.toString();
+                        };
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof5()
+    {
+        String aSrc =
+                """
+                class A {
+                    static void testFooBarNew(String s) {
+                        switch (s) {
+                            case null         -> System.out.println("Oops");
+                            case "Foo", "Bar" -> System.out.println("Great");
+                            default           -> System.out.println("Ok");
+                        }
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof6()
+    {
+        String aSrc =
+                """
+                class A {
+                    static void testStringOld(String response) {
+                        switch (response) {
+                            case null -> { }
+                            case String s -> {
+                                if (s.equalsIgnoreCase("YES"))
+                                    System.out.println("You got it");
+                                else if (s.equalsIgnoreCase("NO"))
+                                    System.out.println("Shame");
+                                else
+                                    System.out.println("Sorry?");
+                            }
+                        }
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof7()
+    {
+        String aSrc =
+                """
+                class A {
+                    static void testStringNew(String response) {
+                        switch (response) {
+                            case null -> { }
+                            case String s
+                            when s.equalsIgnoreCase("YES") -> {
+                                System.out.println("You got it");
+                            }
+                            case String s
+                            when s.equalsIgnoreCase("NO") -> {
+                                System.out.println("Shame");
+                            }
+                            case String s -> {
+                                System.out.println("Sorry?");
+                            }
+                        }
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof8()
+    {
+        String aSrc =
+                """
+                class A {
+                    static void testStringEnhanced(String response) {
+                        switch (response) {
+                            case null -> { }
+                            case "y", "Y" -> {
+                                System.out.println("You got it");
+                            }
+                            case "n", "N" -> {
+                                System.out.println("Shame");
+                            }
+                            case String s
+                            when s.equalsIgnoreCase("YES") -> {
+                                System.out.println("You got it");
+                            }
+                            case String s
+                            when s.equalsIgnoreCase("NO") -> {
+                                System.out.println("Shame");
+                            }
+                            case String s -> {
+                                System.out.println("Sorry?");
+                            }
+                        }
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof9()
+    {
+        String aSrc =
+                """
+                class A {
+                    static void exhaustiveSwitchWithBetterEnumSupport(CardClassification c) {
+                         switch (c) {
+                             case Suit.CLUBS -> {
+                                 System.out.println("It's clubs");
+                             }
+                             case Suit.DIAMONDS -> {
+                                 System.out.println("It's diamonds");
+                             }
+                             case Suit.HEARTS -> {
+                                 System.out.println("It's hearts");
+                             }
+                             case Suit.SPADES -> {
+                                 System.out.println("It's spades");
+                             }
+                             case Tarot t -> {
+                                 System.out.println("It's a tarot");
+                             }
+                         }
+                     }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof10()
+    {
+        String aSrc =
+                """
+                class A {
+                    void testScope4(Object obj) {
+                        switch (obj) {
+                            case String s:
+                                System.out.println("A string: " + s);  // s in scope here!
+                            default:
+                                System.out.println("Done");            // s not in scope here
+                        }
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof11()
+    {
+        String aSrc =
+                """
+                class A {
+                    void testScope4(Object obj) {
+                        switch (obj) {
+                            case String s ->
+                                System.out.println("A string: " + s);
+                            case null, default ->
+                                System.out.println("The rest (including null)");
+                        }
+                    }
+                }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
+    }
+
+    @Test
+    public void testPatternInstanceof12()
+    {
+        String aSrc =
+                """
+                 sealed interface I<T> permits A, B {}
+                 final class A<X> implements I<String> {}
+                 final class B<Y> implements I<Y> {}
+                 
+                 class Foo {
+                     static int testGenericSealedExhaustive(I<Integer> i) {
+                         return switch (i) {
+                             // Exhaustive as no A case possible!
+                             case B<Integer> bi -> 42;
+                         };
+                     }
+                 }
+                """;
+
+        ClassInfo info = InfoParser.parse(new StringReader(aSrc), new ClassLoaderResolver(getClass().getClassLoader()), null);
+        assertNotNull(info);
+        assertFalse(info.hadParseError());
     }
 }

--- a/bluej/src/test/java/bluej/parser/CompletionTest3.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest3.java
@@ -272,6 +272,81 @@ public class CompletionTest3
     }
 
     @Test
+    public void testSwitchInstanceofVar()
+    {
+        assertNamesAtA(List.of("String s"), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case String s ->
+                            {
+                                /*A*/
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchInstanceofVar2()
+    {
+        assertNamesAtA(List.of(), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case String s ->
+                            {
+                            }
+                            default -> { /*A*/ }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchInstanceofVar3()
+    {
+        assertNamesAtA(List.of(), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case String s ->
+                            {
+                            }
+                        }
+                        /*A*/
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchInstanceofVar4()
+    {
+        assertNamesAtA(List.of("String s"), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case String s when /*A*/ ->
+                            {
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
     public void testNoLocalsOnThisDot()
     {
         assertNamesAtA(List.of("int field1", "int field2", "Object field3"), List.of("param1", "var1", "var2", "var3"), """

--- a/bluej/src/test/java/bluej/parser/CompletionTest3.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest3.java
@@ -293,7 +293,7 @@ public class CompletionTest3
     @Test
     public void testSwitchInstanceofVar2()
     {
-        assertNamesAtA(List.of(), List.of(), """
+        assertNamesAtA(List.of(), List.of("s"), """
                 class Foo
                 {
                     void foo()
@@ -312,7 +312,7 @@ public class CompletionTest3
     @Test
     public void testSwitchInstanceofVar3()
     {
-        assertNamesAtA(List.of(), List.of(), """
+        assertNamesAtA(List.of(), List.of("s"), """
                 class Foo
                 {
                     void foo()
@@ -323,6 +323,26 @@ public class CompletionTest3
                             }
                         }
                         /*A*/
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchInstanceofVar5()
+    {
+        assertNamesAtA(List.of("Integer i"), List.of("s"), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case String s ->
+                            {
+                            }
+                            case Integer i -> { /*A*/ }
+                            default -> {}
+                        }
                     }
                 }
                 """);

--- a/bluej/src/test/java/bluej/parser/LexerTest.java
+++ b/bluej/src/test/java/bluej/parser/LexerTest.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2009,2010,2011,2012,2014,2016,2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2009,2010,2011,2012,2014,2016,2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -154,7 +154,7 @@ public class LexerTest extends junit.framework.TestCase
         assertTrue(token.getType() == JavaTokenTypes.EOF);
         
         // Control flow
-        ts = getLexerFor("try catch throw if while do else switch case break continue");
+        ts = getLexerFor("try catch throw if while do else switch case break continue default when");
         token = (LocatableToken) ts.nextToken();
         assertTrue(token.getType() == JavaTokenTypes.LITERAL_try);
         token = (LocatableToken) ts.nextToken();
@@ -177,6 +177,10 @@ public class LexerTest extends junit.framework.TestCase
         assertTrue(token.getType() == JavaTokenTypes.LITERAL_break);
         token = (LocatableToken) ts.nextToken();
         assertTrue(token.getType() == JavaTokenTypes.LITERAL_continue);
+        token = (LocatableToken) ts.nextToken();
+        assertTrue(token.getType() == JavaTokenTypes.LITERAL_default);
+        token = (LocatableToken) ts.nextToken();
+        assertTrue(token.getType() == JavaTokenTypes.LITERAL_when);
         token = (LocatableToken) ts.nextToken();
         assertTrue(token.getType() == JavaTokenTypes.EOF);
         

--- a/bluej/src/test/java/bluej/parser/SwitchExpressionTest.java
+++ b/bluej/src/test/java/bluej/parser/SwitchExpressionTest.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -162,7 +162,7 @@ public class SwitchExpressionTest
         ImmutableList<NodeTree.NodeAndPosition<ParsedNode>> switchBodyContent = ImmutableList.copyOf(switchBody.getNode().getChildren(switchBody.getPosition()));
 
         assertEquals(Arrays.asList(
-            "/*switch-inner*/", "MONDAY", "FRIDAY", "SUNDAY", "System.out.println(6)", "TUESDAY", "System.out.println(7)", "THURSDAY", "SATURDAY", "System.out.println(8)", "WEDNESDAY", "System.out.println(9)"
+            "/*switch-inner*/", "MONDAY, FRIDAY, SUNDAY -> System.out.println(6)", "TUESDAY                -> System.out.println(7)", "THURSDAY, SATURDAY     -> System.out.println(8)", "WEDNESDAY              -> System.out.println(9)"
         ), switchBodyContent.stream().map(nap -> p.nodeContent(nap).trim()).collect(Collectors.toList()));
 
     }
@@ -187,7 +187,7 @@ public class SwitchExpressionTest
         ImmutableList<NodeTree.NodeAndPosition<ParsedNode>> switchBodyContent = ImmutableList.copyOf(switchBody.getNode().getChildren(switchBody.getPosition()));
 
         assertEquals(Arrays.asList(
-            "/*switch-inner*/", "a", "{System.out.println(1);}", "e", "new Exception()", "f", "{return 2;}", "{if (true) return 7;}"
+            "/*switch-inner*/", "a -> {System.out.println(1);", "e -> throw new Exception()", "f -> {return 2;", "{if (true) return 7;}"
         ), switchBodyContent.stream().map(nap -> p.nodeContent(nap).trim()).collect(Collectors.toList()));
     }
 
@@ -227,7 +227,7 @@ public class SwitchExpressionTest
         ImmutableList<NodeTree.NodeAndPosition<ParsedNode>> switchBodyContent = ImmutableList.copyOf(switchBody.getNode().getChildren(switchBody.getPosition()));
         // Break and throw are ignored, only the expressions get put in the tree:
         assertEquals(Arrays.asList(
-            "/*switch-inner*/", "MONDAY", "FRIDAY", "SUNDAY", "6", "TUESDAY", "7", "THURSDAY", "SATURDAY", "8", "WEDNESDAY", "9", "new IllegalStateException(\"Invalid day: \" + day)"
+            "/*switch-inner*/", "MONDAY, FRIDAY, SUNDAY -> 6", "TUESDAY                -> 7", "THURSDAY, SATURDAY     -> 8", "WEDNESDAY              -> 9", "new IllegalStateException(\"Invalid day: \" + day)"
         ), switchBodyContent.stream().map(nap -> p.nodeContent(nap).trim()).collect(Collectors.toList()));
 
     }
@@ -264,7 +264,7 @@ public class SwitchExpressionTest
         ImmutableList<NodeTree.NodeAndPosition<ParsedNode>> switchBodyContent = ImmutableList.copyOf(switchBody.getNode().getChildren(switchBody.getPosition()));
         // Break and throw are ignored, only the expressions get put in the tree:
         assertEquals(Arrays.asList(
-            "/*switch-inner*/", "1", "\"one\"", "2", "\"two\"", "\"many\""
+            "/*switch-inner*/", "1 -> \"one\"", "2 -> \"two\"", "\"many\""
         ), switchBodyContent.stream().map(nap -> p.nodeContent(nap).trim()).collect(Collectors.toList()));
 
     }
@@ -304,7 +304,7 @@ public class SwitchExpressionTest
         ImmutableList<NodeTree.NodeAndPosition<ParsedNode>> switchBodyContent = ImmutableList.copyOf(switchBody.getNode().getChildren(switchBody.getPosition()));
         // Break and throw are ignored, only the expressions get put in the tree:
         assertEquals(Arrays.asList(
-            "/*switch-inner*/", "MONDAY", "0", "TUESDAY", "1",
+            "/*switch-inner*/", "MONDAY  -> 0", "TUESDAY -> 1",
 """
 {
         int k = day.toString().length();
@@ -390,7 +390,7 @@ public class SwitchExpressionTest
         ImmutableList<NodeTree.NodeAndPosition<ParsedNode>> switchBodyContent = ImmutableList.copyOf(switchBody.getNode().getChildren(switchBody.getPosition()));
 
         assertEquals(Arrays.asList(
-            "/*switch-inner*/", "a", "b -> c", "e", "f -> g -> h", "i -> j"
+            "/*switch-inner*/", "a -> b -> c", "e -> f -> g -> h", "i -> j"
         ), switchBodyContent.stream().map(nap -> p.nodeContent(nap).trim()).collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
This adds support for switch patterns, which were added in JEP 441: https://openjdk.org/jeps/441  A lot of the new tests (which take up the bulk of the code changes) are taken directly from there.  This adds support such that the parser can cope with the new syntax, as well as supporting autocomplete on the variables which are defined in these patterns.

It does not yet add support for record patterns (JEP 440) which I will look at next.