### PR TITLE
Upgraded the JavaFX version on Raspberry Pi to 22.0.1 to get menu fix

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -283,7 +283,7 @@ jobs:
           ls $JAVA_HOME
       - name: Adjust JavaFX version on Linux
         run: |
-          find . -name 'build.gradle' -exec sed -i '/javafx_version_setting/c\version = '\''20.0.2'\''' {} +
+          find . -name 'build.gradle' -exec sed -i '/javafx_version_setting/c\version = '\''22.0.1'\''' {} +
       - name: Adjust architecture target on ARM64
         run: |
           find . -name 'control' -exec sed -i '/Architecture:/c\Architecture: arm64' {} +


### PR DESCRIPTION
…for the menus being bugged on Raspberry Pi's default window manager.