### PR TITLE
Suppressed a JavaFX exception that Michael sees on his Mac when opening BlueJ projects

### DIFF
--- a/bluej/src/main/java/bluej/terminal/Terminal.java
+++ b/bluej/src/main/java/bluej/terminal/Terminal.java
@@ -462,7 +462,11 @@ public final class Terminal
         //     WARNING: Unsupported JavaFX configuration: classes were loaded from 'unnamed module @18be7add'
         //     WARNUNG: Unsupported JavaFX configuration: classes were loaded from 'unnamed module @28f3d2a1'
         if (paneType == PaneType.STDERR && lines.removeIf(l -> l.trim().endsWith("com.sun.javafx.application.PlatformImpl startup") ||
-            l.contains("Unsupported JavaFX configuration: classes were loaded from")))
+            l.contains("Unsupported JavaFX configuration: classes were loaded from") ||
+            // These are to cover a stack trace which occurs on Mac when switching between windows:
+            l.contains("com.sun.glass.ui.Application.staticScreen_getScreens(") ||
+            l.contains("com.sun.glass.ui.Screen.initScreens(") ||
+            l.contains("com.sun.glass.ui.Screen.notifySettingsChanged(")))
         {
             // No need to continue (and thus show the terminal window) if there's no new output to add:
             if (lines.isEmpty())

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=4
 bluej_release=0
 bluej_suffix=
-bluej_rcnumber=3
+bluej_rcnumber=4
 
 greenfoot_major=3
 greenfoot_minor=8


### PR DESCRIPTION
We suppress the stack trace on the terminal end.