### PR TITLE
Fix IME caret position and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains the source code for BlueJ and Greenfoot, licensed under
 Building and running
 ---
 
-BlueJ uses Gradle as its automated build tool.  To build you will first need to install a Java (17) JDK.  Check out the repository then execute the following command to run BlueJ:
+BlueJ uses Gradle as its automated build tool.  To build you will first need to install a Java (21) JDK.  Check out the repository then execute the following command to run BlueJ:
 
 ```
 ./gradlew runBlueJ
@@ -37,7 +37,7 @@ Or to run Greenfoot:
 Development
 ---
 
-To work on the project, IntelliJ IDEA should import the Gradle project automatically, although you may need to set the JDK (17) and language level (also 17).
+To work on the project, IntelliJ IDEA should import the Gradle project automatically, although you may need to set the JDK (21) and language level (also 21).
 
 Contributing
 ---

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
@@ -260,12 +260,12 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
             {
                 final int start = imStart;
                 final int end = imStart + imLength;
+                // This call will also position the caret at the end of the inserted text:
                 FlowEditorPane.this.replaceText(start, end, event.getCommitted());
                 // Set imstart and imlength back to having no selection:
                 imStart = -1;
                 imLength = 0;
                 showHighlights(HighlightType.IME_INPUT, getImeInput());
-                positionCaret(end);
                 // I don't think committed and composed can both be there in one event, so return:
                 return;
             }


### PR DESCRIPTION
Very small change to fix the caret not being in the right position after entry in e.g. Chinese in Windows.  Also updated the README.