### PR TITLE
Fix a small bug in the switch parsing

### DIFF
--- a/bluej/src/main/java/bluej/parser/JavaParser.java
+++ b/bluej/src/main/java/bluej/parser/JavaParser.java
@@ -1122,6 +1122,9 @@ public class JavaParser extends JavaParserCallbacks
                         case PatternParse.RecordPattern, PatternParse.TypeThenVariableName -> {
                             if (!parseRecordPattern(false))
                             {
+                                error("Failed to parse record pattern");
+                                tokenStream.pushBack(token);
+                                endSwitchCase(token, true);
                                 return null;
                             }
                             token = nextToken();


### PR DESCRIPTION
If parsing a record pattern failed (because the user was partway through writing it, for example) the scope stack got out of shape and the parsing failed, manifesting as missing scope highlighting.