### PR TITLE
Screenshot feature plus new text file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-java_version='21.0.4'
+java_version='21.0.6'

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -281,9 +281,6 @@ jobs:
       - name: Check install locations
         run: |
           ls $JAVA_HOME
-      - name: Adjust JavaFX version on Linux
-        run: |
-          find . -name 'build.gradle' -exec sed -i '/javafx_version_setting/c\version = '\''22.0.1'\''' {} +
       - name: Adjust architecture target on ARM64
         run: |
           find . -name 'control' -exec sed -i '/Architecture:/c\Architecture: arm64' {} +

--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -76,7 +76,7 @@ repositories {
 }
 
 javafx {
-    version = "21.0.3" // javafx_version_setting <-- The Github Actions on Linux uses this to find and replace this line
+    version = "23.0.2" // javafx_version_setting <-- The Github Actions on Linux uses this to find and replace this line
     // Important that we depend on all the JavaFX modules, so that they are
     // all made available to user code:
     modules = ['javafx.base', 'javafx.controls', 'javafx.graphics', 'javafx.fxml', 'javafx.media', 'javafx.swing', 'javafx.web']

--- a/bluej/lib/english/labels
+++ b/bluej/lib/english/labels
@@ -225,6 +225,8 @@ editor.gotoline.label = Enter line number
 editor.gotoline.prompt=Line number
 editor.gotoline.notNumericMessage = Input must be numeric
 
+editor.screenshotLines=Screenshot line(s)
+
 editor.implementationLabel = Source Code
 editor.interfaceLabel = Documentation
 

--- a/bluej/lib/english/labels
+++ b/bluej/lib/english/labels
@@ -484,12 +484,13 @@ pkgmgr.newPackage.prompt=Package name
 pkgmgr.newPackage.newPackage=Package
 pkgmgr.newPackage.error=Invalid package name
 
-# "new CSS" dialog
-pkgmgr.newCSS.title=BlueJ:  Create New CSS File
-pkgmgr.newCSS.label=CSS File:
-pkgmgr.newCSS.prompt=Filename
-pkgmgr.newCSS.newCSS=CSS
-pkgmgr.newCSS.error=Invalid filename
+# "new text file" dialog
+pkgmgr.newText.title=BlueJ:  Create New Text File
+pkgmgr.newText.label=Text file name:
+pkgmgr.newText.prompt=Filename
+pkgmgr.newText.newText=Text file
+pkgmgr.newText.error=Invalid filename
+pkgmgr.newText.invalidExtension=Supported file extensions: ${allowed}
 
 # "duplicate class" dialog
 pkgmgr.duplicate.title=BlueJ: Duplicate a Class
@@ -655,7 +656,7 @@ menu.package.quit=_Quit@Q
 menu.edit=_Edit
 menu.edit.newClass=New _Class...@N
 menu.edit.newPackage=New _Package...@R
-menu.edit.newCSS=New C_SS File...
+menu.edit.newText=New _Text File...
 menu.edit.addClass=_Add Class from File...
 menu.edit.remove=_Delete@BACK_SPACE
 menu.edit.newUses=New _Uses Arrow...

--- a/bluej/lib/korean/labels
+++ b/bluej/lib/korean/labels
@@ -477,13 +477,6 @@ pkgmgr.newPackage.prompt=\ud328\ud0a4\uc9c0 \uc774\ub984
 pkgmgr.newPackage.newPackage=\ud328\ud0a4\uc9c0
 pkgmgr.newPackage.error=\uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 \ud328\ud0a4\uc9c0 \uc774\ub984\uc785\ub2c8\ub2e4.
 
-# "new CSS" dialog
-pkgmgr.newCSS.title=BlueJ:  \uc0c8 CSS \ud30c\uc77c \ub9cc\ub4e4\uae30
-pkgmgr.newCSS.label=CSS \ud30c\uc77c:
-pkgmgr.newCSS.prompt=\ud30c\uc77c\uba85
-pkgmgr.newCSS.newCSS=CSS
-pkgmgr.newCSS.error=\uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 \ud30c\uc77c\uba85\uc785\ub2c8\ub2e4.
-
 # "duplicate class" dialog
 pkgmgr.duplicate.title=BlueJ: \ud074\ub798\uc2a4 \ubcf5\uc81c
 pkgmgr.duplicate.error.notValidClassName=\uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 \ud074\ub798\uc2a4 \uc774\ub984\uc785\ub2c8\ub2e4.
@@ -648,7 +641,6 @@ menu.package.quit=\uc885\ub8cc@Q
 menu.edit=\ud3b8\uc9d1
 menu.edit.newClass=\uc0c8 \ud074\ub798\uc2a4...@N
 menu.edit.newPackage=\uc0c8 \ud328\ud0a4\uc9c0...@R
-menu.edit.newCSS=\uc0c8 CSS \ud30c\uc77c...
 menu.edit.addClass=\ud30c\uc77c\uc5d0\uc11c \ud074\ub798\uc2a4 \ucd94\uac00...
 menu.edit.remove=\uc0ad\uc81c@BACK_SPACE
 menu.edit.newUses=\uc0c8 \uc0ac\uc6a9 \ud654\uc0b4\ud45c...

--- a/bluej/lib/portuguese/labels
+++ b/bluej/lib/portuguese/labels
@@ -466,12 +466,6 @@ pkgmgr.newPackage.prompt=Nome do pacote
 pkgmgr.newPackage.newPackage=Pacote
 pkgmgr.newPackage.error=Nome de pacote inv\u00E1lido
 
-# "new CSS" dialog
-pkgmgr.newCSS.title=BlueJ:  Criar novo arquivo com Folha de Estilos (CSS)
-pkgmgr.newCSS.label=Arquivo CSS:
-pkgmgr.newCSS.prompt=Nome do arquivo CSS
-pkgmgr.newCSS.newCSS=CSS
-pkgmgr.newCSS.error=Nome inv\u00E1lido
 
 # "duplicate class" dialog
 pkgmgr.duplicate.title=BlueJ: Duplicar uma Classe
@@ -635,7 +629,6 @@ menu.package.quit=_Sair@S
 menu.edit=_Editar
 menu.edit.newClass=Nova Classe...@N
 menu.edit.newPackage=Novo Pacote...@R
-menu.edit.newCSS=Novo Arquivo CSS...
 menu.edit.addClass=_Adicionar Classe de um Arquivo...
 menu.edit.remove=Remover@BACK_SPACE
 menu.edit.newUses=Nova Seta de _Uso...

--- a/bluej/lib/stylesheets/dialogs.css
+++ b/bluej/lib/stylesheets/dialogs.css
@@ -619,3 +619,7 @@
     -fx-min-height:  16em;
     -fx-pref-height: 18em;
 }
+
+.new-textfile-dialog {
+    -fx-pref-width: 25em;
+}

--- a/bluej/lib/stylesheets/flow.css
+++ b/bluej/lib/stylesheets/flow.css
@@ -64,6 +64,13 @@
     -fx-stroke: null;
 }
 
+.margin-and-text-line:bj-screenshotting > .text-line .flow-selection, .margin-and-text-line:bj-screenshotting > .text-line .flow-find-result, .margin-and-text-line:bj-screenshotting > .text-line .flow-bracket-match {
+    -fx-fill: null;
+}
+.line-container:bj-screenshotting .flow-caret {
+    -fx-stroke: null;
+}
+
 
 .line-container {
     -fx-background-color: white;

--- a/bluej/lib/stylesheets/flow.css
+++ b/bluej/lib/stylesheets/flow.css
@@ -32,6 +32,10 @@
     -fx-cursor: default;
 }
 
+.flow-caret {
+    -fx-stroke: red;
+}
+
 .flow-line-label {
     -fx-alignment: center-right;
     -fx-graphic-text-gap: 0;

--- a/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
@@ -110,7 +110,6 @@ public abstract class BaseEditorPane extends Region
         this.editorPaneListener = listener;
         caretShape = new Path();
         caretShape.getStyleClass().add("flow-caret");
-        caretShape.setStroke(Color.RED);
         caretShape.setMouseTransparent(true);
         caretShape.setManaged(false);
 

--- a/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/base/BaseEditorPane.java
@@ -296,6 +296,16 @@ public abstract class BaseEditorPane extends Region
     }
 
     /**
+     * Set/remove a given pseudoclass on the lineContainer.
+     * @param pseudoclass The pseudoclass name
+     * @param on Whether to set it (true) or remove it (false)
+     */
+    protected void setLineDisplayPseudoclass(String pseudoclass, boolean on)
+    {
+        JavaFXUtil.setPseudoclass(pseudoclass, on, lineContainer);
+    }
+
+    /**
      * Get the caret position that corresponds to the XY point featured in the given mouse event.
      */
     public Optional<EditorPosition> getCaretPositionForMouseEvent(MouseEvent e)

--- a/bluej/src/main/java/bluej/editor/base/LineDisplay.java
+++ b/bluej/src/main/java/bluej/editor/base/LineDisplay.java
@@ -27,6 +27,7 @@ import bluej.editor.flow.Document;
 import bluej.prefmgr.PrefMgr;
 import bluej.utility.Debug;
 import bluej.utility.javafx.FXFunction;
+import bluej.utility.javafx.JavaFXUtil;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import javafx.beans.binding.DoubleExpression;
@@ -399,6 +400,11 @@ public class LineDisplay
     public double textLeftEdge()
     {
         return MarginAndTextLine.textLeftEdge(showLeftMargin);
+    }
+
+    public void setPseudoclassOnAllVisibleLines(String pseudoclass, boolean on)
+    {
+        visibleLines.values().forEach(l -> JavaFXUtil.setPseudoclass(pseudoclass, on, l));
     }
 
     public static interface LineDisplayListener

--- a/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
+++ b/bluej/src/main/java/bluej/editor/flow/FlowEditorPane.java
@@ -39,6 +39,7 @@ import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.AccessibleAttribute;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.IndexRange;
 import javafx.scene.input.InputMethodEvent;
@@ -697,6 +698,20 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
         }
         return Optional.empty();
     }
+
+    protected Bounds getLineBoundsInScene(int line, boolean inclMargin)
+    {
+        if (lineDisplay.isLineVisible(line))
+        {
+            MarginAndTextLine marginAndTextLine = lineDisplay.getVisibleLine(line);
+            Node node = inclMargin ? marginAndTextLine : marginAndTextLine.textLine;
+            return node.localToScene(node.getBoundsInLocal());
+        }
+        else
+        {
+            return null;
+        }
+    }
     
     public Rectangle2D getLineBoundsOnScreen(int line, Point2D windowPos, double renderScaleX, double renderScaleY)
     {
@@ -866,6 +881,13 @@ public class FlowEditorPane extends BaseEditorPane implements JavaSyntaxView.Dis
             return sel;
         }
         return null;
+    }
+
+    @Override
+    protected void setLineDisplayPseudoclass(String pseudoclass, boolean on)
+    {
+        super.setLineDisplayPseudoclass(pseudoclass, on);
+        lineDisplay.setPseudoclassOnAllVisibleLines(pseudoclass, on);
     }
 
     private enum EditType { IME_EDIT, NON_IME_EDIT}

--- a/bluej/src/main/java/bluej/pkgmgr/NewTextFileDialog.java
+++ b/bluej/src/main/java/bluej/pkgmgr/NewTextFileDialog.java
@@ -21,46 +21,65 @@
  */
 package bluej.pkgmgr;
 
+import bluej.prefmgr.PrefMgr;
 import javafx.stage.Window;
 
 import bluej.Config;
-import bluej.utility.JavaNames;
 import bluej.utility.javafx.dialog.InputDialog;
 import threadchecker.OnThread;
 import threadchecker.Tag;
 
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
 
 /**
- * Dialog for creating a new CSS file
+ * Dialog for creating a new plain text file (.css, .txt, etc)
  */
 @OnThread(Tag.FXPlatform)
-class NewCSSDialog extends InputDialog<String>
+class NewTextFileDialog extends InputDialog<String>
 {
-    public NewCSSDialog(Window parent)
+    public NewTextFileDialog(Window parent)
     {
-        super(Config.getString("pkgmgr.newCSS.title"), Config.getString("pkgmgr.newCSS.label"), Config.getString("pkgmgr.newCSS.prompt"), "new-css-dialog", ".css");
+        super(Config.getString("pkgmgr.newText.title"), Config.getString("pkgmgr.newText.label"), Config.getString("pkgmgr.newText.prompt"), "new-textfile-dialog", null);
         initOwner(parent);
         setOKEnabled(false);
+        setResizable(true);
     }
     
     public String convert(String fieldText)
     {
-        return fieldText.trim() + ".css"; // Validation is done in convert
+        return fieldText.trim(); // Validation is done in convert
     }
     
-    public boolean validate(String oldInput, String newInput)
+    public boolean validate(String oldInput, String newInputUntrimmed)
     {
-        newInput = newInput.trim();
+        final String newInput = newInputUntrimmed.trim();
         
         if (!newInput.isEmpty() && !newInput.contains("/") && !newInput.contains("\\"))
         {
-            setOKEnabled(true);
-            setErrorText("");
-            return true;
+            ArrayList<String> extensions = new ArrayList<>(PrefMgr.getEditorFormattedTextFileExtensionsList());
+            extensions.add(0, ".css");
+
+            if (extensions.stream().anyMatch(ext -> newInput.toLowerCase().endsWith(ext) && newInput.length() > ext.length()))
+            {
+                setOKEnabled(true);
+                setErrorText("");
+                return true;
+            }
+            else
+            {
+                Properties p = new Properties();
+                p.setProperty("allowed", extensions.stream().collect(Collectors.joining(", ")));
+                setErrorText(Config.getString("pkgmgr.newText.invalidExtension", "", p, true));
+                setOKEnabled(false);
+                return true; // Let it be invalid, but show error
+            }
         }
         else
         {
-            setErrorText(Config.getString("pkgmgr.newCSS.error"));
+            setErrorText(Config.getString("pkgmgr.newText.error"));
             setOKEnabled(false);
             return true; // Let it be invalid, but show error
         }

--- a/bluej/src/main/java/bluej/pkgmgr/PackageEditor.java
+++ b/bluej/src/main/java/bluej/pkgmgr/PackageEditor.java
@@ -290,10 +290,10 @@ public final class PackageEditor extends StackPane
         });
         JavaFXUtil.addStyleClass(newPackage, "class-action-inbuilt");
         
-        MenuItem newCSS = new MenuItem(Config.getString("menu.edit.newCSS"));
+        MenuItem newCSS = new MenuItem(Config.getString("menu.edit.newText"));
         newCSS.setOnAction(e -> {
             pmf.menuCall();
-            pmf.doCreateNewCSS(graphLoc.getX(), graphLoc.getY());
+            pmf.doCreateNewTextFile(graphLoc.getX(), graphLoc.getY());
         });
         JavaFXUtil.addStyleClass(newCSS, "class-action-inbuilt");
 

--- a/bluej/src/main/java/bluej/pkgmgr/actions/NewTextFileAction.java
+++ b/bluej/src/main/java/bluej/pkgmgr/actions/NewTextFileAction.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2017  Michael Kolling and John Rosenberg 
+ Copyright (C) 1999-2009,2017,2025  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -24,21 +24,21 @@ package bluej.pkgmgr.actions;
 import bluej.pkgmgr.PkgMgrFrame;
 
 /**
- * "New CSS File" command. Allows the user to create a new CSS File with a
- * specified name.
+ * "New Text File" command. Allows the user to create a new plain file with a
+ * specified name and extension.
  * 
  * @author Davin McCall
  */
-final public class NewCSSAction extends PkgMgrAction
+final public class NewTextFileAction extends PkgMgrAction
 {
-    public NewCSSAction(PkgMgrFrame pmf)
+    public NewTextFileAction(PkgMgrFrame pmf)
     {
-        super(pmf, "menu.edit.newCSS");
+        super(pmf, "menu.edit.newText");
     }
     
     public void actionPerformed(PkgMgrFrame pmf)
     {
         pmf.menuCall();
-        pmf.doCreateNewCSS(-1, -1);
+        pmf.doCreateNewTextFile(-1, -1);
     }
 }

--- a/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
+++ b/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
@@ -42,6 +42,7 @@ import javafx.collections.*;
 import javafx.css.*;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.event.EventHandler;
+import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Point2D;
@@ -825,6 +826,23 @@ public class JavaFXUtil
     public static boolean containsScenePoint(Node node, double sceneX, double sceneY)
     {
         return node.localToScene(node.getBoundsInLocal()).contains(sceneX, sceneY);
+    }
+
+    /**
+     * Gets the smallest bounding box which contains all of the two given bounds inside it.
+     * If either are null, null is returned.
+     */
+    public static BoundingBox unionBounds(Bounds a, Bounds b)
+    {
+        if (a == null || b == null)
+            return null;
+
+        // The smallest rectangle that encompasses all of both bounds:
+        double minX = Math.min(a.getMinX(), b.getMinX());
+        double minY = Math.min(a.getMinY(), b.getMinY());
+        double maxX = Math.max(a.getMaxX(), b.getMaxX());
+        double maxY = Math.max(a.getMaxY(), b.getMaxY());
+        return new BoundingBox(minX, minY, maxX - minX, maxY - minY);
     }
 
     /**

--- a/bluej/src/main/java/bluej/utility/javafx/dialog/InputDialog.java
+++ b/bluej/src/main/java/bluej/utility/javafx/dialog/InputDialog.java
@@ -87,6 +87,7 @@ public abstract class InputDialog<R>
             }
         });
         error = new Label();
+        error.setWrapText(true);
         if (labelAfterField == null)
         {
             // By default, error label is shown
@@ -184,6 +185,14 @@ public abstract class InputDialog<R>
     protected void setPrompt(String s)
     {
         prompt.setText(s);
+    }
+
+    /**
+     * Sets whether the dialog is resizable.
+     */
+    protected void setResizable(boolean resizable)
+    {
+        dialog.setResizable(resizable);
     }
 
     /**

--- a/boot/build.gradle
+++ b/boot/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 javafx {
-    version = "21.0.3"  // javafx_version_setting <-- The Github Actions on Linux uses this to find and replace this line
+    version = "23.0.2"  // javafx_version_setting <-- The Github Actions on Linux uses this to find and replace this line
     modules = ['javafx.base', 'javafx.controls', 'javafx.graphics', 'javafx.swing']
 }
 

--- a/greenfoot/build.gradle
+++ b/greenfoot/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 javafx {
-    version = "21.0.3"  // javafx_version_setting <-- The Github Actions on Linux uses this to find and replace this line
+    version = "23.0.2"  // javafx_version_setting <-- The Github Actions on Linux uses this to find and replace this line
     modules = ['javafx.base', 'javafx.controls', 'javafx.graphics', 'javafx.swing', 'javafx.web']
 }
 


### PR DESCRIPTION
This is two main features, in the two biggest commits:
 - Add a context menu command to screenshot the currently selected lines.  Copies a screenshot to the clipboard, clipped to just be the lines currently selected (and on screen).
 - Change the "New CSS File..." menu command to be "New Text File..." where the user can create a CSS file, but also .txt, .md, or whatever else they put in the preferences as a file type that BlueJ should support as plain text.