### PR TITLE
Fix a problem with the right-click menu on the line margin

### DIFF
--- a/bluej/src/main/java/bluej/Config.java
+++ b/bluej/src/main/java/bluej/Config.java
@@ -1933,6 +1933,7 @@ public final class Config
             JavaFXUtil.scalePolygonPoints(octagon, 0.5, false);
         }
         JavaFXUtil.addStyleClass(octagon, "octagon");
+        octagon.setMouseTransparent(true);
         Label stop = new Label("STOP");
         stop.setMouseTransparent(true);
         StackPane stackPane = new StackPane(octagon, stop);


### PR DESCRIPTION
The line margin context menu (which lets you turn line numbers on/off) was not working on Windows due to mouse handling issues.

Fixes #2383.