### PR TITLE
Fix MSI upgrade in per-machine install

### DIFF
--- a/bluej/package/winsetup/bluej.wxs
+++ b/bluej/package/winsetup/bluej.wxs
@@ -20,6 +20,21 @@
     <!-- Be fairly permissive, don't want to get in the way of the user: -->
     <MajorUpgrade AllowDowngrades="yes" />
 
+    <Upgrade Id="f4b4357e-6101-4cb1-8e38-3d4f3afb4be2">
+        <!-- Identify older versions to be upgraded -->
+        <!-- The "Maximum=" line is matched by a regex in the build file, so it is important that it be kept as-is. -->
+        <UpgradeVersion
+            Minimum="4.0.0"
+            Maximum="5.4.1"
+            IncludeMaximum="no"
+            Property="OLD_VERSION_DETECTED"
+            />
+    </Upgrade>
+    <!-- Add a condition to check if an older version is detected -->
+    <InstallExecuteSequence>
+        <RemoveExistingProducts After="InstallInitialize" />
+    </InstallExecuteSequence>
+
     <Property Id="ALLUSERS" Secure="yes" />
     
     <Property Id="SOFTWARE" Value="BlueJ"/>

--- a/bluej/package/winsetup/bluej.wxs
+++ b/bluej/package/winsetup/bluej.wxs
@@ -30,10 +30,6 @@
             Property="OLD_VERSION_DETECTED"
             />
     </Upgrade>
-    <!-- Add a condition to check if an older version is detected -->
-    <InstallExecuteSequence>
-        <RemoveExistingProducts After="InstallInitialize" />
-    </InstallExecuteSequence>
 
     <Property Id="ALLUSERS" Secure="yes" />
     

--- a/bluej/package/winsetup/ui.wxs
+++ b/bluej/package/winsetup/ui.wxs
@@ -50,6 +50,7 @@
 
            <Publish Dialog="CheckboxExtrasDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg">1</Publish>
            <Publish Dialog="CheckboxExtrasDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg">1</Publish>
+           <Publish Dialog="CheckboxExtrasDlg" Control="Next" Event="DoAction" Value="FindRelatedProducts">1</Publish>
 
            <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="CheckboxExtrasDlg">1</Publish>
            <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>

--- a/boot/build.gradle
+++ b/boot/build.gradle
@@ -138,6 +138,9 @@ task updateVersionNumber {
     ant.replaceregexp(match:'(\\s*<Property\\s+Id=\"SOFTWAREVERSION\"\\s+Value=).*', replace:"\\1\"${bluejVersionNoSuffix}\"/>", byline:true) {
         fileset(dir: '../bluej/package/winsetup', includes: 'bluej.wxs')
     }
+    ant.replaceregexp(match:'(\\s+Maximum=)\".*\"', replace:"\\1\"${bluejVersionNoSuffix}\"", byline:true) {
+        fileset(dir: '../bluej/package/winsetup', includes: 'bluej.wxs')
+    }
 
     //////////////////////////////////////
     // Greenfoot:

--- a/version.properties
+++ b/version.properties
@@ -5,7 +5,7 @@ bluej_major=5
 bluej_minor=4
 bluej_release=1
 bluej_suffix=
-bluej_rcnumber=1
+bluej_rcnumber=2
 
 greenfoot_major=3
 greenfoot_minor=9


### PR DESCRIPTION
We had a bug where it was possible to install multiple versions of BlueJ when using the per-machine (for-all-users) install.  This was because the detection of existing installations was happening before the point where the installing user chooses per-user/per-machine, so it would only ever look for per-user installs.  We now do the check (again) later in the process so we pick up the existing per-machine installs.