### PR TITLE
Update Greenfoot build to match recent BlueJ changes

### DIFF
--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -206,8 +206,8 @@
                includeantruntime="false"
                debug="true"
         >
-            <compilerarg line="-source 8" />
-            <compilerarg line="-target 8" />
+            <compilerarg line="-source 8"/>
+            <compilerarg line="-target 8"/>
         </javac>
 
         <!-- bundle the resulting class into the final distribution jar file -->
@@ -575,26 +575,26 @@
         <!-- you must do this as root, sigh -->
         <!-- (but we can also do it using fakeroot -->
         <chown owner="root">
-            <fileset dir="gfdeb">
+            <fileset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </fileset>
-            <dirset dir="gfdeb">
+            <dirset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </dirset>
         </chown>
         <chgrp group="root">
-            <fileset dir="gfdeb">
+            <fileset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </fileset>
-            <dirset dir="gfdeb">
+            <dirset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </dirset>
         </chgrp>
         <chmod perm="g-w">
-            <fileset dir="gfdeb">
+            <fileset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </fileset>
-            <dirset dir="gfdeb">
+            <dirset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </dirset>
         </chmod>
@@ -728,26 +728,26 @@
         <!-- you must do this as root, sigh -->
         <!-- (but we can also do it using fakeroot -->
         <chown owner="root">
-            <fileset dir="gfdeb">
+            <fileset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </fileset>
-            <dirset dir="gfdeb">
+            <dirset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </dirset>
         </chown>
         <chgrp group="root">
-            <fileset dir="gfdeb">
+            <fileset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </fileset>
-            <dirset dir="gfdeb">
+            <dirset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </dirset>
         </chgrp>
         <chmod perm="g-w">
-            <fileset dir="gfdeb">
+            <fileset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </fileset>
-            <dirset dir="gfdeb">
+            <dirset dir="gfdeb" followsymlinks="false">
                 <patternset includes="**" />
             </dirset>
         </chmod>

--- a/bluej/package/winlaunch/bjmanifest.xml
+++ b/bluej/package/winlaunch/bjmanifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <!-- Note: the following line is matched by a regex in the build file -->
-  <assemblyIdentity version="5.4.0.0"
+  <assemblyIdentity version="5.4.1.0"
      processorArchitecture="X86"
      name="BlueJ"
      type="win32"/> 

--- a/bluej/package/winlaunch/bluej-version.rc
+++ b/bluej/package/winlaunch/bluej-version.rc
@@ -1,5 +1,5 @@
-FILEVERSION 5,4,0,0
-PRODUCTVERSION 5,4,0,0
+FILEVERSION 5,4,1,0
+PRODUCTVERSION 5,4,1,0
 BEGIN
 	BLOCK "StringFileInfo"
 	BEGIN
@@ -7,11 +7,11 @@ BEGIN
 		BEGIN
 			VALUE "CompanyName", "BlueJ group"
 			VALUE "FileDescription", "BlueJ Launcher"
-			VALUE "FileVersion", "5.4.0"
+			VALUE "FileVersion", "5.4.1"
 			VALUE "InternalName", "bluej"
 			VALUE "OriginalFilename", "bluej.exe"
 			VALUE "ProductName", "BlueJ"
-			VALUE "ProductVersion", "5.4.0"
+			VALUE "ProductVersion", "5.4.1"
 		END
 	END
 END

--- a/bluej/package/winsetup/bluej.wxs
+++ b/bluej/package/winsetup/bluej.wxs
@@ -5,7 +5,7 @@
      If you get a build failure here with a message about ${bluej-3.1.7} or similar not being a legal
       guid value, then it is because you failed to make a new GUID for this version: see the
       update-version-number task in ant for details on what to do. -->
-<Product Version='5.4.0' Id='30e757e4-97f8-40f7-b9d8-d45f946f5aa4'
+<Product Version='5.4.1' Id='63208583-71fe-4504-93c2-377e202cc28a'
     Name='BlueJ' UpgradeCode='f4b4357e-6101-4cb1-8e38-3d4f3afb4be2'
     Language='1033' Codepage='1252' Manufacturer='BlueJ Team'>
     
@@ -34,7 +34,7 @@
     <Property Id="ALLUSERS" Secure="yes" />
     
     <Property Id="SOFTWARE" Value="BlueJ"/>
-    <Property Id="SOFTWAREVERSION" Value="5.4.0"/>
+    <Property Id="SOFTWAREVERSION" Value="5.4.1"/>
     <Property Id="SOFTWAREPROJECTEXT" Value="bluej"/>
     <Property Id="SOFTWAREARCHIVEEXT" Value="bjar"/>
     <!-- Define all the necessary GUIDs here, to make sure they are different from Greenfoot -->

--- a/bluej/package/winsetup/greenfoot.wxs
+++ b/bluej/package/winsetup/greenfoot.wxs
@@ -20,6 +20,17 @@
     <!-- Be fairly permissive, don't want to get in the way of the user: -->
     <MajorUpgrade AllowDowngrades="yes" />
 
+    <Upgrade Id="3ec7b829-9e53-4132-b2bf-fb7d4c08aebc">
+        <!-- Identify older versions to be upgraded -->
+        <!-- The "Maximum=" line is matched by a regex in the build file, so it is important that it be kept as-is. -->
+        <UpgradeVersion
+            Minimum="3.0.2"
+            Maximum="3.9.0"
+            IncludeMaximum="no"
+            Property="OLD_VERSION_DETECTED"
+            />
+    </Upgrade>
+
     <Property Id="ALLUSERS" Secure="yes" />
     
     <Property Id="SOFTWARE" Value="Greenfoot"/>

--- a/boot/build.gradle
+++ b/boot/build.gradle
@@ -175,6 +175,10 @@ task updateVersionNumber {
     ant.replaceregexp(match:'(\\s*<Property\\s+Id=\"SOFTWAREVERSION\"\\s+Value=).*', replace:"\\1\"${greenfootVersionNoSuffix}\"/>", byline:true) {
         fileset(dir: '../bluej/package/winsetup', includes: 'greenfoot.wxs')
     }
+
+    ant.replaceregexp(match:'(\\s+Maximum=)\".*\"', replace:"\\1\"${greenfootVersionNoSuffix}\"", byline:true) {
+        fileset(dir: '../bluej/package/winsetup', includes: 'greenfoot.wxs')
+    }
 }
 
 updateVersionNumber.dependsOn drawBlueJSplashVersion

--- a/boot/src/main/java/bluej/Boot.java
+++ b/boot/src/main/java/bluej/Boot.java
@@ -59,7 +59,7 @@ public class Boot
     // The version numbers for BlueJ and Greenfoot are changed in the top-level
     // version.properties file and then the :boot:updateVersionNumber task should be
     // executed to change them here and elsewhere where needed.
-    public static final String BLUEJ_VERSION = "5.4.0";
+    public static final String BLUEJ_VERSION = "5.4.1";
     public static final String GREENFOOT_VERSION = "3.9.0";
     public static final String GREENFOOT_API_VERSION = "3.1.0";
 

--- a/version.properties
+++ b/version.properties
@@ -11,7 +11,7 @@ greenfoot_major=3
 greenfoot_minor=9
 greenfoot_release=0
 greenfoot_suffix=
-greenfoot_rcnumber=1
+greenfoot_rcnumber=2
 
 # Change when API has changed in a way that is likely to break some scenarios. 
 # A warning will be shown to the user - update the greenfoot-labels file to


### PR DESCRIPTION
This mainly includes the fix for upgrading per-machine installations on Windows.