### PR TITLE
Fix incorrect help text on Stride cheat sheet 

### DIFF
--- a/bluej/src/main/java/bluej/stride/framedjava/frames/StrideDictionary.java
+++ b/bluej/src/main/java/bluej/stride/framedjava/frames/StrideDictionary.java
@@ -73,7 +73,7 @@ public class StrideDictionary extends FrameDictionary<StrideCategory>
 //            new Entry<>('e', IfFrame.getFactory(), false, StrideCategory.CONDITIONAL, "stride.dictionary.else.name", "stride.dictionary.else.description"),
             new Entry<>('i', ImportFrame.getFactory(), false, StrideCategory.IMPORT, "stride.dictionary.import.name", "stride.dictionary.import.description"),
             new Entry<>('m', NormalMethodFrame.getFactory(), false, StrideCategory.CLASS_METHOD, "stride.dictionary.method.name", "stride.dictionary.method.description"),
-            new Entry<>('m', MethodProtoFrame.getFactory(), false, StrideCategory.INTERFACE_METHOD, "stride.dictionary.abstarct.name", "stride.dictionary.abstract.method.interface.description"),
+            new Entry<>('m', MethodProtoFrame.getFactory(), false, StrideCategory.INTERFACE_METHOD, "stride.dictionary.abstract.method.name", "stride.dictionary.abstract.method.interface.description"),
             //case 'o': return new ObjectBlock(editor);
             new Entry<>('r', ReturnFrame.getFactory(), false, StrideCategory.RETURN, "stride.dictionary.return.name", "stride.dictionary.return.description"),
             new Entry<>('s', SwitchFrame.getFactory(), false, StrideCategory.SWITCH, "stride.dictionary.switch.name", "stride.dictionary.switch.description"),


### PR DESCRIPTION
Fix incorrect help text on Stride cheat sheet for abstract method creation. Without this fix the Stride cheat sheet incorrectly displays "stride.dictionary.abstarct.name" instead of the intended, localisable, help text "Abstract method".

![stride-interface-cheat-sheet-glitch](https://github.com/user-attachments/assets/571dbc3a-18a4-4832-8c2f-b0917e474191)
