### PR TITLE
Add support for record patterns

### DIFF
--- a/bluej/src/main/java/bluej/parser/JavaParser.java
+++ b/bluej/src/main/java/bluej/parser/JavaParser.java
@@ -1117,31 +1117,37 @@ public class JavaParser extends JavaParserCallbacks
                 {
                     // Could be a pattern variable:
                     // A declaration of a variable?
-                    List<LocatableToken> tlist = new LinkedList<LocatableToken>();
-                    boolean isTypeSpec = parseTypeSpec(true, true, tlist);
-                    token = tokenStream.LA(1);
-                    pushBackAll(tlist);
-                    if (isTypeSpec && token.getType() == JavaTokenTypes.IDENT) {
-                        token = tlist.get(0);
-                        gotDeclBegin(token);
-                        parseVariableDeclarations(token, false);
-                        token = nextToken();
-                        if (token.getType() == JavaTokenTypes.LITERAL_when)
-                        {
-                            parseExpression(false, false);
+                    PatternParse pp = lookAheadParsePattern();
+                    switch (pp) {
+                        case PatternParse.TypeThenVariableName -> {
+                            gotDeclBegin(token);
+                            parseVariableDeclarations(token, false);
                             token = nextToken();
+                            if (token.getType() == JavaTokenTypes.LITERAL_when) {
+                                parseExpression(false, false);
+                                token = nextToken();
+                            }
                         }
-                    }
-                    else
-                    {
-                        // No (unbracketed) lambdas allowed in a case expression:
-                        parseExpression(false, false);
-                        token = nextToken();
-                        while (token.getType() == JavaTokenTypes.COMMA)
-                        {
+                        case PatternParse.RecordPattern -> {
+                            if (!parseRecordPattern(true))
+                            {
+                                return null;
+                            }
+                            token = nextToken();
+                            if (token.getType() == JavaTokenTypes.LITERAL_when) {
+                                parseExpression(false, false);
+                                token = nextToken();
+                            }
+                        }
+                        default -> {
+                            // No (unbracketed) lambdas allowed in a case expression:
                             parseExpression(false, false);
                             token = nextToken();
-                            hadCommas = true;
+                            while (token.getType() == JavaTokenTypes.COMMA) {
+                                parseExpression(false, false);
+                                token = nextToken();
+                                hadCommas = true;
+                            }
                         }
                     }
                 }
@@ -2127,6 +2133,56 @@ public class JavaParser extends JavaParserCallbacks
         }
         return true;
     }
+
+    private boolean parseRecordPattern(boolean outermost)
+    {
+        List<LocatableToken> typeSpecTokens = new LinkedList<LocatableToken>();
+        if (!parseTypeSpec(false, false, typeSpecTokens)) {
+            return false;
+        }
+        gotTypeSpec(typeSpecTokens);
+
+        LocatableToken token = nextToken();
+        if (!outermost && token.getType() == JavaTokenTypes.LBRACK)
+        {
+            // Square bracket, can be an array part of a type if not outermost
+            tokenStream.pushBack(token);
+            parseArrayDeclarators();
+        }
+        switch (token.getType())
+        {
+            case JavaTokenTypes.LPAREN -> {
+                // Now we process a nested pattern
+                token = nextToken();
+                if (token.getType() != JavaTokenTypes.RPAREN)
+                {
+                    tokenStream.pushBack(token);
+                    if (!parseRecordPattern(false))
+                        return false;
+                    token = nextToken();
+                    while (token.getType() == JavaTokenTypes.COMMA) {
+                        // Can have comma then another pattern:
+                        if (!parseRecordPattern(false))
+                            return false;
+                        token = nextToken();
+                    }
+                }
+
+                // Must now be closing bracket:
+                if (token.getType() != JavaTokenTypes.RPAREN)
+                {
+                    return false;
+                }
+            }
+
+            case JavaTokenTypes.IDENT -> {
+                // A variable name for a declaration
+
+            }
+        }
+
+        return true;
+    }
         
     /**
      * Parse a type specification. This includes class name(s) (Xyz.Abc), type arguments
@@ -2997,12 +3053,22 @@ public class JavaParser extends JavaParserCallbacks
                     break;
                 case 9: // LITERAL_instanceof
                     gotInstanceOfOperator(token);
-                    parseTypeSpec(true);
-                    if (tokenStream.LA(1).getType() == JavaTokenTypes.IDENT)
+                    switch (lookAheadParsePattern())
                     {
-                        // A pattern-matching instance of
-                        token = nextToken();
-                        gotInstanceOfVar(token);
+                        case PatternParse.TypeThenVariableName -> {
+                            parseTypeSpec(true);
+                            token = nextToken();
+                            gotInstanceOfVar(token);
+                        }
+                        case PatternParse.RecordPattern -> {
+                            parseRecordPattern(true);
+                        }
+                        case PatternParse.OnlyType -> {
+                            parseTypeSpec(true);
+                        }
+                        default -> {
+                            error("Expected type or pattern following instanceof");
+                        }
                     }
                     break;
                 case 10: // DOT
@@ -3111,6 +3177,56 @@ public class JavaParser extends JavaParserCallbacks
                     }
                 }
             }
+        }
+    }
+
+    // Java now has the notion of patterns, which can occur in instanceof:
+    //     if (obj instance String s) { }
+    // Or in case statements:
+    //     case String s -> { }
+    // In both cases they can be record patterns, with variables declared inside a nested structure:
+    //     case Rectangle(Point(int ax, int ay), Point b) -> {}
+    // The challenge with parsing them is that when you parse the type, you don't know
+    // in the instanceof cases if there will be a variable name following, and you don't know if
+    // the type could actually be a pattern until you hit the round bracket.  Also, in case statements
+    // it could actually be an expression instead.
+    // So when we parse there are multiple possible outcomes:
+    // - Just a type (valid for instanceof)
+    // - A type and then a variable name
+    // - A record pattern (including new variable names, but not followed by them)
+    // - None of the above (could be a parse error, but could be an expression that is valid for case)
+    private enum PatternParse
+    {
+        OnlyType,
+        TypeThenVariableName,
+        RecordPattern,
+        Other
+    }
+    // Looks ahead in token stream to estimate what kind of pattern follows (see comment and data type above)
+    // When it returns, the token stream will be in the same state as when the method is called; nothing
+    // is actually consumed or processed.  This is used for after "instanceof", and after "case".
+    // Note that a parse error still may occur (especially for record patterns) when parsing fully:
+    private PatternParse lookAheadParsePattern() {
+        List<LocatableToken> tlist = new LinkedList<LocatableToken>();
+        boolean isTypeSpec = parseTypeSpec(true, true, tlist);
+        LocatableToken laToken = tokenStream.LA(1);
+        pushBackAll(tlist);
+        if (isTypeSpec) {
+            return switch (laToken.getType()) {
+                case JavaTokenTypes.IDENT ->
+                    // A type then variable name e.g. String s or List<String> list
+                        PatternParse.TypeThenVariableName;
+                case JavaTokenTypes.LPAREN ->
+                    // A record pattern, e.g. Empty() or Point(int x, int y)
+                        PatternParse.RecordPattern;
+                default ->
+                    // Just a type, e.g. String or Integer:
+                        PatternParse.OnlyType;
+            };
+        }
+        else
+        {
+            return PatternParse.Other;
         }
     }
 

--- a/bluej/src/test/java/bluej/parser/CompletionTest2.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest2.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2022  Michael Kolling and John Rosenberg
+ Copyright (C) 2022,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -557,6 +557,35 @@ public class CompletionTest2
                     throw new Exception();
                 // s is in scope
                 System.out.println(s./*A*/length());
+            }
+        """));
+
+        // Test record patterns:
+        assertTypeAtA("java.lang.String", withLambdaDefs("""
+            public final boolean equals(Object o) {
+                return (o instanceof WrappedString(String s)) &&
+                    s./*A*/equalsIgnoreCase(this);
+            }
+        """));
+
+        assertTypeAtA("java.lang.String[][][]", withLambdaDefs("""
+            public final boolean equals(Object o) {
+                return (o instanceof WrappedString(String[][][] s)) &&
+                    s./*A*/equalsIgnoreCase(this);
+            }
+        """));
+
+        assertTypeAtA("java.lang.Object", withLambdaDefs("""
+            public final boolean equals(Object o) {
+                return (o instanceof WrappedString(String[][][] s, Object o)) &&
+                    !o./*A*/toString().isEmpty();
+            }
+        """));
+
+        assertTypeAtA("java.lang.Double[]", withLambdaDefs("""
+            public final boolean equals(Object o) {
+                return (o instanceof WrappedString(String[][][] s, Object o, Double[] d)) &&
+                    d./*A*/length() > 0;
             }
         """));
         

--- a/bluej/src/test/java/bluej/parser/CompletionTest3.java
+++ b/bluej/src/test/java/bluej/parser/CompletionTest3.java
@@ -367,6 +367,25 @@ public class CompletionTest3
     }
 
     @Test
+    public void testSwitchInstanceofVar6()
+    {
+        assertNamesAtA(List.of("String[][][] sss"), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case String[][][] sss ->
+                            {
+                                /*A*/
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
     public void testNoLocalsOnThisDot()
     {
         assertNamesAtA(List.of("int field1", "int field2", "Object field3"), List.of("param1", "var1", "var2", "var3"), """
@@ -480,6 +499,139 @@ public class CompletionTest3
                         String var3;
                         x/*A*/
                         myObj.toString();
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchRecordVar()
+    {
+        assertNamesAtA(List.of("String s"), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case WrappedString(String s) ->
+                            {
+                                /*A*/
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchRecordVar2()
+    {
+        assertNamesAtA(List.of(), List.of("s"), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case WrappedString(String s) ->
+                            {
+                            }
+                            default -> { /*A*/ }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchRecordVar3()
+    {
+        assertNamesAtA(List.of(), List.of("s"), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case WrappedString(String s) ->
+                            {
+                            }
+                        }
+                        /*A*/
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchRecordVar4()
+    {
+        assertNamesAtA(List.of("Integer i"), List.of("s"), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case WrappedString(String s) ->
+                            {
+                            }
+                            case WrappedInteger(Integer i) -> { /*A*/ }
+                            default -> {}
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchRecordVar5()
+    {
+        assertNamesAtA(List.of("String s"), List.of(), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case WrappedString(String s) when /*A*/ ->
+                            {
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchRecordVar6()
+    {
+        assertNamesAtA(List.of("String s", "Integer i", "Object o"), List.of("Grandparent", "Parent", "Child"), """
+                class Foo
+                {
+                    void foo()
+                    {
+                        switch ("hi") {
+                            case Grandparent(Parent(String s, Child(Integer i, Object o))) ->
+                            {
+                                /*A*/
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testSwitchRecordVar7()
+    {
+        assertNamesAtA(List.of("var a", "var b"), List.of("x", "y"), """
+                record Point(Integer x, Double y) 
+                {
+                    static void foo()
+                    {
+                        switch ("hi") {
+                            case Point(var a, var b) ->
+                            {
+                                /*A*/
+                            }
+                        }
                     }
                 }
                 """);

--- a/bluej/src/test/java/bluej/stride/framedjava/convert/JavaToStrideTest.java
+++ b/bluej/src/test/java/bluej/stride/framedjava/convert/JavaToStrideTest.java
@@ -587,7 +587,8 @@ public class JavaToStrideTest
 
     private static CaseElement genCase()
     {
-        return new CaseElement(null, genExpression(), some(() -> genStatement(2)), true);
+        // Case expressions can only be constants:
+        return new CaseElement(null, filled(oneOf("0", "\"hi\"", "'d'")), some(() -> genStatement(2)), true);
     }
 
     private static boolean rand()


### PR DESCRIPTION
This adds support for the new record patterns feature from JEP 440: https://openjdk.org/jeps/440

It includes both parsing it, and handling code completion on the variables that are declared.  A lot of the change is adding tests, which now all pass.