### PR TITLE
Fix infinite compile loop with sealed classes

### DIFF
--- a/bluej/src/main/java/bluej/compiler/Job.java
+++ b/bluej/src/main/java/bluej/compiler/Job.java
@@ -37,47 +37,19 @@ import bluej.classmgr.BPClassLoader;
  *
  * @author  Michael Cahill
  */
-class Job
+record Job(CompileInputFile[] sources, Compiler compiler, CompileObserver observer, BPClassLoader bpClassLoader, File destDir,
+           boolean internal, // true for compiling shell files,
+                             // or user files if we want to suppress
+                             // "unchecked" warnings, false otherwise
+           List<String> userCompileOptions, Charset fileCharset, CompileType type, CompileReason reason)
 {
-    Compiler compiler;  // The compiler for this job
-    CompileObserver observer;
-    File destDir;
-    BPClassLoader bpClassLoader;
-    CompileInputFile sources[];
-    boolean internal; // true for compiling shell files, 
-                      // or user files if we want to suppress 
-                      // "unchecked" warnings, false otherwise
-    private List<String> userCompileOptions;
-    private Charset fileCharset;
-    private CompileType type;
-    private CompileReason reason;
-
     /**
      * Generator for unique ascending compilation identifiers.  It doesn't matter if it's shared between
      * packages or between projects, it just needs to be unique and ascending.  An individual user won't manage
      * 2 billion compilations in a single session, so integer is fine:
      */
     private static final AtomicInteger nextCompilationSequence = new AtomicInteger(1);
-    
-    /**
-     * Create a job with a set of sources.
-     */
-    public Job(CompileInputFile[] sourceFiles, Compiler compiler, CompileObserver observer,
-                        BPClassLoader bpClassLoader, File destDir, boolean internal,
-                        List<String> userCompileOptions, Charset fileCharset, CompileType type, CompileReason reason)
-    {
-        this.sources = sourceFiles;
-        this.compiler = compiler;
-        this.observer = observer;
-        this.bpClassLoader = bpClassLoader;
-        this.destDir = destDir;
-        this.internal = internal;
-        this.userCompileOptions = userCompileOptions;
-        this.fileCharset = fileCharset;
-        this.type = type;
-        this.reason = reason;
-    }
-    
+
     /**
      * Compile this job
      */

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/Dependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/Dependency.java
@@ -39,7 +39,7 @@ import java.util.Properties;
  * @author Michael Kolling
  */
 @OnThread(Tag.FXPlatform)
-public abstract class Dependency
+public abstract sealed class Dependency permits ExtendsOrImplementsDependency, UsesDependency, PermitsDependency
 {
     @OnThread(Tag.Any)
     public final Target from;

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/ExtendsDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/ExtendsDependency.java
@@ -34,7 +34,7 @@ import java.util.Properties;
  * @author Michael Kolling
  */
 @OnThread(Tag.FXPlatform)
-public class ExtendsDependency extends Dependency
+public final class ExtendsDependency extends ExtendsOrImplementsDependency
 {
     @OnThread(Tag.Any)
     public ExtendsDependency(Package pkg, DependentTarget from, DependentTarget to)

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/ExtendsOrImplementsDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/ExtendsOrImplementsDependency.java
@@ -1,0 +1,18 @@
+package bluej.pkgmgr.dependency;
+
+import bluej.pkgmgr.Package;
+import bluej.pkgmgr.target.DependentTarget;
+
+/**
+ * The parent of ExtendsDependency and ImplementsDependency.
+ *
+ * These kinds of dependency are shown with an open-triangle-head arrow
+ * in the class diagram.
+ */
+public abstract sealed class ExtendsOrImplementsDependency extends Dependency permits ExtendsDependency, ImplementsDependency
+{
+    public ExtendsOrImplementsDependency(Package pkg, DependentTarget from, DependentTarget to)
+    {
+        super(pkg, from, to);
+    }
+}

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/ImplementsDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/ImplementsDependency.java
@@ -34,7 +34,7 @@ import java.util.Properties;
  * @author  Michael Kolling
  */
 @OnThread(Tag.FXPlatform)
-public class ImplementsDependency extends Dependency
+public final class ImplementsDependency extends ExtendsOrImplementsDependency
 {
     @OnThread(Tag.Any)
     public ImplementsDependency(Package pkg, DependentTarget from, DependentTarget to)

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/PermitsDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/PermitsDependency.java
@@ -45,7 +45,7 @@ import threadchecker.Tag;
  * to fix up its dependencies) but without the ExtendsDependency, Child will not
  * get recompiled.  So we use the PermitsDependency to make sure Child is compiled too.
  */
-public class PermitsDependency extends Dependency
+public final class PermitsDependency extends Dependency
 {
     public PermitsDependency(Package pkg, DependentTarget sealedParent, DependentTarget permittedChild)
     {

--- a/bluej/src/main/java/bluej/pkgmgr/dependency/UsesDependency.java
+++ b/bluej/src/main/java/bluej/pkgmgr/dependency/UsesDependency.java
@@ -36,7 +36,7 @@ import java.util.Properties;
  * @author  Michael Kolling
  */
 @OnThread(Tag.FXPlatform)
-public class UsesDependency extends Dependency
+public final class UsesDependency extends Dependency
 {
     // All are rounded to the nearest integer + 0.5 boundary
     // to make the lines sharp;

--- a/bluej/src/main/java/bluej/pkgmgr/target/DependentTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/DependentTarget.java
@@ -246,27 +246,6 @@ public abstract class DependentTarget extends EditableTarget
                 permits.stream().map(Dependency::getTo)
             ).collect(Collectors.toList());
     }
-    
-    /**
-     * Get the dependencies between this target and its parent(s).
-     * The returned list should not be modified and may be a view or a copy.
-     */
-    @OnThread(value = Tag.Any, requireSynchronized = true)
-    public synchronized List<Dependency> getParents()
-    {
-        return Collections.unmodifiableList(new ArrayList<>(parents));
-    }
-    
-    /**
-     * Get the dependencies between this target and its children.
-     * 
-     * @return
-     */
-    @OnThread(value = Tag.Any)
-    public synchronized List<Dependency> getChildrenDependencies()
-    {
-        return Collections.unmodifiableList(new ArrayList<>(children));
-    }
 
     @OnThread(Tag.Any)
     public synchronized List<Dependency> dependentsAsList()

--- a/bluej/src/main/java/bluej/pkgmgr/target/DependentTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/DependentTarget.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2012,2016,2017,2019,2020,2021,2023  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2012,2016,2017,2019,2020,2021,2023,2024  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -222,7 +222,10 @@ public abstract class DependentTarget extends EditableTarget
     @OnThread(Tag.Any)
     public final synchronized Collection<DependentTarget> dependencies()
     {
-        return Stream.concat(parents.stream(), outUses.stream())
+        // It is important we include permits, because javac treats it as a dependency,
+        // and without this, we can end up endlessly trying to compile a sealed parent class
+        // without realising that the problem is a compile error in the child class
+        return Stream.concat(Stream.concat(parents.stream(), outUses.stream()), permits.stream())
             .map(Dependency::getTo)
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
As discussed, fixes a bug with infinite compilation of an errorless parent sealed class, and corrects the display of a double-headed arrow between sealed parent and child.

This also has a bit of refactoring to tidy up some affected code by using the new Java 17/21 features in BlueJ's code itself: record classes and sealed classes and switch patterns.