### PR TITLE
MacOS add Aarch64 build

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -26,11 +26,11 @@ jobs:
           DISPLAY=:42.0 icewm &
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
-      - name: Gradle Build and Test
+      - name: Gradle Setup
         uses: gradle/actions/setup-gradle@v3
+      - name: Build and Test
         env:
           DISPLAY: ":42.0"
-        with:
-          arguments: build test -Pheadless=false --info --stacktrace --no-daemon
+        run: ./gradlew build test -Pheadless=false --info --stacktrace --no-daemon
       - name: Check copyright
         run: bash check-copyright.sh

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@v2.3.0
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.java_version }}

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@v2.3.0
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.java_version }}
@@ -47,20 +47,20 @@ jobs:
           (Get-Content $propfile) -replace 'mingw_root=.*', "mingw_root=C:/ProgramData/mingw64/mingw64" | Set-Content $propfile
           (Get-Content $propfile) -replace 'wix_bin=.*', "wix_bin=C:/Program Files (x86)/WiX Toolset v3.14/bin" | Set-Content $propfile
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@859c33240bd026ce8d5f711f5adcc65c2f8eafc1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Gradle Build and Test
-        uses: gradle/gradle-build-action@0842a550d10f5211be8c8295f6888889e1fca291
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: :bluej:packageBlueJWindows :greenfoot:packageGreenfootWindows --info --stacktrace --no-daemon          
       - name: Archive BlueJ Windows installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bluej-installers-windows
           path: |
             bluej/package/BlueJ-windows*.msi
             bluej/package/BlueJ-windows*.zip
       - name: Archive Greenfoot Windows installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: greenfoot-installers-windows
           path: |
@@ -70,11 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@v2.3.0
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.java_version }}
@@ -90,20 +90,20 @@ jobs:
         run: |
           find . -name 'build.gradle' -exec sed -i '/javafx_version_setting/c\version = '\''20.0.2'\''' {} +
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@859c33240bd026ce8d5f711f5adcc65c2f8eafc1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Gradle Build and Test
-        uses: gradle/gradle-build-action@0842a550d10f5211be8c8295f6888889e1fca291
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: :bluej:packageBlueJLinux :greenfoot:packageGreenfootLinux --info --stacktrace --no-daemon
       - name: Archive BlueJ Ubuntu installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bluej-installers-other
           path: |
             bluej/package/BlueJ-linux*.deb
             bluej/package/BlueJ-generic*.jar
       - name: Archive Greenfoot Ubuntu installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: greenfoot-installers-other
           path: |
@@ -114,11 +114,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@v2.3.0
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.java_version }}
@@ -159,9 +159,9 @@ jobs:
           security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@859c33240bd026ce8d5f711f5adcc65c2f8eafc1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Gradle Build and Test
-        uses: gradle/gradle-build-action@0842a550d10f5211be8c8295f6888889e1fca291
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: :bluej:packageBlueJMacIntel :greenfoot:packageGreenfootMacIntel --info --stacktrace --no-daemon
       - name: Sign and package
@@ -173,13 +173,13 @@ jobs:
           bash ../sign-mac.sh ${{ secrets.DEVELOPER_NAME }} ../BlueJ-mac*.zip ${{ secrets.APPLEID_EMAIL }} ${{ secrets.APPLEID_PASSWORD }} ${{ secrets.APPLEID_TEAMID }} `basename ../BlueJ-mac*.zip .zip`.dmg bluej_appdmg.json bluej-installer-icon
           bash ../sign-mac.sh ${{ secrets.DEVELOPER_NAME }} ../Greenfoot-mac*.zip ${{ secrets.APPLEID_EMAIL }} ${{ secrets.APPLEID_PASSWORD }} ${{ secrets.APPLEID_TEAMID }} `basename ../Greenfoot-mac*.zip .zip`.dmg greenfoot_appdmg.json greenfoot-installer-icon
       - name: Archive BlueJ Mac installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bluej-installers-mac-intel
           path: |
             bluej/package/BlueJ*.dmg
       - name: Archive Greenfoot Mac installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: greenfoot-installers-mac-intel
           path: |
@@ -188,11 +188,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@v2.3.0
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.java_version }}
@@ -233,9 +233,9 @@ jobs:
           security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@859c33240bd026ce8d5f711f5adcc65c2f8eafc1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Gradle Build and Test
-        uses: gradle/gradle-build-action@0842a550d10f5211be8c8295f6888889e1fca291
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: :bluej:packageBlueJMacAarch :greenfoot:packageGreenfootMacAarch --info --stacktrace --no-daemon
       - name: Sign and package
@@ -247,13 +247,13 @@ jobs:
           bash ../sign-mac.sh ${{ secrets.DEVELOPER_NAME }} ../BlueJ-mac*.zip ${{ secrets.APPLEID_EMAIL }} ${{ secrets.APPLEID_PASSWORD }} ${{ secrets.APPLEID_TEAMID }} `basename ../BlueJ-mac*.zip .zip`.dmg bluej_appdmg.json bluej-installer-icon
           bash ../sign-mac.sh ${{ secrets.DEVELOPER_NAME }} ../Greenfoot-mac*.zip ${{ secrets.APPLEID_EMAIL }} ${{ secrets.APPLEID_PASSWORD }} ${{ secrets.APPLEID_TEAMID }} `basename ../Greenfoot-mac*.zip .zip`.dmg greenfoot_appdmg.json greenfoot-installer-icon
       - name: Archive BlueJ Mac installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bluej-installers-mac-aarch
           path: |
             bluej/package/BlueJ*.dmg
       - name: Archive Greenfoot Mac installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: greenfoot-installers-mac-aarch
           path: |
@@ -264,11 +264,11 @@ jobs:
     runs-on: LinuxARM64
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@v2.3.0
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.java_version }}
@@ -287,19 +287,19 @@ jobs:
         run: |
           find . -name 'control' -exec sed -i '/Architecture:/c\Architecture: arm64' {} +
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@859c33240bd026ce8d5f711f5adcc65c2f8eafc1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Gradle Build and Test
-        uses: gradle/gradle-build-action@0842a550d10f5211be8c8295f6888889e1fca291
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: :bluej:packageBlueJLinux :greenfoot:packageGreenfootLinux --info --stacktrace --no-daemon
       - name: Archive BlueJ Ubuntu installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bluej-installers-arm64
           path: |
             bluej/package/BlueJ-linux*.deb
       - name: Archive Greenfoot Ubuntu installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: greenfoot-installers-arm64
           path: |

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -48,10 +48,10 @@ jobs:
           (Get-Content $propfile) -replace 'wix_bin=.*', "wix_bin=C:/Program Files (x86)/WiX Toolset v3.14/bin" | Set-Content $propfile
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
-      - name: Gradle Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :bluej:packageBlueJWindows :greenfoot:packageGreenfootWindows --info --stacktrace --no-daemon          
+      - name: Build
+        run: ./gradlew :bluej:packageBlueJWindows :greenfoot:packageGreenfootWindows --info --stacktrace --no-daemon
       - name: Archive BlueJ Windows installers
         uses: actions/upload-artifact@v4
         with:
@@ -91,10 +91,10 @@ jobs:
           find . -name 'build.gradle' -exec sed -i '/javafx_version_setting/c\version = '\''20.0.2'\''' {} +
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
-      - name: Gradle Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :bluej:packageBlueJLinux :greenfoot:packageGreenfootLinux --info --stacktrace --no-daemon
+      - name: Build
+        run: ./gradlew :bluej:packageBlueJLinux :greenfoot:packageGreenfootLinux --info --stacktrace --no-daemon
       - name: Archive BlueJ Ubuntu installers
         uses: actions/upload-artifact@v4
         with:
@@ -160,10 +160,10 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
-      - name: Gradle Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :bluej:packageBlueJMacIntel :greenfoot:packageGreenfootMacIntel --info --stacktrace --no-daemon
+      - name: Build
+        run: ./gradlew :bluej:packageBlueJMacIntel :greenfoot:packageGreenfootMacIntel --info --stacktrace --no-daemon
       - name: Sign and package
         run: |
           cd ${{ github.workspace }}
@@ -234,10 +234,10 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
-      - name: Gradle Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :bluej:packageBlueJMacAarch :greenfoot:packageGreenfootMacAarch --info --stacktrace --no-daemon
+      - name: Build
+        run: ./gradlew :bluej:packageBlueJMacAarch :greenfoot:packageGreenfootMacAarch --info --stacktrace --no-daemon
       - name: Sign and package
         run: |
           cd ${{ github.workspace }}
@@ -288,10 +288,10 @@ jobs:
           find . -name 'control' -exec sed -i '/Architecture:/c\Architecture: arm64' {} +
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
-      - name: Gradle Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :bluej:packageBlueJLinux :greenfoot:packageGreenfootLinux --info --stacktrace --no-daemon
+      - name: Build
+        run: ./gradlew :bluej:packageBlueJLinux :greenfoot:packageGreenfootLinux --info --stacktrace --no-daemon
       - name: Archive BlueJ Ubuntu installers
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -110,7 +110,7 @@ jobs:
             bluej/package/Greenfoot-linux*.deb
             bluej/package/Greenfoot-generic*.jar
 
-  Build-Mac-Installers:
+  Build-Mac-Installers-Intel:
     runs-on: macos-latest
     steps:
       - name: Check out repository code
@@ -163,7 +163,7 @@ jobs:
       - name: Gradle Build and Test
         uses: gradle/gradle-build-action@0842a550d10f5211be8c8295f6888889e1fca291
         with:
-          arguments: :bluej:packageBlueJMac :greenfoot:packageGreenfootMac --info --stacktrace --no-daemon
+          arguments: :bluej:packageBlueJMacIntel :greenfoot:packageGreenfootMacIntel --info --stacktrace --no-daemon
       - name: Sign and package
         run: |
           cd ${{ github.workspace }}
@@ -175,13 +175,87 @@ jobs:
       - name: Archive BlueJ Mac installers
         uses: actions/upload-artifact@v3
         with:
-          name: bluej-installers-mac
+          name: bluej-installers-mac-intel
           path: |
             bluej/package/BlueJ*.dmg
       - name: Archive Greenfoot Mac installers
         uses: actions/upload-artifact@v3
         with:
-          name: greenfoot-installers-mac
+          name: greenfoot-installers-mac-intel
+          path: |
+            bluej/package/Greenfoot*.dmg
+  Build-Mac-Installers-Aarch:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.java_version }}
+          java-package: jdk
+          architecture: aarch64
+      - name: Check install locations
+        run: |
+          ls $JAVA_HOME
+      - name: Run setup
+        run: |
+          brew install grep
+          brew install imagemagick
+          brew install python@3.9
+          export PATH=/usr/local/opt/python@3.9/libexec/bin:$PATH
+          brew install npm && npm install -g appdmg
+          cd ${{ github.workspace }}
+          echo 'ant_exe=ant' > tools.properties
+      - name: Install the Apple certificate and provisioning profile
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: Vh4o2zhsnBE5f
+        run: |
+          # From https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          
+          # import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@859c33240bd026ce8d5f711f5adcc65c2f8eafc1
+      - name: Gradle Build and Test
+        uses: gradle/gradle-build-action@0842a550d10f5211be8c8295f6888889e1fca291
+        with:
+          arguments: :bluej:packageBlueJMacAarch :greenfoot:packageGreenfootMacAarch --info --stacktrace --no-daemon
+      - name: Sign and package
+        run: |
+          cd ${{ github.workspace }}
+          cd bluej/package
+          mkdir tmpsign
+          cd tmpsign
+          bash ../sign-mac.sh ${{ secrets.DEVELOPER_NAME }} ../BlueJ-mac*.zip ${{ secrets.APPLEID_EMAIL }} ${{ secrets.APPLEID_PASSWORD }} ${{ secrets.APPLEID_TEAMID }} `basename ../BlueJ-mac*.zip .zip`.dmg bluej_appdmg.json bluej-installer-icon
+          bash ../sign-mac.sh ${{ secrets.DEVELOPER_NAME }} ../Greenfoot-mac*.zip ${{ secrets.APPLEID_EMAIL }} ${{ secrets.APPLEID_PASSWORD }} ${{ secrets.APPLEID_TEAMID }} `basename ../Greenfoot-mac*.zip .zip`.dmg greenfoot_appdmg.json greenfoot-installer-icon
+      - name: Archive BlueJ Mac installers
+        uses: actions/upload-artifact@v3
+        with:
+          name: bluej-installers-mac-aarch
+          path: |
+            bluej/package/BlueJ*.dmg
+      - name: Archive Greenfoot Mac installers
+        uses: actions/upload-artifact@v3
+        with:
+          name: greenfoot-installers-mac-aarch
           path: |
             bluej/package/Greenfoot*.dmg
   

--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ The installers are built automatically on Github.  If you want to build them man
 ```
 ./gradlew packageBlueJWindows
 ./gradlew packageBlueJLinux
-./gradlew packageBlueJMac
+./gradlew packageBlueJMacIntel
+./gradlew packageBlueJMacAarch
 ./gradlew packageGreenfootWindows
 ./gradlew packageGreenfootLinux
-./gradlew packageGreenfootMac
+./gradlew packageGreenfootMacIntel
+./gradlew packageGreenfootMacAarch
 ```
 
-None of the installers can be cross-built, so you must build Windows on Windows, Mac on Mac and Linux on Debian/Ubuntu.  Windows requires an installation of WiX 3.10 and MinGW64 to build the installer.
+None of the installers can be cross-built, so you must build Windows on Windows, Mac on Mac and Linux on Debian/Ubuntu.  Windows requires an installation of WiX 3.10 and MinGW64 to build the installer.  On Mac, JAVA_HOME must point to an Intel JDK for the Intel build, and an Aarch/ARM JDK for the Aarch build, so you cannot run them in the same command.
 

--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -129,7 +129,7 @@ test.dependsOn copyLibToTestBuild
 group = 'org.bluej'
 description = 'bluej'
 
-task packageBlueJMac(type: Exec) {
+task packageBlueJMacIntel(type: Exec) {
     workingDir "package"
     environment JAVA_HOME: System.getProperty('java.home')
     commandLine toolProps["ant_exe"], "mac-dist",
@@ -137,9 +137,25 @@ task packageBlueJMac(type: Exec) {
         "-Dmac_bundled_jdk_path=" + System.getProperty('java.home'),
         "-Dbluej.version=" + bluejVersion,
         "-Dbluej.rcsuffix=" + bluejRCSuffix,
-        "-Dbluej_home=" + projectDir.getAbsoluteFile()
+        "-Dbluej_home=" + projectDir.getAbsoluteFile(),
+        "-Dmac_arch=x86_64",
+        "-Dmac_bundler_arch_dir=x64"
+
 }
-packageBlueJMac.dependsOn assemble
+task packageBlueJMacAarch(type: Exec) {
+    workingDir "package"
+    environment JAVA_HOME: System.getProperty('java.home')
+    commandLine toolProps["ant_exe"], "mac-dist",
+            "-Dbuild_java_home=" + System.getProperty('java.home'),
+            "-Dmac_bundled_jdk_path=" + System.getProperty('java.home'),
+            "-Dbluej.version=" + bluejVersion,
+            "-Dbluej.rcsuffix=" + bluejRCSuffix,
+            "-Dbluej_home=" + projectDir.getAbsoluteFile(),
+            "-Dmac_arch=arm64",
+            "-Dmac_bundler_arch_dir=aarch64"
+}
+packageBlueJMacIntel.dependsOn assemble
+packageBlueJMacAarch.dependsOn assemble
 
 task packageBlueJWindows(type: Exec) {
     workingDir "package"

--- a/bluej/package/build.xml
+++ b/bluej/package/build.xml
@@ -8,7 +8,7 @@
     <!-- Names of the the distributables created by the dist-target -->
     <property name="dist.jarinstaller" value="BlueJ-generic-${bluej.version}${bluej.rcsuffix}.jar"/>
     <property name="dist.jarinstaller.final" value="BlueJ-generic-${bluej.version}.jar"/>
-    <property name="dist.mac" value="BlueJ-mac-${bluej.version}${bluej.rcsuffix}"/>
+    <property name="dist.mac" value="BlueJ-mac-${mac_bundler_arch_dir}-${bluej.version}${bluej.rcsuffix}"/>
     <property name="dist.mac.final" value="BlueJ-mac-${bluej.version}"/>
 
     <property name="dist.linux" value="BlueJ-linux-${bluej.version}${bluej.rcsuffix}"/>
@@ -233,8 +233,8 @@
                             name="BlueJ archive"
                             role="Editor"/>
             <runtime dir="${mac_bundled_jdk_path}"/>
-            <arch name="x86_64"/>
-            <environment name="JAVA_HOME" value="$APP_ROOT/Contents/PlugIns/x64/Contents/Home"/>
+            <arch name="${mac_arch}"/>
+            <environment name="JAVA_HOME" value="$APP_ROOT/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home"/>
             <option value="-Dapple.laf.useScreenMenuBar"/>
             <option value="-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2"/>
             <option value="-Xmx512M" name="Xmx"/>

--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -5,7 +5,7 @@
              classpath="appbundler-20230419.jar"
              classname="com.oracle.appbundler.AppBundlerTask"/>
     <import file="../shared.xml"/>
-    <property name="dist.mac" value="Greenfoot-mac-${greenfoot.version}${greenfoot.rcsuffix}.zip"/>
+    <property name="dist.mac" value="Greenfoot-mac-${mac_bundler_arch_dir}-${greenfoot.version}${greenfoot.rcsuffix}.zip"/>
     <property name="installer.jar" value="Greenfoot-generic-${greenfoot.version}${greenfoot.rcsuffix}.jar"/>
     
     <!-- Most of the targets in this build file are designed to be called from the
@@ -258,8 +258,8 @@
                             name="Greenfoot archive"
                             role="Editor"/>
             <runtime dir="${mac_bundled_jdk_path}"/>
-            <arch name="x86_64"/>
-            <environment name="JAVA_HOME" value="$APP_ROOT/Contents/PlugIns/x64/Contents/Home"/>
+            <arch name="${mac_arch}"/>
+            <environment name="JAVA_HOME" value="$APP_ROOT/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home"/>
             <option value="-Dapple.laf.useScreenMenuBar"/>
             <option value="-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2"/>
             <option value="-Xmx512M" name="Xmx"/>

--- a/bluej/package/sign-mac.sh
+++ b/bluej/package/sign-mac.sh
@@ -22,11 +22,11 @@ unzip -q "$2"
 echo "Unzip download - done"
 
 # JLI causes problems but is not needed:
-rm "$TOP_LEVEL"/Contents/PlugIns/x64/Contents/MacOS/libjli.dylib
+rm "$TOP_LEVEL"/Contents/PlugIns/*/Contents/MacOS/libjli.dylib
 # Fix permissions on JSA files, which are read-only by default:
 # These files are currently missing due to https://github.com/adoptium/adoptium-support/issues/937
 # We should restore this once the files are put back
-#chmod u+w $TOP_LEVEL/Contents/PlugIns/x64/Contents/Home/lib/server/*.jsa
+#chmod u+w $TOP_LEVEL/Contents/PlugIns/*/Contents/Home/lib/server/*.jsa
 
 # Sign the executable:
 echo "Signing BlueJ executable..."

--- a/greenfoot/build.gradle
+++ b/greenfoot/build.gradle
@@ -153,7 +153,7 @@ task userJavadoc(type: Javadoc) {
 }
 userJavadoc.dependsOn assemble
 
-task packageGreenfootMac(type: Exec) {
+task packageGreenfootMacIntel(type: Exec) {
     workingDir "../bluej/package"
     environment JAVA_HOME: System.getProperty('java.home')
     commandLine toolProps["ant_exe"], "-buildfile", "greenfoot-build.xml", "mac-dist",
@@ -162,9 +162,25 @@ task packageGreenfootMac(type: Exec) {
             "-Dgreenfoot.version=" + greenfootVersion,
             "-Dgreenfoot.rcsuffix=" + greenfootRCSuffix,
             "-Dbluej_home=" + rootDir.getAbsoluteFile() + "/bluej/",
-            "-Dgreenfoot_home=" + projectDir.getAbsoluteFile()
+            "-Dgreenfoot_home=" + projectDir.getAbsoluteFile(),
+            "-Dmac_arch=x86_64",
+            "-Dmac_bundler_arch_dir=x64"
 }
-packageGreenfootMac.dependsOn assemble, userJavadoc
+task packageGreenfootMacAarch(type: Exec) {
+    workingDir "../bluej/package"
+    environment JAVA_HOME: System.getProperty('java.home')
+    commandLine toolProps["ant_exe"], "-buildfile", "greenfoot-build.xml", "mac-dist",
+            "-Dbuild_java_home=" + System.getProperty('java.home'),
+            "-Dmac_bundled_jdk_path=" + System.getProperty('java.home'),
+            "-Dgreenfoot.version=" + greenfootVersion,
+            "-Dgreenfoot.rcsuffix=" + greenfootRCSuffix,
+            "-Dbluej_home=" + rootDir.getAbsoluteFile() + "/bluej/",
+            "-Dgreenfoot_home=" + projectDir.getAbsoluteFile(),
+            "-Dmac_arch=arm64",
+            "-Dmac_bundler_arch_dir=aarch64"
+}
+packageGreenfootMacIntel.dependsOn assemble, userJavadoc
+packageGreenfootMacAarch.dependsOn assemble, userJavadoc
 
 task packageGreenfootWindows(type: Exec) {
     workingDir "../bluej/package"

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=4
 bluej_release=0
 bluej_suffix=
-bluej_rcnumber=1
+bluej_rcnumber=2
 
 greenfoot_major=3
 greenfoot_minor=8


### PR DESCRIPTION
This adds an Apple architecture (M1/M2) build on Github.  It's a matter of bundling the right JDK, and getting the bundler to build the right native installation.  This is easiest to do in two separate Github Actions (plus, that way they can run in parallel).  I also updated the versions of all the Github Actions (like libraries) to eliminate all the deprecation warnings.