### PR TITLE
Fix errors not being shown in Java editor

### DIFF
--- a/bluej/src/main/java/bluej/utility/BackgroundSupplier.java
+++ b/bluej/src/main/java/bluej/utility/BackgroundSupplier.java
@@ -1,0 +1,34 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2024  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * Like supplier but must be run on background thread.
+ */
+@OnThread(Tag.Worker)
+public interface BackgroundSupplier<T>
+{
+    T get();
+}

--- a/bluej/src/main/java/bluej/utility/ImportScanner.java
+++ b/bluej/src/main/java/bluej/utility/ImportScanner.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2019,2020,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2019,2020,2021,2024  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -136,7 +136,16 @@ public class ImportScanner
                         }
                         else
                         {
-                            f.complete(new AssistContentThreadSafe(new ImportedTypeCompletion(c, javadocResolver)));
+                            AssistContentThreadSafe ac = null;
+                            try
+                            {
+                                ac = new AssistContentThreadSafe(new ImportedTypeCompletion(c, javadocResolver));
+                            }
+                            catch (Throwable t)
+                            {
+                                Debug.reportError(t);
+                            }
+                            f.complete(ac);
                         }
                     });
                     return f.get();


### PR DESCRIPTION
It seems like there were two causes for this.  One is that an exception thrown (which I'm still digging into, as it seems to have happened on Windows where the Windows installed version is using a mixture of JavaFX versions) while scanning the imports would stop quick fixes being calculated, and the other is that if quick fixes were not available (either permanently, or temporarily while BlueJ is still loading up and working out imports the first time) then the errors wouldn't show at all.

Fixes #2392 