### PR TITLE
Fix Mac Aarch Java executable path

### DIFF
--- a/bluej/package/build.xml
+++ b/bluej/package/build.xml
@@ -258,12 +258,12 @@
         </move>
         <!-- We also have to copy the java executable in ourselves, as by default
              appbundler doesn't do so -->
-        <mkdir dir="BlueJ.app/Contents/PlugIns/x64/Contents/Home/bin"/>
-        <copy todir="BlueJ.app/Contents/PlugIns/x64/Contents/Home/bin">
+        <mkdir dir="BlueJ.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin"/>
+        <copy todir="BlueJ.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin">
             <file basedir="${mac_bundled_jdk_path}/bin" name="java/"/>
         </copy>
         <chmod perm="a+x">
-            <fileset dir="BlueJ.app/Contents/PlugIns/x64/Contents/Home/bin" includes="java" />
+            <fileset dir="BlueJ.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin" includes="java" />
         </chmod>
 
         <!-- codesign needs Internet connection to verify current time -->

--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -296,12 +296,12 @@
         </move>
         <!-- We also have to copy the java executable in ourselves, as by default
              appbundler doesn't do so -->
-        <mkdir dir="Greenfoot.app/Contents/PlugIns/x64/Contents/Home/bin"/>
-        <copy todir="Greenfoot.app/Contents/PlugIns/x64/Contents/Home/bin">
+        <mkdir dir="Greenfoot.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin"/>
+        <copy todir="Greenfoot.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin">
             <file basedir="${mac_bundled_jdk_path}/bin" name="java/"/>
         </copy>
         <chmod perm="a+x">
-            <fileset dir="Greenfoot.app/Contents/PlugIns/x64/Contents/Home/bin" includes="java" />
+            <fileset dir="Greenfoot.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin" includes="java" />
         </chmod>
 
         <!-- codesign needs Internet connection to verify current time -->

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=4
 bluej_release=0
 bluej_suffix=
-bluej_rcnumber=2
+bluej_rcnumber=3
 
 greenfoot_major=3
 greenfoot_minor=8


### PR DESCRIPTION
This was being copied to the wrong place.