### PR TITLE
Fix Korean/IME input

### DIFF
--- a/bluej/lib/stylesheets/flow.css
+++ b/bluej/lib/stylesheets/flow.css
@@ -55,6 +55,12 @@
     -fx-stroke: null;
 }
 
+.text-line .flow-ime-input {
+    -fx-fill: hsb(180, 50%, 70%);
+    -fx-stroke: null;
+}
+
+
 .line-container {
     -fx-background-color: white;
 }

--- a/bluej/package/winlaunch/bjmanifest.xml
+++ b/bluej/package/winlaunch/bjmanifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <!-- Note: the following line is matched by a regex in the build file -->
-  <assemblyIdentity version="5.3.0.0"
+  <assemblyIdentity version="5.4.0.0"
      processorArchitecture="X86"
      name="BlueJ"
      type="win32"/> 

--- a/bluej/package/winlaunch/bluej-version.rc
+++ b/bluej/package/winlaunch/bluej-version.rc
@@ -1,5 +1,5 @@
-FILEVERSION 5,3,0,0
-PRODUCTVERSION 5,3,0,0
+FILEVERSION 5,4,0,0
+PRODUCTVERSION 5,4,0,0
 BEGIN
 	BLOCK "StringFileInfo"
 	BEGIN
@@ -7,11 +7,11 @@ BEGIN
 		BEGIN
 			VALUE "CompanyName", "BlueJ group"
 			VALUE "FileDescription", "BlueJ Launcher"
-			VALUE "FileVersion", "5.3.0"
+			VALUE "FileVersion", "5.4.0"
 			VALUE "InternalName", "bluej"
 			VALUE "OriginalFilename", "bluej.exe"
 			VALUE "ProductName", "BlueJ"
-			VALUE "ProductVersion", "5.3.0"
+			VALUE "ProductVersion", "5.4.0"
 		END
 	END
 END

--- a/bluej/package/winsetup/bluej.wxs
+++ b/bluej/package/winsetup/bluej.wxs
@@ -5,7 +5,7 @@
      If you get a build failure here with a message about ${bluej-3.1.7} or similar not being a legal
       guid value, then it is because you failed to make a new GUID for this version: see the
       update-version-number task in ant for details on what to do. -->
-<Product Version='5.3.0' Id='1baa4b8b-603a-4110-bf3d-880fedc342b3'
+<Product Version='5.4.0' Id='30e757e4-97f8-40f7-b9d8-d45f946f5aa4'
     Name='BlueJ' UpgradeCode='f4b4357e-6101-4cb1-8e38-3d4f3afb4be2'
     Language='1033' Codepage='1252' Manufacturer='BlueJ Team'>
     
@@ -23,7 +23,7 @@
     <Property Id="ALLUSERS" Secure="yes" />
     
     <Property Id="SOFTWARE" Value="BlueJ"/>
-    <Property Id="SOFTWAREVERSION" Value="5.3.0"/>
+    <Property Id="SOFTWAREVERSION" Value="5.4.0"/>
     <Property Id="SOFTWAREPROJECTEXT" Value="bluej"/>
     <Property Id="SOFTWAREARCHIVEEXT" Value="bjar"/>
     <!-- Define all the necessary GUIDs here, to make sure they are different from Greenfoot -->

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditor.java
@@ -514,6 +514,7 @@ public class FlowEditor extends ScopeColorsBorderPane implements TextEditor, Flo
                 }
                 flowEditorPane.showHighlights(HighlightType.FIND_RESULT, findResults);
                 flowEditorPane.showHighlights(HighlightType.BRACKET_MATCH, bracketMatches);
+                flowEditorPane.showHighlights(HighlightType.IME_INPUT, flowEditorPane.getImeInput());
             }
         });
 

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
@@ -265,6 +265,8 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
                 // Set imstart and imlength back to having no selection:
                 imStart = -1;
                 imLength = 0;
+                showHighlights(HighlightType.IME_INPUT, getImeInput());
+                positionCaret(end);
                 // I don't think committed and composed can both be there in one event, so return:
                 return;
             }
@@ -285,7 +287,17 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
             FlowEditorPane.this.replaceText(imStart, imStart + imLength, composed.toString(), EditType.IME_EDIT);
             // Update imlength to the new composed length:
             imLength = composed.length();
+            positionCaret(imStart + imLength, EditType.IME_EDIT);
+            showHighlights(HighlightType.IME_INPUT, getImeInput());
         }
+    }
+
+    public List<int[]> getImeInput()
+    {
+        if (imStart != -1)
+            return List.of(new int[]{imStart, imStart + imLength});
+        else
+            return List.of();
     }
 
     @Override
@@ -703,7 +715,7 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
     {
         if (editType == EditType.NON_IME_EDIT)
         {
-            nonIMEdit();
+            //nonIMEdit();
         }
         caret.moveTo(position);
         anchor.moveTo(position);

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
@@ -260,8 +260,7 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
             {
                 final int start = imStart;
                 final int end = imStart + imLength;
-                // Must call super so we don't do any extra Stride processing:
-                FlowEditorPane.this.replaceText(start, end, event.getCommitted(), EditType.IME_EDIT);
+                FlowEditorPane.this.replaceText(start, end, event.getCommitted());
                 // Set imstart and imlength back to having no selection:
                 imStart = -1;
                 imLength = 0;
@@ -284,10 +283,10 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
                 composed.append(run.getText());
             }
             // Replace the IM section with the latest text:
-            FlowEditorPane.this.replaceText(imStart, imStart + imLength, composed.toString(), EditType.IME_EDIT);
+            FlowEditorPane.this.replaceText(imStart, imStart + imLength, composed.toString());
             // Update imlength to the new composed length:
             imLength = composed.length();
-            positionCaret(imStart + imLength, EditType.IME_EDIT);
+            positionCaret(imStart + imLength);
             showHighlights(HighlightType.IME_INPUT, getImeInput());
         }
     }
@@ -711,12 +710,8 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
     /**
      * Set the position of the caret and anchor, and scroll to ensure the caret is on screen.
      */
-    public void positionCaret(int position, EditType editType)
+    public void positionCaret(int position)
     {
-        if (editType == EditType.NON_IME_EDIT)
-        {
-            //nonIMEdit();
-        }
         caret.moveTo(position);
         anchor.moveTo(position);
         targetColumnForVerticalMovement = -1;
@@ -724,12 +719,6 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
         updateRender(true);
         callSelectionListeners();
     }
-    // The default move is a non-IME:
-    public void positionCaret(int position)
-    {
-        positionCaret(position, EditType.NON_IME_EDIT);
-    }
-
 
     /**
      * Set the position of the caret and anchor, but do not scroll.
@@ -812,16 +801,16 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
     public void replaceSelection(String text)
     {
         nonIMEdit(); // IME calls replaceText directly, not this method
-        replaceText(getSelectionStart(), getSelectionEnd(), text, EditType.NON_IME_EDIT);
+        replaceText(getSelectionStart(), getSelectionEnd(), text);
     }
 
     private enum EditType { IME_EDIT, NON_IME_EDIT}
 
-    private void replaceText(int start, int end, String text, EditType editType)
+    private void replaceText(int start, int end, String text)
     {
         document.replaceText(start, end, text);
         // This makes sure the anchor is reset, too:
-        positionCaret(start + text.length(), editType);
+        positionCaret(start + text.length());
     }
 
     public int getSelectionEnd()

--- a/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
+++ b/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
@@ -456,6 +456,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
                 // Set imstart and imlength back to having no selection:
                 imStart = -1;
                 imLength = 0;
+                positionCaret(end);
                 // I don't think committed and composed can both be there in one event, so return:
                 return;
             }
@@ -477,6 +478,7 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
             super.replaceText(imStart, imStart + imLength, composed.toString());
             // Update imlength to the new composed length:
             imLength = composed.length();
+            positionCaret(imStart + imLength);
         }
     }
     

--- a/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
+++ b/bluej/src/main/java/bluej/utility/javafx/DelegableScalableTextField.java
@@ -434,18 +434,21 @@ public final class DelegableScalableTextField<DELEGATE_IDENT> extends ScalableHe
     }
 
     @OnThread(Tag.FXPlatform)
-    private void handleInputMethodEvent(InputMethodEvent event) {
+    private void handleInputMethodEvent(InputMethodEvent event)
+    {
         // This is adapted from the default handler in TextInputControlSkin.  That handler
         // uses selection to keep track of some things.  We keep track manually here but
         // there is not currently a visual representation of the highlight.
 
         // Check we're in an editable state:
-        if (this.isEditable() && !this.textProperty().isBound() && !this.isDisabled()) {
+        if (this.isEditable() && !this.textProperty().isBound() && !this.isDisabled())
+        {
 
             // Committed text is the final bit that the user might select from the on-screen IME keyboard,
             // or the plain English bit by pressing a key.
             // Insert committed text
-            if (event.getCommitted().length() != 0) {
+            if (event.getCommitted().length() != 0)
+            {
                 final int start = imStart;
                 final int end = imStart + imLength;
                 // Must call super so we don't do any extra Stride processing:

--- a/boot/src/main/java/bluej/Boot.java
+++ b/boot/src/main/java/bluej/Boot.java
@@ -59,7 +59,7 @@ public class Boot
     // The version numbers for BlueJ and Greenfoot are changed in the top-level
     // version.properties file and then the :boot:updateVersionNumber task should be
     // executed to change them here and elsewhere where needed.
-    public static final String BLUEJ_VERSION = "5.3.0";
+    public static final String BLUEJ_VERSION = "5.4.0";
     public static final String GREENFOOT_VERSION = "3.8.2";
     public static final String GREENFOOT_API_VERSION = "3.1.0";
 

--- a/version.properties
+++ b/version.properties
@@ -2,10 +2,10 @@
 # further down with a new GUID (e.g. from the website http://guidgen.com/)
 # for that release (even if you're not building for Windows):
 bluej_major=5
-bluej_minor=3
+bluej_minor=4
 bluej_release=0
 bluej_suffix=
-bluej_rcnumber=3
+bluej_rcnumber=1
 
 greenfoot_major=3
 greenfoot_minor=8
@@ -53,6 +53,7 @@ bluej-5.1.0a=10d73101-433a-4d19-aaa4-d667fb10e224
 bluej-5.2.0=8da631f6-8578-4bc0-8672-b46cb91b125d
 bluej-5.2.1=bc4cf1d0-8af3-450e-8640-509ebc746da1
 bluej-5.3.0=1baa4b8b-603a-4110-bf3d-880fedc342b3
+bluej-5.4.0=30e757e4-97f8-40f7-b9d8-d45f946f5aa4
 
 # Greenfoot GUIDs:
 greenfoot-3.0.2=8c838b70-3a71-41e8-91a6-4adcf2e483d0


### PR DESCRIPTION
As discussed recently...  The problem with the Korean IME in Java was the same as the recent Stride problem with Chinese IME (https://github.com/k-pet-group/BlueJ-Greenfoot/pull/2340) so the fix is very similar too.  The main extra change is that because it's easier in our own editor, I've added a highlight on the composite character being edited.

I'm not 100% sure about some of the behaviour but it does at least match the behaviour of standard text fields in Java, for better or worse.  For example, if you type "dud" to get a Korean character then type "." the character is replaced, although "dud" followed by <space> will keep it, which feels confusing to me.  Similarly if you type "dud" then left, the character will disappear.  But I think it's at least a lot better than it was where it was not combining any of the Korean symbols into characters.

I've also bumped the version number while I was doing a PR, since I think the next thing might be to build an RC.

(This is non-urgent, can wait until next week, but I just wanted to tick submitting the PR off my list.)