### PR TITLE
Several tidy-ups

### DIFF
--- a/bluej/package/build.xml
+++ b/bluej/package/build.xml
@@ -266,6 +266,12 @@
             <fileset dir="BlueJ.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin" includes="java" />
         </chmod>
 
+        <!-- We want to augment the error that appears when loading Apple build on Intel -->
+        <replaceregexp file="BlueJ.app/Contents/Resources/en.lproj/Localizable.strings"
+                       match='(\"JRELoadError\".*?)\";'
+                       replace='\1 You may need to download the Mac Intel version from bluej.org\";'
+                       byline="true"/>
+
         <!-- codesign needs Internet connection to verify current time -->
         <echo message="Signing and verifying bundle (NOTE: Internet connection is required to sign)"/>
         <chmod perm="+x" file="bundle-mac.sh" />

--- a/bluej/package/greenfoot-build.xml
+++ b/bluej/package/greenfoot-build.xml
@@ -304,6 +304,12 @@
             <fileset dir="Greenfoot.app/Contents/PlugIns/${mac_bundler_arch_dir}/Contents/Home/bin" includes="java" />
         </chmod>
 
+        <!-- We want to augment the error that appears when loading Apple build on Intel -->
+        <replaceregexp file="Greenfoot.app/Contents/Resources/en.lproj/Localizable.strings"
+                       match='(\"JRELoadError\".*?)\";'
+                       replace='\1 You may need to download the Mac Intel version from greenfoot.org\";'
+                       byline="true"/>
+
         <!-- codesign needs Internet connection to verify current time -->
         <echo message="Signing and verifying bundle (NOTE: Internet connection is required to sign)"/>
         <chmod perm="+x" file="bundle-mac.sh" />

--- a/boot/src/main/java/bluej/Boot.java
+++ b/boot/src/main/java/bluej/Boot.java
@@ -84,7 +84,6 @@ public class Boot
         "failureaccess-*.jar",
         "simple-png*.jar",
         "http*.jar"};
-    private static final int greenfootUserBuildJars = 4;
     
     // A singleton boot object so the rest of BlueJ can pick up args etc.
     private static Boot instance;

--- a/greenfoot/src/main/java/greenfoot/vmcomm/GreenfootDebugHandler.java
+++ b/greenfoot/src/main/java/greenfoot/vmcomm/GreenfootDebugHandler.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the Greenfoot program. 
- Copyright (C) 2010,2011,2012,2013,2015,2018,2019,2020,2021 Poul Henriksen and Michael Kolling
+ Copyright (C) 2010,2011,2012,2013,2015,2018,2019,2020,2021,2024 Poul Henriksen and Michael Kolling
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -799,6 +799,7 @@ public class GreenfootDebugHandler implements DebuggerListener, ObjectBenchInter
      * Set the simulation thread going if it's suspended: The user has clicked reset (or a reset
      * has otherwise been issued, eg after successful compile).
      */
+    @OnThread(Tag.FXPlatform)
     public void simulationThreadResumeOnResetClick()
     {
         project.getDebugger().runOnEventHandler(() -> {
@@ -807,6 +808,7 @@ public class GreenfootDebugHandler implements DebuggerListener, ObjectBenchInter
                 simulationThread.cont();
             }
         });
+        project.removeStepMarks();
         objectBench.clear();
     }
 }


### PR DESCRIPTION
A collection of small unrelated commits: fix an issue with the green "you are here" annotation remaining when you're debugging but then click Reset in Greenfoot; improve the Mac error message (with a slight hack, because its an error message from the app bundler we use, not our message directly) when you try to run the Apple silicon build on an Intel Mac.