### PR TITLE
Consolidate class metadata

### DIFF
--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly project(':threadchecker')
     implementation project(':boot')
     implementation project(':lang-stride')
+    compileOnly 'org.jetbrains:annotations:26.0.2-1'
 
     implementation 'com.google.guava:guava:33.3.1-jre'
     implementation 'com.google.guava:failureaccess:1.0.2'

--- a/bluej/src/main/java/bluej/debugmgr/LibraryCallDialog.java
+++ b/bluej/src/main/java/bluej/debugmgr/LibraryCallDialog.java
@@ -181,7 +181,7 @@ public class LibraryCallDialog extends Dialog<CallableView>
      */
     private void displayMethodsForClass(Class<?> cl)
     {
-        View classView = View.getView(cl);
+        View classView = View.getView(cl, pkg.getProject());
         ViewFilter filter;
 
         ConstructorView[] constructors = classView.getConstructors();

--- a/bluej/src/main/java/bluej/debugmgr/objectbench/ObjectWrapper.java
+++ b/bluej/src/main/java/bluej/debugmgr/objectbench/ObjectWrapper.java
@@ -432,7 +432,7 @@ public class ObjectWrapper extends StackPane implements InvokeListener, NamedVal
         menu = new ContextMenu();
 
         // add the menu items to call the methods
-        createMethodMenuItems(menu.getItems(), cl, iType, this, pkg.getQualifiedName(), true);
+        createMethodMenuItems(menu.getItems(), pkg.getProject(), cl, iType, this, pkg.getQualifiedName(), true);
 
         // add inspect and remove options
         MenuItem item;
@@ -460,11 +460,11 @@ public class ObjectWrapper extends StackPane implements InvokeListener, NamedVal
      *            methods)
      * @param showObjectMethods Whether to show the submenu with methods from java.lang.Object
      */
-    public static void createMethodMenuItems(ObservableList<MenuItem> menu, Class<?> cl, InvokeListener il,
+    public static void createMethodMenuItems(ObservableList<MenuItem> menu, Project project, Class<?> cl, InvokeListener il,
                                              String currentPackageName, boolean showObjectMethods)
     {
         GenTypeClass gt = new GenTypeClass(new JavaReflective(cl));
-        createMethodMenuItems(menu, cl, gt, il, currentPackageName, showObjectMethods);
+        createMethodMenuItems(menu, project, cl, gt, il, currentPackageName, showObjectMethods);
     }
 
     /**
@@ -479,11 +479,11 @@ public class ObjectWrapper extends StackPane implements InvokeListener, NamedVal
      *            methods)
      * @param showObjectMethods Whether to show the submenu for methods inherited from java.lang.Object
      */
-    public static void createMethodMenuItems(ObservableList<MenuItem> menu, Class<?> cl, GenTypeClass gtype, InvokeListener il,
+    public static void createMethodMenuItems(ObservableList<MenuItem> menu, Project project, Class<?> cl, GenTypeClass gtype, InvokeListener il,
                                              String currentPackageName, boolean showObjectMethods)
     {
         if (cl != null) {
-            View view = View.getView(cl);
+            View view = View.getView(cl, project);
             Hashtable<String, String> methodsUsed = new Hashtable<>();
             List<Class<?>> classes = getClassHierarchy(cl);
 
@@ -513,7 +513,7 @@ public class ObjectWrapper extends StackPane implements InvokeListener, NamedVal
             // create submenus for superclasses
             for(int i = 1; i < classes.size(); i++ ) {
                 Class<?> currentClass = classes.get(i);
-                view = View.getView(currentClass);
+                view = View.getView(currentClass, project);
 
                 // Determine visibility of package private / protected members
                 filter = new ViewFilter(StaticOrInstance.INSTANCE, currentPackageName);
@@ -532,7 +532,7 @@ public class ObjectWrapper extends StackPane implements InvokeListener, NamedVal
             // Create submenus for interfaces which have default methods:
             for (Class<?> iface : getInterfacesWithDefaultMethods(cl))
             {
-                view = View.getView(iface);
+                view = View.getView(iface, project);
                 declaredMethods = view.getDeclaredMethods();
                 Menu subMenu = new Menu(inheritedFrom + " "
                         + JavaNames.stripPrefix(iface.getName()));

--- a/bluej/src/main/java/bluej/extensions2/Identifier.java
+++ b/bluej/src/main/java/bluej/extensions2/Identifier.java
@@ -56,6 +56,7 @@ import java.io.File;
  */
 class Identifier
 {
+    private final Project project;
     private File projectId;
     private String packageId;
     private String qualifiedClassName;
@@ -87,6 +88,7 @@ class Identifier
     @OnThread(Tag.Any)
     Identifier(Project bluejProject, Package bluejPackage, String aQualifiedClassName)
     {
+        project = bluejProject;
         projectId = bluejProject.getProjectDir();
         if (bluejPackage != null) packageId = bluejPackage.getQualifiedName();
         qualifiedClassName = aQualifiedClassName;
@@ -225,7 +227,7 @@ class Identifier
         Class<?> aClass = getJavaClass();
 
         // View.getView does not fail, if the class does not exist it will be created.
-        return View.getView(aClass);
+        return View.getView(aClass, project);
     }
 
     /*

--- a/bluej/src/main/java/bluej/parser/context/ClassLoaderProvider.java
+++ b/bluej/src/main/java/bluej/parser/context/ClassLoaderProvider.java
@@ -1,0 +1,57 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2025  Michael Kolling and John Rosenberg 
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import bluej.classmgr.BPClassLoader;
+
+import java.io.File;
+
+/**
+ * Interface providing the minimal dependencies needed by CompilationUnitContextLoader.
+ * This abstraction enables unit testing without requiring full Project instantiation.
+ * 
+ * <p>The interface defines the contract for providing:
+ * <ul>
+ *   <li>A ClassLoader for loading project classes</li>
+ *   <li>The project directory root for resolving .ctxt files</li>
+ * </ul>
+ * 
+ * <p>Production code uses Project which implements this interface.
+ * Test code can provide lightweight implementations for specific scenarios.
+ * 
+ * @see CompilationUnitContextLoader
+ */
+public interface ClassLoaderProvider {
+    /**
+     * Gets the ClassLoader to use for loading classes and resources.
+     * 
+     * @return the BPClassLoader for this provider
+     */
+    BPClassLoader getClassLoader();
+    
+    /**
+     * Gets the project directory root.
+     * 
+     * @return the project directory
+     */
+    File getProjectDir();
+}

--- a/bluej/src/main/java/bluej/parser/context/CommentEntry.java
+++ b/bluej/src/main/java/bluej/parser/context/CommentEntry.java
@@ -1,0 +1,86 @@
+package bluej.parser.context;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a single comment entry (method, field, constructor, etc.)
+ * Each entry contains a target signature, documentation text, and optional parameter names.
+ */
+public class CommentEntry {
+    // Method/field signature
+    @NotNull
+    private final String target;
+
+    // Comment text
+    @NotNull
+    private final String text;
+
+    // Parameter names (if applicable)
+    @NotNull
+    private final List<String> paramNames;
+
+    /**
+     * Creates a new comment entry.
+     *
+     * @param target     The target signature (e.g. "void test(int,String)")
+     * @param text       The comment text
+     * @param paramNames The parameter names
+     */
+    public CommentEntry(@NotNull String target, @NotNull String text, @NotNull List<String> paramNames) {
+        this.target = target;
+        this.text = text;
+        this.paramNames = List.copyOf(paramNames);
+    }
+
+    /**
+     * Creates a new comment entry with no parameter names.
+     *
+     * @param target The target signature (e.g. "void test(int,String)")
+     * @param text   The comment text
+     */
+    public CommentEntry(@NotNull String target, @NotNull String text) {
+        this(target, text, Collections.emptyList());
+    }
+
+    /**
+     * Creates a new comment entry, with no text and parameter names.
+     *
+     * @param target The target signature (e.g. "void test(int,String)")
+     */
+    public CommentEntry(@NotNull String target) {
+        this(target, "");
+    }
+
+    /**
+     * Gets the target signature.
+     *
+     * @return The target signature
+     */
+    @NotNull
+    public String getTarget() {
+        return target;
+    }
+
+    /**
+     * Gets the comment text.
+     *
+     * @return The comment text, or null if not present
+     */
+    @NotNull
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Gets the parameter names.
+     *
+     * @return An unmodifiable list of parameter names
+     */
+    @NotNull
+    public List<String> getParamNames() {
+        return Collections.unmodifiableList(paramNames);
+    }
+}

--- a/bluej/src/main/java/bluej/parser/context/CompilationUnitContext.java
+++ b/bluej/src/main/java/bluej/parser/context/CompilationUnitContext.java
@@ -1,0 +1,192 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2025  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Encapsulates the context information for a compilation unit.
+ * This includes method/field documentation, parameter names, and other metadata
+ * stored in .ctxt files.
+ */
+public class CompilationUnitContext {
+    
+    /** A list of comments contained in this compilation unit */
+    private final List<CommentEntry> comments;
+    /** The class contained in this compilation unit (NOTE: this will have to be changed for Kotlin) */
+    private final String className;
+    /** The context file backing this information (if any) */
+    private final File ctxtFile;
+    /** Stores whether this context is read only */
+    private final boolean readOnly;
+
+
+    CompilationUnitContext(@NotNull String className, File ctxtFile, boolean readOnly) {
+        this.className = className;
+        this.ctxtFile = ctxtFile;
+        this.readOnly = readOnly;
+        this.comments = new ArrayList<>();
+    }
+
+
+    /**
+     * Creates a new context for a class.
+     *
+     * @param className The name of the class
+     * @param ctxtFile The .ctxt file backing this context class
+     */
+    static CompilationUnitContext writable(@NotNull String className, @NotNull File ctxtFile) {
+        return new CompilationUnitContext(className, ctxtFile, false);
+    }
+
+
+    /**
+     * Creates a new read-only context for a class.
+     * 
+     * @param className The name of the class
+     */
+    static CompilationUnitContext readOnly(@NotNull String className) {
+        return new CompilationUnitContext(className, null, true);
+    }
+
+
+    /**
+     * Gets the class name.
+     *
+     * @return The class name
+     */
+    @NotNull public String getClassName() {
+        return className;
+    }
+
+
+    /**
+     * Gets all comments.
+     *
+     * @return An unmodifiable list of comments
+     */
+    @NotNull public List<CommentEntry> getComments() {
+        return Collections.unmodifiableList(comments);
+    }
+
+
+    /**
+     * Adds a comment entry.
+     *
+     * @param comment The comment to add
+     */
+    public void addComment(@NotNull CommentEntry comment) {
+        comments.add(comment);
+    }
+
+
+    /**
+     * Replace all comments with the given list.
+     *
+     * @param entries The comments to replace with
+     */
+    void setComments(List<CommentEntry> entries) {
+        comments.clear();
+        comments.addAll(entries);
+    }
+
+
+    /**
+     * Clears all comments.
+     */
+    public void clear() {
+        comments.clear();
+    }
+
+
+    /**
+     * Checks if the context is empty.
+     *
+     * @return true if there are no comments
+     */
+    public boolean isEmpty() {
+        return comments.isEmpty();
+    }
+
+
+    /**
+     * Finds a comment by target signature.
+     * 
+     * @param targetSignature The target signature to search for
+     *
+     * @return The matching comment entry, or null if not found
+     */
+    public CommentEntry findComment(@NotNull String targetSignature) {
+        return comments.stream()
+            .filter(c -> c.getTarget().equals(targetSignature))
+            .findFirst()
+            .orElse(null);
+    }
+
+
+    /**
+     * Gets comments matching a regular expression pattern.
+     * 
+     * @param regex The regular expression pattern
+     *
+     * @return A list of matching comments
+     */
+    @NotNull public List<CommentEntry> findCommentsMatching(@NotNull String regex) {
+        try {
+            return comments.stream()
+                .filter(c -> c.getTarget().matches(regex))
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            // Invalid regex
+            return Collections.emptyList();
+        }
+    }
+    
+
+    /**
+     * Deletes the .ctxt file.
+     * 
+     * @return true if the file was deleted, false otherwise
+     */
+    public boolean delete() {
+        if (!readOnly && ctxtFile != null && ctxtFile.exists()) {
+            boolean deleted = ctxtFile.delete();
+            if (deleted) {
+                comments.clear();
+            }
+            return deleted;
+        }
+        return false;
+    }
+
+
+    @Override
+    @NotNull public String toString() {
+        return "CompilationUnitContext[class=" + className + 
+               ", comments=" + comments.size() + 
+               ", file=" + (ctxtFile != null ? ctxtFile.getName() : "<none>") + "]";
+    }
+}

--- a/bluej/src/main/java/bluej/parser/context/CompilationUnitContextLoader.java
+++ b/bluej/src/main/java/bluej/parser/context/CompilationUnitContextLoader.java
@@ -1,0 +1,371 @@
+
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 1999-2009,2010,2011,2016  Michael Kolling and John Rosenberg 
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import bluej.parser.symtab.ClassInfo;
+import javafx.application.Platform;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Loader for CompilationUnitContext from classpath resources.
+ * This class encapsulates the logic for loading .ctxt files from
+ * the classpath, with proper classloader handling and optional caching.
+ */
+public class CompilationUnitContextLoader implements AutoCloseable {
+    
+    /** The primary classloader to use for loading resources */
+    @NotNull private final ClassLoader primaryLoader;
+
+    /** Package roots for project classes */
+    private final Set<Path> packageRoots = ConcurrentHashMap.newKeySet();
+
+    /** Cache for loaded contexts, null if caching is disabled */
+    private final ConcurrentHashMap<String, CompilationUnitContext> cache;
+    
+    /** Whether caching is enabled for this loader */
+    private final boolean cachingEnabled;
+    
+    /**
+     * Creates a new loader with the specified classloader.
+     * Caching is enabled by default.
+     * 
+     * @param classLoader The classloader to use
+     */
+    public CompilationUnitContextLoader(@NotNull ClassLoader classLoader) {
+        this(classLoader, true);
+    }
+
+
+    /**
+     * Creates a new loader with the specified classloader and caching option.
+     * 
+     * @param classLoader The classloader to use
+     * @param enableCaching Whether to cache loaded contexts for performance
+     */
+    public CompilationUnitContextLoader(@NotNull ClassLoader classLoader, boolean enableCaching) {
+        this.primaryLoader = classLoader;
+        this.cachingEnabled = enableCaching;
+        this.cache = enableCaching ? new ConcurrentHashMap<>() : null;
+    }
+
+
+    /**
+     * Creates a new loader with the system classloader and caching option.
+     *
+     * @param enableCaching Whether to cache loaded contexts for performance
+     */
+    public CompilationUnitContextLoader(boolean enableCaching) {
+        this(ClassLoader.getSystemClassLoader(), enableCaching);
+    }
+
+    /**
+     * Adds a package root to the loader.
+     * This allows the loader to resolve classes in different package directories.
+     *
+     * @param packageRoot The root directory for a package
+     */
+    public void addPackageRoot(@NotNull Path packageRoot) {
+        if (Files.exists(packageRoot) && Files.isDirectory(packageRoot)) {
+            packageRoots.add(packageRoot.toAbsolutePath());
+        }
+    }
+
+
+    /**
+     * Removes a package root from the loader.
+     *
+     * @param packageRoot The root directory to remove
+     */
+    public void removePackageRoot(@NotNull Path packageRoot) {
+        packageRoots.remove(packageRoot.toAbsolutePath());
+    }
+
+
+    /**
+     * Loads a CompilationUnitContext for a class with caching.
+     * This method searches through all registered package roots to find
+     * the .ctxt file and handles the case where the file doesn't exist
+     * by returning an empty context.
+     *
+     * @param qualifiedName The fully qualified class name
+     *
+     * @return A CompilationUnitContext
+     */
+    @NotNull public CompilationUnitContext contextForClass(@NotNull String qualifiedName) {
+        CompilationUnitContext context = resolveFromResources(this.primaryLoader, qualifiedName);
+
+        if (context != null) {
+            return context;
+        }
+
+        context = resolveFromPackageRoots(qualifiedName);
+
+        return context != null
+            ? context
+            : CompilationUnitContext.readOnly(qualifiedName);
+    }
+
+
+    /**
+     * Loads context for a class using its Class object.
+     * Convenience method that extracts the qualified name and classloader.
+     * 
+     * <p>Given Class's classloader is given preference, if available.
+     * 
+     * @param clazz The class to load context for
+     *
+     * @return The loaded context, or an empty context if a context file is not found
+     */
+    @NotNull public CompilationUnitContext contextForClass(@NotNull Class<?> clazz) {
+        ClassLoader specificClassLoader = clazz.getClassLoader();
+        String qualifiedName = clazz.getName();
+
+        if (specificClassLoader != null) {
+            CompilationUnitContext context = resolveFromResources(specificClassLoader, qualifiedName);
+
+            if (context != null) {
+                return context;
+            }
+        }
+
+        // Fall back to class-specific loader
+        return contextForClass(qualifiedName);
+    }
+
+
+    /**
+     * Resolves the given class FQDN against resources present on the classpath
+     * 
+     * @param qualifiedName the FQDN of the class to resolve
+     * @param loader the classloader to resolve
+     * 
+     * @return a compilation unit context for this class, or null if not present
+     */
+    private CompilationUnitContext resolveFromResources(ClassLoader loader, String qualifiedName) {
+        Path resourcePath = constructContextFilePath(qualifiedName);
+
+        URL resource = loader.getResource(resourcePath.toString());
+
+        if (resource != null) {
+            return loadContextFromFile(new File(resource.getFile()), qualifiedName);
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Constructs the resource path for a .ctxt file from a qualified class name.
+     *
+     * @param qualifiedName The fully qualified class name (e.g., "java.lang.String")
+     *
+     * @return The resource path (e.g., "java/lang/String.ctxt")
+     */
+    @NotNull protected Path constructContextFilePath(@NotNull String qualifiedName) {
+        String[] elements = qualifiedName.split("\\.");
+
+        elements[elements.length - 1] += ".ctxt";
+
+        return Paths.get("", elements);
+    }
+
+
+    /**
+     * Resolves the given class FQDN against BlueJ project roots
+     * 
+     * @param qualifiedName the FQDN of the class to resolve
+     * 
+     * @return a compilation unit context for this class, or null if not present
+     */
+    private CompilationUnitContext resolveFromPackageRoots(@NotNull String qualifiedName) {
+        if (packageRoots.isEmpty()) {
+            return null;
+        }
+
+        Path resourcePath = constructContextFilePath(qualifiedName);
+
+        for (Path packageRoot : packageRoots) {
+            Path path = packageRoot.resolve(resourcePath);
+
+            if (Files.exists(path)) {
+                CompilationUnitContext context = loadContextFromFile(path.toFile(), qualifiedName);
+
+                if (context != null) {
+                    return context;
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Loads a compilation unit context from a file
+     * 
+     * @param file the file to load the compilation unit context from
+     * @param qualifiedName the FQDN of the class being loaded (TODO: should be contained in the file)
+     * 
+     * @return a compilation unit context loaded from this file
+     */
+    private CompilationUnitContext loadContextFromFile(@NotNull File file, @NotNull String qualifiedName) {
+        if (!cachingEnabled || cache == null) {
+            return PropertyContextFormat.fromFile(qualifiedName, file);
+        }
+
+        return cache.computeIfAbsent(qualifiedName, key -> PropertyContextFormat.fromFile(qualifiedName, file));
+    }
+
+
+    /**
+     * Creates a CompilationUnitContext from ClassInfo using the fully qualified class name.
+     * The loader will construct the appropriate file path internally.
+     *
+     * @param qualifiedName The fully qualified class name
+     * @param info The ClassInfo from the parser
+     *
+     * @return A new CompilationUnitContext with the data from ClassInfo
+     */
+    @NotNull public CompilationUnitContext updateContextFromClassInfo(@NotNull String qualifiedName, @NotNull ClassInfo info) {
+        // Extract ClassInfo data first (handles FX thread requirements)
+        ClassInfoData data = extractClassInfoData(info);
+
+        CompilationUnitContext context = CompilationUnitContext.readOnly(data.className);
+
+        context.setComments(PropertyContextFormat.fromProperties(data.comments));
+
+        Path contextFilePath = constructContextFilePath(qualifiedName);
+
+        try {
+            File contextFile = contextFilePath.toFile();
+
+            PropertyContextFormat.writeToFile(context, contextFile);
+        } catch (IOException ioe) {
+            throw new UncheckedIOException("Could not write context for " + contextFilePath, ioe);
+        }
+
+        // Invalidate cache entry so subsequent lookups reload the updated data
+        evictFromCache(qualifiedName);
+
+        return context;
+    }
+
+
+    /**
+     * Invalidates the cached context for a class.
+     * This method searches through all registered package roots to find
+     * and evict the corresponding cache entry.
+     *
+     * @param qualifiedName The fully qualified class name
+     * @return true if an entry was removed from cache, false otherwise
+     */
+    public boolean evictFromCache(@NotNull String qualifiedName) {
+        boolean evicted = false;
+
+        if (cachingEnabled) {
+            cache.remove(qualifiedName);
+        }
+
+        return evicted;
+    }
+
+
+    /**
+     * Clears the cache if caching is enabled.
+     * No-op if caching is disabled.
+     *
+     * <p>This method is thread-safe and can be called while other threads
+     * are accessing the cache.
+     */
+    public void clearCache() {
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+
+    /**
+     * Closes this loader and releases any cached resources.
+     * This method clears the cache to free memory.
+     *
+     * <p>After closing, the loader can still be used but will need to
+     * reload any previously cached contexts.
+     *
+     * <p>This method is idempotent and thread-safe.
+     */
+    @Override
+    public void close() {
+        clearCache();
+    }
+
+
+    /**
+     * Helper method to safely extract ClassInfo data on the FX thread.
+     * This method ensures that ClassInfo.getName() and ClassInfo.getComments()
+     * are called on the JavaFX platform thread as required.
+     *
+     * @param info The ClassInfo to access
+     * @return A ClassInfoData record containing the extracted data
+     */
+    static ClassInfoData extractClassInfoData(@NotNull ClassInfo info) {
+        // Need to execute on FX thread
+        CompletableFuture<ClassInfoData> future = new CompletableFuture<>();
+
+        Platform.runLater(() -> {
+            try {
+                String className = info.getName();
+                Properties comments = info.getComments();
+                future.complete(new ClassInfoData(className, comments));
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+
+        try {
+            return future.get();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to extract ClassInfo data", e);
+        }
+    }
+
+
+    /**
+     * Record class to hold extracted ClassInfo data.
+     * This allows ClassInfo data to be extracted on the FX thread
+     * and used elsewhere without thread constraints.
+     */
+    public record ClassInfoData(
+            @NotNull String className,
+            @NotNull Properties comments
+    ) {}
+}

--- a/bluej/src/main/java/bluej/parser/context/PropertyContextFormat.java
+++ b/bluej/src/main/java/bluej/parser/context/PropertyContextFormat.java
@@ -1,0 +1,141 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 1999-2009,2010,2011,2016  Michael Kolling and John Rosenberg 
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.*;
+
+final class PropertyContextFormat {
+
+    /**
+     *
+     * @param className
+     * @param ctxtFile
+     * @return
+     */
+    static CompilationUnitContext fromFile(@NotNull String className, @NotNull File ctxtFile) {
+        try {
+            Properties props = loadProperties(ctxtFile);
+            CompilationUnitContext context;
+
+            if (ctxtFile.canWrite()) {
+                context = CompilationUnitContext.writable(className, ctxtFile);
+            } else {
+                context = CompilationUnitContext.readOnly(className);
+            }
+
+            context.setComments(fromProperties(props));
+
+            return context;
+        }
+        catch (IOException e) {
+            return null;
+        }
+    }
+
+    static void writeToFile(@NotNull CompilationUnitContext context, @NotNull File ctxtFile) throws IOException {
+        Properties props = toProperties(context.getComments());
+
+        File parentDir = ctxtFile.getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
+
+        try (OutputStream out = new FileOutputStream(ctxtFile)) {
+            props.store(out, "BlueJ class context");
+        }
+    }
+
+    static Properties toProperties(List<CommentEntry> comments) {
+        Properties props = new Properties() {
+            @Override
+            public synchronized Enumeration<Object> keys() {
+                return java.util.Collections.enumeration(new TreeSet<>(super.keySet()));
+            }
+        };
+
+        props.setProperty("numComments", String.valueOf(comments.size()));
+
+        for (int i = 0; i < comments.size(); i++) {
+            CommentEntry entry = comments.get(i);
+            props.setProperty("comment" + i + ".target", entry.getTarget());
+            String text = entry.getText();
+            if (text != null && !text.isEmpty()) {
+                props.setProperty("comment" + i + ".text", text);
+            }
+            List<String> params = entry.getParamNames();
+            if (!params.isEmpty()) {
+                props.setProperty("comment" + i + ".params", String.join(" ", params));
+            }
+        }
+
+        return props;
+    }
+
+    static List<CommentEntry> fromProperties(Properties props) {
+        int numComments = 0;
+        try {
+            numComments = Integer.parseInt(props.getProperty("numComments", "0"));
+        } catch (NumberFormatException e) {
+            // ignore invalid value
+        }
+
+        List<CommentEntry> entries = new ArrayList<>(numComments);
+        for (int i = 0; i < numComments; i++) {
+            String prefix = "comment" + i;
+            String target = props.getProperty(prefix + ".target");
+            if (target == null) {
+                continue;
+            }
+            String text = props.getProperty(prefix + ".text");
+            String paramString = props.getProperty(prefix + ".params");
+            List<String> params = null;
+            if (paramString != null && !paramString.isEmpty()) {
+                params = Arrays.asList(paramString.split(" "));
+            }
+            else {
+                params = Collections.emptyList();
+            }
+            entries.add(new CommentEntry(target, text, params));
+        }
+        return entries;
+    }
+
+    private static Properties loadProperties(File file) throws IOException {
+        try (InputStream in = new FileInputStream(file)) {
+            return loadProperties(in);
+        }
+    }
+
+    private static Properties loadProperties(InputStream in) throws IOException {
+        Properties props = new Properties();
+        props.load(in);
+        return props;
+    }
+}

--- a/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
+++ b/bluej/src/main/java/bluej/parser/symtab/ClassInfo.java
@@ -25,6 +25,8 @@ import java.util.*;
 
 import bluej.utility.JavaUtils;
 import bluej.utility.SortedProperties;
+import threadchecker.OnThread;
+import threadchecker.Tag;
 
 /**
  * Information about a class found in a source file. The information is
@@ -51,6 +53,7 @@ public final class ClassInfo
 
     private boolean foundPublicClass = false;
 
+    @OnThread(value = Tag.Any, ignoreParent = true)
     private String name;
     private String superclass;
 
@@ -58,6 +61,7 @@ public final class ClassInfo
     private List<String> used = new ArrayList<String>();
 
     private List<String> permits = new ArrayList<>();
+    @OnThread(value = Tag.Any, ignoreParent = true)
     private List<SavedComment> comments = new LinkedList<SavedComment>();
 
     private List<String> typeParameterTexts = new ArrayList<String>();
@@ -76,13 +80,16 @@ public final class ClassInfo
 
     public class SavedComment
     {
+        @OnThread(value = Tag.Any, ignoreParent = true)
         public final String target; // the method signature of the item we have a
                                     // comment for. Can be class name or interface
                                     // name in the case of a comment for a whole
                                     // class/interface
 
+        @OnThread(value = Tag.Any, ignoreParent = true)
         public final String comment;  // the actual text of the comment
 
+        @OnThread(value = Tag.Any, ignoreParent = true)
         public final String paramnames;  // if this is a method or constructor, then
                                          // this is a comma seperated list of name
                                          // associated with the parameters
@@ -96,6 +103,7 @@ public final class ClassInfo
             this.paramnames = paramnames;
         }
 
+        @OnThread(value = Tag.Any, ignoreParent = true)
         public void save(Properties p, String prefix)
         {
             p.put(prefix + ".target", target);
@@ -446,6 +454,7 @@ public final class ClassInfo
         return superclass;
     }
 
+    @OnThread(value = Tag.Any, ignoreParent = true)
     public String getName()
     {
         return name;
@@ -487,6 +496,7 @@ public final class ClassInfo
         return permits;
     }
 
+    @OnThread(value = Tag.Any, ignoreParent = true)
     public Properties getComments()
     {
         Properties props = new SortedProperties();

--- a/bluej/src/main/java/bluej/pkgmgr/Package.java
+++ b/bluej/src/main/java/bluej/pkgmgr/Package.java
@@ -22,9 +22,7 @@
 package bluej.pkgmgr;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -2758,9 +2756,8 @@ public final class Package
                         ClassInfo info = t.getSourceInfo().getInfo(t.getJavaSourceFile(), t.getPackage());
 
                         if (info != null) {
-                            OutputStream out = new FileOutputStream(t.getContextFile());
-                            info.getComments().store(out, "BlueJ class context");
-                            out.close();
+                            // Use ClassTarget method to create and save context
+                            t.updateMetadata(info);
                         }
                     }
                     catch (Exception ex) {

--- a/bluej/src/main/java/bluej/pkgmgr/ProjectJavadocResolver.java
+++ b/bluej/src/main/java/bluej/pkgmgr/ProjectJavadocResolver.java
@@ -85,7 +85,7 @@ public class ProjectJavadocResolver implements JavadocResolver
 
         try {
             Class<?> cl = project.getClassLoader().loadClass(declName);
-            View clView = View.getView(cl);
+            View clView = View.getView(cl, project);
             List<CallableView> methods = Utility.concat(Arrays.asList(clView.getAllMethods()), Arrays.asList(clView.getConstructors()));
 
             for (CallableView method : methods)
@@ -164,7 +164,7 @@ public class ProjectJavadocResolver implements JavadocResolver
 
         try {
             Class<?> cl = project.getClassLoader().loadClass(declName);
-            View clView = View.getView(cl);
+            View clView = View.getView(cl, project);
             CallableView[] methods = method instanceof MethodReflective ? clView.getAllMethods() : clView.getConstructors();
 
             for (int i = 0; i < methods.length; i++) {

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -214,9 +214,6 @@ public class ClassTarget extends DependentTarget
     // The body of the class target which goes hashed, etc:
     @OnThread(Tag.FX)
     protected ResizableCanvas canvas;
-    
-    // Static loader for compilation unit contexts
-    private static final CompilationUnitContextLoader contextLoader = new CompilationUnitContextLoader(true);
 
     /**
      * Create a new class target in package 'pkg'.
@@ -239,10 +236,6 @@ public class ClassTarget extends DependentTarget
     public ClassTarget(Package pkg, String baseName, String template)
     {
         super(pkg, baseName, "Class");
-
-        // Register project root with the static context loader
-        // TODO:
-        contextLoader.addPackageRoot(pkg.getProject().getProjectDir().toPath());
 
         if (pseudos == null)
         {
@@ -1213,7 +1206,7 @@ public class ClassTarget extends DependentTarget
      * @throws IOException if an I/O error occurs while saving
      */
     public void updateMetadata(@NotNull ClassInfo info) throws IOException {
-        contextLoader.updateContextFromClassInfo(getQualifiedName(), info);
+        this.getPackage().getProject().updateClassMetadata(getQualifiedName(), info);
     }
 
     /**
@@ -1222,7 +1215,7 @@ public class ClassTarget extends DependentTarget
      * or when the .ctxt file may have been updated.
      */
     public void invalidateCompilationContext() {
-        contextLoader.evictFromCache(getQualifiedName());
+        this.getPackage().getProject().evictFromCache(getQualifiedName());
     }
 
     /**

--- a/bluej/src/main/java/bluej/pkgmgr/target/role/ClassRole.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/role/ClassRole.java
@@ -212,7 +212,7 @@ public abstract class ClassRole
     @OnThread(Tag.FXPlatform)
     public List<ClassTargetOperation> getClassConstructorOperations(ClassTarget ct, Class<?> cl)
     {
-        View view = View.getView(cl);
+        View view = View.getView(cl, ct.getPackage().getProject());
 
         if (!java.lang.reflect.Modifier.isAbstract(cl.getModifiers())) {
             ViewFilter filter = new ViewFilter(StaticOrInstance.INSTANCE, ct.getPackage().getQualifiedName());
@@ -236,7 +236,7 @@ public abstract class ClassRole
     @OnThread(Tag.FXPlatform)
     public List<ClassTargetOperation> getClassStaticOperations(ClassTarget ct, Class<?> cl)
     {
-        View view = View.getView(cl);
+        View view = View.getView(cl, ct.getPackage().getProject());
 
         ViewFilter filter = new ViewFilter(StaticOrInstance.STATIC, ct.getPackage().getQualifiedName());
         MethodView[] allMethods = view.getAllMethods();

--- a/bluej/src/main/java/bluej/pkgmgr/target/role/ClassRole.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/role/ClassRole.java
@@ -287,27 +287,6 @@ public abstract class ClassRole
     {}
 
     /**
-     * Get all the files belonging to a class target - source, class, ctxt, docs
-     * @param ct  The class target
-     * @return  A list of File objects
-     */
-    public List<File> getAllFiles(ClassTarget ct)
-    {
-        // .frame (if available), .java, .class, .ctxt, and doc (.html)
-        List<File> rlist = new ArrayList<>();
-
-        rlist.add(ct.getClassFile());
-        rlist.addAll(Utility.mapList(ct.getAllSourceFilesJavaLast(), sf -> sf.file));
-        rlist.add(ct.getContextFile());
-        rlist.add(ct.getDocumentationFile());
-
-        File [] innerClasses = ct.getInnerClassFiles();
-        Collections.addAll(rlist, innerClasses);
-
-        return rlist;
-    }
-
-    /**
      * True if this can be converted to Stride (assuming Java source is available;
      * this method does not need to check for that).  Returns false for unsupported
      * class types, like enums or unit tests.

--- a/bluej/src/main/java/bluej/views/FieldView.java
+++ b/bluej/src/main/java/bluej/views/FieldView.java
@@ -73,7 +73,7 @@ public final class FieldView extends MemberView
     public View getType()
     {
         if(type == null)
-            type = View.getView(field.getType());
+            type = View.getView(field.getType(), this.getDeclaringView().project);
 
         return type;
     }

--- a/bluej/src/main/java/bluej/views/MethodView.java
+++ b/bluej/src/main/java/bluej/views/MethodView.java
@@ -281,7 +281,7 @@ public class MethodView extends CallableView implements Comparable<MethodView>
     public View getReturnType()
     {
         if (returnType == null) {
-            returnType = View.getView(method.getReturnType());
+            returnType = View.getView(method.getReturnType(), getDeclaringView().project);
         }
         return returnType;
     }

--- a/bluej/src/main/java/bluej/views/View.java
+++ b/bluej/src/main/java/bluej/views/View.java
@@ -30,6 +30,7 @@ import bluej.debugger.gentype.GenTypeDeclTpar;
 import bluej.parser.context.CommentEntry;
 import bluej.parser.context.CompilationUnitContext;
 import bluej.parser.context.CompilationUnitContextLoader;
+import bluej.pkgmgr.Project;
 import bluej.utility.JavaNames;
 import bluej.utility.JavaUtils;
 import threadchecker.OnThread;
@@ -47,7 +48,8 @@ import threadchecker.Tag;
 public class View
 {
     /** The class that this view is for **/
-    protected Class<?> cl;
+    protected final Class<?> cl;
+    protected final Project project;
 
     protected FieldView[] fields;
     protected FieldView[] allFields;
@@ -71,7 +73,7 @@ public class View
      * This is the only way to obtain a View object.
      * This method is thread-safe.
      */
-    public static View getView(Class<?> cl)
+    public static View getView(Class<?> cl, Project project)
     {
         if(cl == null)
             return null;
@@ -81,7 +83,7 @@ public class View
         synchronized (views) {
             View v = views.get(cl);
             if(v == null) {
-                v = new View(cl);
+                v = new View(cl, project);
                 views.put(cl, v);
             }
 
@@ -114,9 +116,10 @@ public class View
         }
     }
 
-    private View(Class<?> cl)
+    private View(Class<?> cl, Project project)
     {
         this.cl = cl;
+        this.project = project;
     }
 
     private ClassLoader getClassLoader()
@@ -156,7 +159,7 @@ public class View
 
     public View getSuper()
     {
-        return getView(cl.getSuperclass());
+        return getView(cl.getSuperclass(), this.project);
     }
 
     public View[] getInterfaces()
@@ -165,7 +168,7 @@ public class View
 
         View[] interfaceViews = new View[interfaces.length];
         for(int i = 0; i < interfaces.length; i++)
-            interfaceViews[i] =  getView(interfaces[i]);
+            interfaceViews[i] =  getView(interfaces[i], this.project);
 
         return interfaceViews;
     }

--- a/bluej/src/test/java/bluej/parser/context/CompilationUnitContextIntegrationTest.java
+++ b/bluej/src/test/java/bluej/parser/context/CompilationUnitContextIntegrationTest.java
@@ -1,0 +1,441 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2025  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Comprehensive integration test for CompilationUnitContext across
+ * Package, View, ClassTarget, and ClassInfo components.
+ */
+public class CompilationUnitContextIntegrationTest {
+    
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    
+    private File projectDir;
+    private File packageDir;
+    private File ctxtFile;
+    private File classFile;
+    
+    @Before
+    public void setUp() throws IOException {
+        // Create test directory structure
+        projectDir = tempFolder.newFolder("test_project");
+        packageDir = new File(projectDir, "test_package");
+        packageDir.mkdirs();
+        
+        // Create test .java file
+        classFile = new File(packageDir, "TestClass.java");
+        try (PrintWriter writer = new PrintWriter(classFile)) {
+            writer.println("package test_package;");
+            writer.println("");
+            writer.println("/**");
+            writer.println(" * Test class for integration testing");
+            writer.println(" */");
+            writer.println("public class TestClass {");
+            writer.println("    ");
+            writer.println("    /**");
+            writer.println("     * Constructor");
+            writer.println("     * @param value Initial value");
+            writer.println("     * @param name The name");
+            writer.println("     */");
+            writer.println("    public TestClass(int value, String name) {");
+            writer.println("    }");
+            writer.println("    ");
+            writer.println("    /**");
+            writer.println("     * Test method");
+            writer.println("     */");
+            writer.println("    public void testMethod() {");
+            writer.println("    }");
+            writer.println("    ");
+            writer.println("    /**");
+            writer.println("     * Another method with parameters");
+            writer.println("     * @param input Input string");
+            writer.println("     * @param count Number of times");
+            writer.println("     * @return Result string");
+            writer.println("     */");
+            writer.println("    public String processData(String input, int count) {");
+            writer.println("        return input;");
+            writer.println("    }");
+            writer.println("}");
+        }
+        
+        // Create corresponding .ctxt file
+        ctxtFile = new File(packageDir, "TestClass.ctxt");
+    }
+    
+    @After
+    public void tearDown() {
+        // Cleanup is handled by TemporaryFolder
+    }
+    
+    /**
+     * Test 1: ClassInfo to CompilationUnitContext flow
+     * Verifies that ClassInfo properly populates CompilationUnitContext
+     */
+    @Test
+    public void testClassInfoToContextFlow() throws Exception {
+        // Create a context from ClassInfo
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", ctxtFile);
+        
+        // Simulate what ClassInfo would do: add comments based on parsed Javadoc
+        context.addComment(new CommentEntry(
+            "TestClass(int,String)", 
+            "Constructor", 
+            Arrays.asList("value", "name")
+        ));
+        
+        context.addComment(new CommentEntry(
+            "void testMethod()", 
+            "Test method", 
+            Collections.emptyList()
+        ));
+        
+        context.addComment(new CommentEntry(
+            "String processData(String,int)", 
+            "Another method with parameters", 
+            Arrays.asList("input", "count")
+        ));
+        
+        // Verify the context has the expected data
+        assertEquals("Should have 3 comments", 3, context.getComments().size());
+        
+        // Verify first comment (constructor)
+        CommentEntry entry0 = context.getComments().get(0);
+        assertEquals("TestClass(int,String)", entry0.getTarget());
+        assertEquals("Constructor", entry0.getText());
+        assertEquals(2, entry0.getParamNames().size());
+        assertEquals("value", entry0.getParamNames().get(0));
+        assertEquals("name", entry0.getParamNames().get(1));
+        
+        // Verify second comment (test method)
+        CommentEntry entry1 = context.getComments().get(1);
+        assertEquals("void testMethod()", entry1.getTarget());
+        assertEquals("Test method", entry1.getText());
+        assertEquals(0, entry1.getParamNames().size());
+        
+        // Verify third comment (process data method)
+        CommentEntry entry2 = context.getComments().get(2);
+        assertEquals("String processData(String,int)", entry2.getTarget());
+        assertEquals("Another method with parameters", entry2.getText());
+        assertEquals(2, entry2.getParamNames().size());
+        assertEquals("input", entry2.getParamNames().get(0));
+        assertEquals("count", entry2.getParamNames().get(1));
+    }
+    
+    /**
+     * Test 2: Package.java save context functionality
+     * Verifies that Package can save CompilationUnitContext to .ctxt files
+     */
+    @Test
+    public void testPackageSaveContext() throws Exception {
+        // Create and populate context
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", ctxtFile);
+        
+        context.addComment(new CommentEntry(
+            "TestClass(int,String)", 
+            "Constructor with parameters", 
+            Arrays.asList("value", "name")
+        ));
+        
+        context.addComment(new CommentEntry(
+            "void doSomething()", 
+            "Method that does something"
+        ));
+        
+        // Save the context (simulates what Package would do)
+        PropertyContextFormat.writeToFile(context, ctxtFile);
+        
+        // Verify the file was created
+        assertTrue("Ctxt file should exist", ctxtFile.exists());
+        
+        // Verify the saved format by reading with Properties
+        Properties props = new Properties();
+        try (InputStream in = new FileInputStream(ctxtFile)) {
+            props.load(in);
+        }
+        
+        // Verify Properties format compatibility
+        assertEquals("2", props.getProperty("numComments"));
+        assertEquals("TestClass(int,String)", props.getProperty("comment0.target"));
+        assertEquals("Constructor with parameters", props.getProperty("comment0.text"));
+        assertEquals("value name", props.getProperty("comment0.params"));
+        assertEquals("void doSomething()", props.getProperty("comment1.target"));
+        assertEquals("Method that does something", props.getProperty("comment1.text"));
+        assertNull("Should not have params for second comment", props.getProperty("comment1.params"));
+    }
+    
+    /**
+     * Test 3: View.java library class resource loading
+     * Verifies that View can load CompilationUnitContext for library classes
+     */
+    @Test
+    public void testViewLibraryClassLoading() throws Exception {
+        // Create a .ctxt file simulating a library class context
+        Properties libProps = new Properties();
+        libProps.setProperty("numComments", "3");
+        libProps.setProperty("comment0.target", "java.lang.String()");
+        libProps.setProperty("comment0.text", "Default constructor");
+        libProps.setProperty("comment1.target", "int length()");
+        libProps.setProperty("comment1.text", "Returns the length of this string");
+        libProps.setProperty("comment2.target", "String substring(int,int)");
+        libProps.setProperty("comment2.text", "Returns a substring");
+        libProps.setProperty("comment2.params", "beginIndex endIndex");
+        
+        File libCtxtFile = new File(tempFolder.getRoot(), "String.ctxt");
+        try (OutputStream out = new FileOutputStream(libCtxtFile)) {
+            libProps.store(out, "Library class context");
+        }
+        
+        // Load using PropertyContextFormat (simulates what View would do)
+        CompilationUnitContext libContext = PropertyContextFormat.fromFile("String", libCtxtFile);
+
+        assertNotNull("Context should not be null", libContext);
+
+        // Verify library context was loaded correctly
+        assertEquals("Should have 3 comments", 3, libContext.getComments().size());
+        
+        CommentEntry entry0 = libContext.getComments().get(0);
+        assertEquals("java.lang.String()", entry0.getTarget());
+        assertEquals("Default constructor", entry0.getText());
+        
+        CommentEntry entry1 = libContext.getComments().get(1);
+        assertEquals("int length()", entry1.getTarget());
+        assertEquals("Returns the length of this string", entry1.getText());
+        
+        CommentEntry entry2 = libContext.getComments().get(2);
+        assertEquals("String substring(int,int)", entry2.getTarget());
+        assertEquals("Returns a substring", entry2.getText());
+        assertEquals(2, entry2.getParamNames().size());
+        assertEquals("beginIndex", entry2.getParamNames().get(0));
+        assertEquals("endIndex", entry2.getParamNames().get(1));
+    }
+    
+    /**
+     * Test 4: ClassTarget getCompilationContext() API
+     * Verifies the ClassTarget can provide CompilationUnitContext
+     */
+    @Test
+    public void testClassTargetGetCompilationContext() throws Exception {
+        // Create a context and save it to file
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", ctxtFile);
+        
+        context.addComment(new CommentEntry(
+            "TestClass()", 
+            "Default constructor", 
+            Collections.emptyList()
+        ));
+        
+        context.addComment(new CommentEntry(
+            "void initialize(String)", 
+            "Initialization method", 
+            Arrays.asList("config")
+        ));
+        
+        PropertyContextFormat.writeToFile(context, ctxtFile);
+        
+        CompilationUnitContext loadedContext = PropertyContextFormat.fromFile("TestClass", ctxtFile);
+
+        assertNotNull("Loaded context should not be null", loadedContext);
+        
+        // Verify the loaded context matches what was saved
+        assertEquals("Should have 2 comments", 2, loadedContext.getComments().size());
+        
+        CommentEntry entry0 = loadedContext.getComments().get(0);
+        assertEquals("TestClass()", entry0.getTarget());
+        assertEquals("Default constructor", entry0.getText());
+        assertEquals(0, entry0.getParamNames().size());
+        
+        CommentEntry entry1 = loadedContext.getComments().get(1);
+        assertEquals("void initialize(String)", entry1.getTarget());
+        assertEquals("Initialization method", entry1.getText());
+        assertEquals(1, entry1.getParamNames().size());
+        assertEquals("config", entry1.getParamNames().get(0));
+    }
+    
+    /**
+     * Test 5: Round-trip compatibility test
+     * Write with CompilationUnitContext, read with Properties, 
+     * then write with Properties and read with CompilationUnitContext
+     */
+    @Test
+    public void testRoundTripCompatibility() throws Exception {
+        // Step 1: Create and save with CompilationUnitContext
+        CompilationUnitContext context1 = CompilationUnitContext.writable("TestClass", ctxtFile);
+        context1.addComment(new CommentEntry(
+            "TestClass(String,int,boolean)", 
+            "Complex constructor", 
+            Arrays.asList("name", "value", "flag")
+        ));
+        PropertyContextFormat.writeToFile(context1, ctxtFile);
+        
+        // Step 2: Read with Properties
+        Properties props = new Properties();
+        try (InputStream in = new FileInputStream(ctxtFile)) {
+            props.load(in);
+        }
+        
+        // Verify Properties content
+        assertEquals("1", props.getProperty("numComments"));
+        assertEquals("TestClass(String,int,boolean)", props.getProperty("comment0.target"));
+        assertEquals("Complex constructor", props.getProperty("comment0.text"));
+        assertEquals("name value flag", props.getProperty("comment0.params"));
+        
+        // Step 3: Modify and save with Properties
+        props.setProperty("comment1.target", "void newMethod()");
+        props.setProperty("comment1.text", "Added method");
+        props.setProperty("numComments", "2");
+        
+        try (OutputStream out = new FileOutputStream(ctxtFile)) {
+            props.store(out, "Modified by Properties");
+        }
+        
+        // Step 4: Read with CompilationUnitContext
+        CompilationUnitContext context2 = PropertyContextFormat.fromFile("TestClass", ctxtFile);
+
+        assertNotNull("Context should not be null", context2);
+        
+        // Verify both comments are present
+        assertEquals("Should have 2 comments", 2, context2.getComments().size());
+        
+        CommentEntry entry0 = context2.getComments().get(0);
+        assertEquals("TestClass(String,int,boolean)", entry0.getTarget());
+        assertEquals("Complex constructor", entry0.getText());
+        assertEquals(3, entry0.getParamNames().size());
+        
+        CommentEntry entry1 = context2.getComments().get(1);
+        assertEquals("void newMethod()", entry1.getTarget());
+        assertEquals("Added method", entry1.getText());
+        assertEquals(0, entry1.getParamNames().size());
+    }
+    
+    /**
+     * Test 6: Error handling - malformed .ctxt file
+     */
+    @Test
+    public void testMalformedCtxtFileHandling() throws Exception {
+        // Create a malformed .ctxt file
+        try (PrintWriter writer = new PrintWriter(ctxtFile)) {
+            writer.println("This is not a valid properties file!");
+            writer.println("numComments = not_a_number");
+            writer.println("comment0.target missing equals");
+        }
+        
+        // Try to load it - should handle gracefully
+        CompilationUnitContext context = PropertyContextFormat.fromFile("TestClass", ctxtFile);
+
+        assertNotNull("Context should not be null", context);
+        
+        // Context should be empty or have partial data
+        assertNotNull("Context should not be null", context);
+        // The exact behavior depends on Properties.load() error handling
+    }
+    
+    /**
+     * Test 7: Performance test - large .ctxt file
+     */
+    @Test
+    public void testLargeCtxtFilePerformance() throws Exception {
+        // Create a large context with many comments
+        CompilationUnitContext context = CompilationUnitContext.writable("LargeClass", ctxtFile);
+        
+        int numComments = 100;
+        for (int i = 0; i < numComments; i++) {
+            List<String> params = new ArrayList<>();
+            for (int j = 0; j < 5; j++) {
+                params.add("param" + j);
+            }
+            
+            context.addComment(new CommentEntry(
+                "void method" + i + "(String,int,boolean,Object,List)",
+                "Method number " + i + " with multiple parameters",
+                params
+            ));
+        }
+        
+        // Measure save performance
+        long startSave = System.currentTimeMillis();
+        PropertyContextFormat.writeToFile(context, ctxtFile);
+        long saveDuration = System.currentTimeMillis() - startSave;
+        
+        assertTrue("Save should complete within reasonable time", saveDuration < 1000);
+        
+        // Measure load performance
+        long startLoad = System.currentTimeMillis();
+        CompilationUnitContext loadedContext = PropertyContextFormat.fromFile("LargeClass", ctxtFile);
+
+        assertNotNull("Context should not be null", loadedContext);
+        long loadDuration = System.currentTimeMillis() - startLoad;
+        
+        assertTrue("Load should complete within reasonable time", loadDuration < 1000);
+        assertEquals("Should load all comments", numComments, loadedContext.getComments().size());
+    }
+    
+    /**
+     * Test 8: Unicode and special characters handling
+     */
+    @Test
+    public void testUnicodeAndSpecialCharacters() throws Exception {
+        // Create context with Unicode and special characters
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", ctxtFile);
+        
+        context.addComment(new CommentEntry(
+            "void método()", 
+            "Method with Unicode: 日本語 中文 한국어 العربية"
+        ));
+        
+        context.addComment(new CommentEntry(
+            "String processText(String)", 
+            "Handles special chars: !@#$%^&*(){}[]|\\:;\"'<>,.?/", 
+            Arrays.asList("tëxt_with_ümläuts")
+        ));
+        
+        // Save and reload
+        PropertyContextFormat.writeToFile(context, ctxtFile);
+        
+        CompilationUnitContext loadedContext = PropertyContextFormat.fromFile("TestClass", ctxtFile);
+
+        assertNotNull("Context should not be null", loadedContext);
+        
+        // Verify Unicode and special characters are preserved
+        assertEquals(2, loadedContext.getComments().size());
+        
+        CommentEntry entry0 = loadedContext.getComments().get(0);
+        assertEquals("void método()", entry0.getTarget());
+        assertTrue(entry0.getText().contains("日本語"));
+        assertTrue(entry0.getText().contains("中文"));
+        
+        CommentEntry entry1 = loadedContext.getComments().get(1);
+        assertTrue(entry1.getText().contains("!@#$%^&*()"));
+        assertEquals("tëxt_with_ümläuts", entry1.getParamNames().get(0));
+    }
+}

--- a/bluej/src/test/java/bluej/parser/context/CompilationUnitContextLoaderTest.java
+++ b/bluej/src/test/java/bluej/parser/context/CompilationUnitContextLoaderTest.java
@@ -1,0 +1,181 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2025  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.*;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link CompilationUnitContextLoader} focusing on file versus
+ * classpath resolution behaviour.
+ */
+public class CompilationUnitContextLoaderTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void contextForClassLoadsFromPackageRoot() throws Exception {
+        File root = temp.newFolder("projectRoot");
+        File packageDir = new File(root, "example/app");
+        assertTrue(packageDir.mkdirs());
+
+        File ctxtFile = new File(packageDir, "Sample.ctxt");
+        Properties props = new Properties();
+        props.setProperty("numComments", "1");
+        props.setProperty("comment0.target", "void greet()");
+        props.setProperty("comment0.text", "Greets the user");
+        try (OutputStream out = new FileOutputStream(ctxtFile)) {
+            props.store(out, "test");
+        }
+
+        CompilationUnitContextLoader loader = new CompilationUnitContextLoader(ClassLoader.getSystemClassLoader(), true);
+        loader.addPackageRoot(root.toPath());
+
+        CompilationUnitContext context = loader.contextForClass("example.app.Sample");
+
+        assertNotNull("Context should not be null", context);
+        assertEquals("Expected one comment", 1, context.getComments().size());
+        assertEquals("void greet()", context.getComments().get(0).getTarget());
+        assertEquals("Greets the user", context.getComments().get(0).getText());
+
+        // Cached access should return the same instance when caching is enabled
+        assertSame("Context should be cached", context, loader.contextForClass("example.app.Sample"));
+    }
+
+    @Test
+    public void contextForClassFallsBackToResource() throws Exception {
+        final File resourceFile;
+
+        try {
+            Properties props = new Properties();
+            props.setProperty("numComments", "1");
+            props.setProperty("comment0.target", "int size()");
+            props.setProperty("comment0.text", "Returns size");
+
+
+            File root = temp.newFolder("resourceRoot");
+
+            File packageDir = new File(root, "cache/demo");
+            assertTrue(packageDir.mkdirs());
+
+            resourceFile = new File(packageDir, "List.ctxt");
+
+            props.store(new FileOutputStream(resourceFile), "test");
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+
+        ClassLoader resourceLoader = new ClassLoader(null) {
+            @Override
+            public URL getResource(String name) {
+                if ("cache/demo/List.ctxt".equals(name)) {
+                    try {
+                        return resourceFile.toURL();
+                    }
+                    catch (Exception e) {
+                        return null;
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        CompilationUnitContextLoader loader = new CompilationUnitContextLoader(resourceLoader, true);
+
+        CompilationUnitContext context = loader.contextForClass("cache.demo.List");
+        assertNotNull("Context should be loaded from resource", context);
+        assertEquals(1, context.getComments().size());
+        assertEquals("int size()", context.getComments().get(0).getTarget());
+        assertEquals("Returns size", context.getComments().get(0).getText());
+
+        // Ensure caching uses resource key (second call should reuse instance)
+        assertSame(context, loader.contextForClass("cache.demo.List"));
+    }
+
+    @Test
+    public void contextForClassWithClassObjectUsesPackageRoot() throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            // Skip test when compiler is not available (e.g. running on JRE)
+            return;
+        }
+
+        File root = temp.newFolder("compiledProject");
+        File sourceDir = new File(root, "sample");
+        assertTrue(sourceDir.mkdirs());
+
+        File sourceFile = new File(sourceDir, "LoaderSubject.java");
+        String source = "package sample; public class LoaderSubject { public void ping() {} }";
+        try (OutputStream out = new FileOutputStream(sourceFile)) {
+            out.write(source.getBytes(StandardCharsets.UTF_8));
+        }
+
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
+            Iterable<? extends javax.tools.JavaFileObject> units =
+                fileManager.getJavaFileObjectsFromFiles(Arrays.asList(sourceFile));
+            boolean success = compiler.getTask(null, fileManager, null,
+                Arrays.asList("-d", root.getAbsolutePath()), null, units).call();
+            assertTrue("Compilation should succeed", success);
+        }
+
+        // Create corresponding ctxt file next to compiled class
+        File ctxtFile = new File(sourceDir, "LoaderSubject.ctxt");
+        Properties props = new Properties();
+        props.setProperty("numComments", "1");
+        props.setProperty("comment0.target", "void ping()");
+        props.setProperty("comment0.text", "Ping method");
+        try (OutputStream out = new FileOutputStream(ctxtFile)) {
+            props.store(out, "compiled");
+        }
+
+        try (URLClassLoader urlClassLoader = new URLClassLoader(new URL[] { root.toURI().toURL() }, null)) {
+            Class<?> clazz = Class.forName("sample.LoaderSubject", true, urlClassLoader);
+
+            CompilationUnitContextLoader loader = new CompilationUnitContextLoader(urlClassLoader, true);
+            loader.addPackageRoot(root.toPath());
+
+            CompilationUnitContext context = loader.contextForClass(clazz);
+            assertNotNull(context);
+            assertEquals(1, context.getComments().size());
+            assertEquals("void ping()", context.getComments().get(0).getTarget());
+            assertEquals("Ping method", context.getComments().get(0).getText());
+        }
+    }
+}
+
+

--- a/bluej/src/test/java/bluej/parser/context/CompilationUnitContextTest.java
+++ b/bluej/src/test/java/bluej/parser/context/CompilationUnitContextTest.java
@@ -1,0 +1,150 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2025  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import static org.junit.Assert.*;
+import java.io.*;
+import java.util.*;
+
+/**
+ * Test class for CompilationUnitContext to verify backwards compatibility
+ * with existing .ctxt file format.
+ */
+public class CompilationUnitContextTest {
+    
+    private File testCtxtFile;
+    
+    @Before
+    public void setUp() throws IOException {
+        testCtxtFile = File.createTempFile("test", ".ctxt");
+        testCtxtFile.deleteOnExit();
+    }
+    
+    @After
+    public void tearDown() {
+        if (testCtxtFile != null && testCtxtFile.exists()) {
+            testCtxtFile.delete();
+        }
+    }
+    
+    /**
+     * Test backwards compatibility: reading old format .ctxt files
+     * created with Properties.store()
+     */
+    @Test
+    public void testBackwardsCompatibilityRead() throws IOException {
+        // Create a .ctxt file in the old format using Properties
+        Properties oldProps = new Properties();
+        oldProps.setProperty("numComments", "2");
+        oldProps.setProperty("comment0.target", "void test()");
+        oldProps.setProperty("comment0.text", "Test method");
+        oldProps.setProperty("comment1.target", "TestClass(int,String)");
+        oldProps.setProperty("comment1.text", "Constructor");
+        oldProps.setProperty("comment1.params", "value name");
+        
+        try (OutputStream out = new FileOutputStream(testCtxtFile)) {
+            oldProps.store(out, "BlueJ class context");
+        }
+        
+        // Read it using CompilationUnitContext
+        CompilationUnitContext context = PropertyContextFormat.fromFile("TestClass", testCtxtFile);
+
+        assertNotNull("Context should not be null", context);
+
+        // Verify the data was loaded correctly
+        assertEquals("Should have 2 comments", 2, context.getComments().size());
+        
+        CommentEntry entry0 = context.getComments().get(0);
+        assertEquals("void test()", entry0.getTarget());
+        assertEquals("Test method", entry0.getText());
+        assertEquals(0, entry0.getParamNames().size());
+        
+        CommentEntry entry1 = context.getComments().get(1);
+        assertEquals("TestClass(int,String)", entry1.getTarget());
+        assertEquals("Constructor", entry1.getText());
+        assertEquals(2, entry1.getParamNames().size());
+        assertEquals("value", entry1.getParamNames().get(0));
+        assertEquals("name", entry1.getParamNames().get(1));
+    }
+    
+    /**
+     * Test backwards compatibility: writing .ctxt files 
+     * that can be read by old Properties.load()
+     */
+    @Test
+    public void testBackwardsCompatibilityWrite() throws IOException {
+        // Create context with data
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", testCtxtFile);
+        context.addComment(new CommentEntry(
+            "void test()", "Test method"));
+        context.addComment(new CommentEntry(
+            "TestClass(int,String)", "Constructor", 
+            Arrays.asList("value", "name")));
+        
+        // Save using CompilationUnitContext
+        PropertyContextFormat.writeToFile(context, testCtxtFile);
+        
+        // Read it back using old Properties method
+        Properties readProps = new Properties();
+        try (InputStream in = new FileInputStream(testCtxtFile)) {
+            readProps.load(in);
+        }
+        
+        // Verify the format is compatible
+        assertEquals("2", readProps.getProperty("numComments"));
+        assertEquals("void test()", readProps.getProperty("comment0.target"));
+        assertEquals("Test method", readProps.getProperty("comment0.text"));
+        assertEquals("TestClass(int,String)", readProps.getProperty("comment1.target"));
+        assertEquals("Constructor", readProps.getProperty("comment1.text"));
+        assertEquals("value name", readProps.getProperty("comment1.params"));
+    }
+    
+    /**
+     * Test that empty/missing files are handled gracefully
+     */
+    @Test
+    public void testEmptyFile() throws IOException {
+        File emptyFile = File.createTempFile("empty", ".ctxt");
+        emptyFile.deleteOnExit();
+        
+        CompilationUnitContext context = PropertyContextFormat.fromFile("TestClass", emptyFile);
+
+        assertNotNull("Context should not be null", context);
+        assertTrue("Should have no comments", context.isEmpty());
+        assertEquals(0, context.getComments().size());
+    }
+    
+    /**
+     * Test that non-existent files are handled gracefully
+     */
+    @Test
+    public void testNonExistentFile() throws IOException {
+        File nonExistent = new File("non_existent_file.ctxt");
+        
+        CompilationUnitContext context = PropertyContextFormat.fromFile("TestClass", nonExistent);
+
+        assertNull("Context should be null", context);
+    }
+}

--- a/bluej/src/test/java/bluej/parser/context/CtxtFileCompatibilityTest.java
+++ b/bluej/src/test/java/bluej/parser/context/CtxtFileCompatibilityTest.java
@@ -1,0 +1,299 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2025  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+*/
+package bluej.parser.context;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.Assert.*;
+import java.io.*;
+import java.util.*;
+
+/**
+ * Test to verify .ctxt file format compatibility between old and new implementations.
+ * This test creates actual .ctxt files and verifies they maintain the exact format
+ * expected by BlueJ.
+ */
+public class CtxtFileCompatibilityTest {
+    
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    
+    private File testCtxtFile;
+    
+    @Before
+    public void setUp() throws IOException {
+        testCtxtFile = tempFolder.newFile("TestClass.ctxt");
+    }
+    
+    /**
+     * Test that we can read actual BlueJ .ctxt file format
+     */
+    @Test
+    public void testReadActualBlueJFormat() throws IOException {
+        // Create a .ctxt file in the actual BlueJ format
+        String actualBlueJContent = 
+            "#BlueJ class context\n" +
+            "comment0.target=TestClass\n" +
+            "comment0.text=\\\n" +
+            "\\ TestClass\\ is\\ a\\ sample\\ class\\ for\\ testing.\\\n" +
+            "\\ It\\ demonstrates\\ various\\ features.\\\n" +
+            "\\ \n" +
+            "comment1.params=x\\ y\n" +
+            "comment1.target=TestClass(int,\\ int)\n" + 
+            "comment1.text=\\\n" +
+            "\\ Constructor\\ for\\ objects\\ of\\ class\\ TestClass\\\n" +
+            "\\ @param\\ x\\ the\\ x\\ coordinate\\\n" +
+            "\\ @param\\ y\\ the\\ y\\ coordinate\\\n" +
+            "\\ \n" +
+            "comment2.params=\n" +
+            "comment2.target=int\\ sampleMethod()\n" +
+            "comment2.text=\\\n" +
+            "\\ An\\ example\\ of\\ a\\ method\\ -\\ replace\\ this\\ comment\\ with\\ your\\ own\\\n" +
+            "\\ \n" +
+            "comment3.params=y\n" +
+            "comment3.target=int\\ anotherMethod(int)\n" +
+            "comment3.text=\\\n" +
+            "\\ Another\\ method\\ with\\ parameter\\\n" +
+            "\\ @param\\ y\\ a\\ sample\\ parameter\\ for\\ this\\ method\\\n" +
+            "\\ @return\\ the\\ sum\\ of\\ x\\ and\\ y\\\n" +
+            "\\ \n" +
+            "numComments=4\n";
+        
+        try (PrintWriter writer = new PrintWriter(testCtxtFile)) {
+            writer.write(actualBlueJContent);
+        }
+        
+        // Load using CompilationUnitContext
+        CompilationUnitContext context = PropertyContextFormat.fromFile("TestClass", testCtxtFile);
+
+        assertNotNull("Context should not be null", context);
+        
+        // Verify all comments were loaded correctly
+        assertEquals("Should have 4 comments", 4, context.getComments().size());
+        
+        // Verify class comment
+        CommentEntry classComment = context.getComments().get(0);
+        assertEquals("TestClass", classComment.getTarget());
+        assertTrue("Class comment should contain description", 
+            classComment.getText().contains("sample class for testing"));
+        
+        // Verify constructor comment
+        CommentEntry constructorComment = context.getComments().get(1);
+        assertEquals("TestClass(int, int)", constructorComment.getTarget());
+        assertEquals(2, constructorComment.getParamNames().size());
+        assertEquals("x", constructorComment.getParamNames().get(0));
+        assertEquals("y", constructorComment.getParamNames().get(1));
+        assertTrue("Constructor comment should contain param descriptions",
+            constructorComment.getText().contains("x coordinate"));
+        
+        // Verify method comments
+        CommentEntry method1 = context.getComments().get(2);
+        assertEquals("int sampleMethod()", method1.getTarget());
+        assertEquals(0, method1.getParamNames().size());
+        
+        CommentEntry method2 = context.getComments().get(3);
+        assertEquals("int anotherMethod(int)", method2.getTarget());
+        assertEquals(1, method2.getParamNames().size());
+        assertEquals("y", method2.getParamNames().get(0));
+    }
+    
+    /**
+     * Test that we generate the correct format when saving
+     */
+    @Test
+    public void testWriteCorrectFormat() throws IOException {
+        // Create a context with typical BlueJ content
+        CompilationUnitContext context = CompilationUnitContext.writable("MyClass", testCtxtFile);
+        
+        // Add class comment
+        context.addComment(new CommentEntry(
+            "MyClass",
+            "MyClass represents a sample object in BlueJ.\n" +
+            "This is a multi-line comment that explains the class.\n",
+            Collections.emptyList()
+        ));
+        
+        // Add constructor comment
+        context.addComment(new CommentEntry(
+            "MyClass(String, int)",
+            "Constructor for MyClass\n" +
+            "@param name The name of the object\n" +
+            "@param value The initial value\n",
+            Arrays.asList("name", "value")
+        ));
+        
+        // Add method comments
+        context.addComment(new CommentEntry(
+            "void doSomething()",
+            "Method that performs an action",
+            Collections.emptyList()
+        ));
+        
+        context.addComment(new CommentEntry(
+            "String getName()",
+            "Returns the name of this object\n" +
+            "@return the name",
+            Collections.emptyList()
+        ));
+        
+        context.addComment(new CommentEntry(
+            "boolean validate(String, int, boolean)",
+            "Validates the object state\n" +
+            "@param input The input to validate\n" +
+            "@param threshold The threshold value\n" +
+            "@param strict Whether to use strict validation\n" +
+            "@return true if valid, false otherwise",
+            Arrays.asList("input", "threshold", "strict")
+        ));
+        
+        // Save the context
+        PropertyContextFormat.writeToFile(context, testCtxtFile);
+        
+        // Read the file as Properties to verify format
+        Properties props = new Properties();
+        try (InputStream in = new FileInputStream(testCtxtFile)) {
+            props.load(in);
+        }
+        
+        // Verify the Properties format
+        assertEquals("5", props.getProperty("numComments"));
+        
+        // Check class comment
+        assertEquals("MyClass", props.getProperty("comment0.target"));
+        assertNotNull(props.getProperty("comment0.text"));
+        
+        // Check constructor
+        assertEquals("MyClass(String, int)", props.getProperty("comment1.target"));
+        assertEquals("name value", props.getProperty("comment1.params"));
+        assertNotNull(props.getProperty("comment1.text"));
+        
+        // Check methods
+        assertEquals("void doSomething()", props.getProperty("comment2.target"));
+        assertNull(props.getProperty("comment2.params")); // No params
+        
+        assertEquals("String getName()", props.getProperty("comment3.target"));
+        assertNull(props.getProperty("comment3.params")); // No params
+        
+        assertEquals("boolean validate(String, int, boolean)", props.getProperty("comment4.target"));
+        assertEquals("input threshold strict", props.getProperty("comment4.params"));
+        assertNotNull(props.getProperty("comment4.text"));
+    }
+    
+    /**
+     * Test handling of escape sequences in Properties format
+     */
+    @Test
+    public void testEscapeSequenceHandling() throws IOException {
+        // Create content with special characters that need escaping in Properties
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", testCtxtFile);
+        
+        context.addComment(new CommentEntry(
+            "void test()",
+            "Method with special chars: = : \\ \n" +
+            "New line above, tab\there, and unicode \\u0041",
+            Collections.emptyList()
+        ));
+        
+        PropertyContextFormat.writeToFile(context, testCtxtFile);
+        
+        // Read back
+        CompilationUnitContext loaded = PropertyContextFormat.fromFile("TestClass", testCtxtFile);
+
+        assertNotNull("Context should not be null", testCtxtFile);
+        
+        assertEquals(1, loaded.getComments().size());
+        CommentEntry entry = loaded.getComments().get(0);
+        
+        // Properties should handle escaping automatically
+        assertTrue("Should preserve special characters", 
+            entry.getText().contains("special chars"));
+    }
+    
+    /**
+     * Test that empty params are handled correctly (no params property written)
+     */
+    @Test
+    public void testEmptyParamsHandling() throws IOException {
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", testCtxtFile);
+        
+        // Method with no parameters
+        context.addComment(new CommentEntry(
+            "void noParams()",
+            "Method with no parameters"
+        ));
+
+        // Method with empty list
+        context.addComment(new CommentEntry(
+            "void emptyList()",
+            "Method with empty param list",
+            Collections.emptyList() // empty list
+        ));
+        
+        // Method with parameters
+        context.addComment(new CommentEntry(
+            "void withParams(int, String)",
+            "Method with parameters",
+            Arrays.asList("value", "text")
+        ));
+        
+        PropertyContextFormat.writeToFile(context, testCtxtFile);
+        
+        // Verify the file content
+        Properties props = new Properties();
+        try (InputStream in = new FileInputStream(testCtxtFile)) {
+            props.load(in);
+        }
+        
+        // No params property should be written for methods without parameters
+        assertNull("Should not have params property for first method", 
+            props.getProperty("comment0.params"));
+        assertNull("Should not have params property for second method", 
+            props.getProperty("comment1.params"));
+        assertEquals("value text", props.getProperty("comment2.params"));
+    }
+    
+    /**
+     * Test compatibility with BlueJ's actual file header
+     */
+    @Test
+    public void testFileHeaderCompatibility() throws IOException {
+        CompilationUnitContext context = CompilationUnitContext.writable("TestClass", testCtxtFile);
+        context.addComment(new CommentEntry(
+            "TestClass",
+            "A test class",
+            Collections.emptyList()
+        ));
+        PropertyContextFormat.writeToFile(context, testCtxtFile);
+        
+        // Read the file content
+        String content;
+        try (BufferedReader reader = new BufferedReader(new FileReader(testCtxtFile))) {
+            content = reader.readLine();
+        }
+        
+        // Should start with the BlueJ header
+        assertTrue("File should start with BlueJ header", 
+            content.startsWith("#BlueJ class context"));
+    }
+}

--- a/bluej/src/test/java/bluej/parser/context/TestClassLoaderProvider.java
+++ b/bluej/src/test/java/bluej/parser/context/TestClassLoaderProvider.java
@@ -1,0 +1,174 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2024  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.parser.context;
+
+import bluej.classmgr.BPClassLoader;
+
+import java.io.File;
+import java.net.URL;
+
+/**
+ * Test implementation of ClassLoaderProvider for unit testing.
+ * 
+ * This helper class allows tests to inject custom ClassLoader and project directory
+ * configurations without requiring a full Project instance.
+ */
+public class TestClassLoaderProvider implements ClassLoaderProvider
+{
+    private final BPClassLoader classLoader;
+    private final File projectDir;
+    
+    /**
+     * Creates a test ClassLoaderProvider with the specified ClassLoader and project directory.
+     * 
+     * @param classLoader The ClassLoader to use for class resolution
+     * @param projectDir  The project directory root
+     */
+    public TestClassLoaderProvider(BPClassLoader classLoader, File projectDir)
+    {
+        if (classLoader == null) {
+            throw new IllegalArgumentException("ClassLoader cannot be null");
+        }
+        if (projectDir == null) {
+            throw new IllegalArgumentException("Project directory cannot be null");
+        }
+        
+        this.classLoader = classLoader;
+        this.projectDir = projectDir;
+    }
+    
+    /**
+     * Creates a test ClassLoaderProvider with a default ClassLoader using the specified
+     * project directory and system classpath.
+     * 
+     * @param projectDir The project directory root
+     */
+    public TestClassLoaderProvider(File projectDir)
+    {
+        this(createDefaultClassLoader(projectDir), projectDir);
+    }
+    
+    @Override
+    public BPClassLoader getClassLoader()
+    {
+        return classLoader;
+    }
+    
+    @Override
+    public File getProjectDir()
+    {
+        return projectDir;
+    }
+    
+    /**
+     * Creates a default BPClassLoader for testing purposes.
+     * 
+     * @param projectDir The project directory to use as a classpath root
+     * @return A new BPClassLoader instance configured for testing
+     */
+    private static BPClassLoader createDefaultClassLoader(File projectDir)
+    {
+        if (projectDir == null) {
+            throw new IllegalArgumentException("Project directory cannot be null");
+        }
+        
+        // Create a basic BPClassLoader with the project directory in the classpath
+        URL[] urls = new URL[] { };  // Empty URLs for basic testing
+        return new BPClassLoader(urls, TestClassLoaderProvider.class.getClassLoader());
+    }
+    
+    /**
+     * Builder class for creating TestClassLoaderProvider instances with various configurations.
+     */
+    public static class Builder
+    {
+        private BPClassLoader classLoader;
+        private File projectDir;
+        private File[] additionalClasspaths;
+        
+        public Builder projectDir(File projectDir)
+        {
+            this.projectDir = projectDir;
+            return this;
+        }
+        
+        public Builder projectDir(String projectDirPath)
+        {
+            this.projectDir = new File(projectDirPath);
+            return this;
+        }
+        
+        /**
+         * Configures the Builder to use a ClassLoader that can load resources from the specified path.
+         * Creates a BPClassLoader internally with the given path as a classpath entry.
+         *
+         * @param resourcePath Path to the resource directory (will be converted to a URL)
+         * @return This Builder instance for method chaining
+         */
+        public Builder withResource(String resourcePath)
+        {
+            return withResource(new File(resourcePath));
+        }
+        
+        /**
+         * Configures the Builder to use a ClassLoader that can load resources from the specified path.
+         * Creates a BPClassLoader internally with the given path as a classpath entry.
+         *
+         * @param resourcePath Path to the resource directory (as a File)
+         * @return This Builder instance for method chaining
+         */
+        public Builder withResource(File resourcePath)
+        {
+            try {
+                URL resourceUrl = resourcePath.toURI().toURL();
+                this.classLoader = new BPClassLoader(
+                    new URL[] { resourceUrl },
+                    TestClassLoaderProvider.class.getClassLoader()
+                );
+                return this;
+            } catch (java.net.MalformedURLException e) {
+                throw new IllegalArgumentException("Invalid resource path: " + resourcePath, e);
+            }
+        }
+        
+        public Builder withAdditionalClasspaths(File... paths)
+        {
+            this.additionalClasspaths = paths;
+            return this;
+        }
+        
+        public TestClassLoaderProvider build()
+        {
+            if (projectDir == null) {
+                throw new IllegalStateException("Project directory must be specified");
+            }
+            
+            if (classLoader == null) {
+                // Create a ClassLoader with additional classpaths if specified
+                // For test purposes, create a simple BPClassLoader
+                classLoader = createDefaultClassLoader(projectDir);
+            }
+            
+            return new TestClassLoaderProvider(classLoader, projectDir);
+        }
+    }
+}

--- a/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/GreenfootStage.java
@@ -1830,7 +1830,7 @@ public class GreenfootStage extends Stage implements FXCompileObserver,
                         if (target instanceof ClassTarget)
                         {
                             Menu menu = new Menu(namesForActors[i].getName() + ":" + actor.getClassName());
-                            ObjectWrapper.createMethodMenuItems(menu.getItems(), project.loadClass(actor.getClassName()), new RecordInvoke(actor), "", true);
+                            ObjectWrapper.createMethodMenuItems(menu.getItems(), project, project.loadClass(actor.getClassName()), new RecordInvoke(actor), "", true);
                             menu.getItems().add(makeInspectMenuItem(actor, namesForActors[i].getName()));
                             //add a listener to the action event on the items in the sub-menu to hide the context menus
                             for (MenuItem menuItem : menu.getItems())
@@ -1879,7 +1879,7 @@ public class GreenfootStage extends Stage implements FXCompileObserver,
                         contextMenu.setOnHidden(e -> {
                             contextMenu = null;
                         });
-                        ObjectWrapper.createMethodMenuItems(contextMenu.getItems(),
+                        ObjectWrapper.createMethodMenuItems(contextMenu.getItems(), project,
                                 project.loadClass(world.getClassName()), new RecordInvoke(world), "", true);
                         contextMenu.getItems().add(makeInspectMenuItem(world, debugHandler.nameObjects(List.of(world))[0].getName()));
                         

--- a/greenfoot/src/main/java/greenfoot/guifx/classes/GClassDiagram.java
+++ b/greenfoot/src/main/java/greenfoot/guifx/classes/GClassDiagram.java
@@ -95,7 +95,7 @@ public class GClassDiagram extends BorderPane
                     // Can't load class, so rule it out:
                     return null;
                 }
-                View view = View.getView(cl);
+                View view = View.getView(cl, project);
 
                 // Needs to be non-abstract to instantiate:
                 if (!java.lang.reflect.Modifier.isAbstract(cl.getModifiers()))


### PR DESCRIPTION
Sorry that I didn't get it out last week, but between various distractions, ending up with too convoluted code and minor issues with the code, this slipped up until weekend and I had time to clean this up only now.

This should now consolidate all the data handling in one place and can be merged as-is — further work will be done on the Kotlin branch (possibly as a separate PR to that branch first), as the next step is to support Kotlin here. As mentioned I eventually want to serialise objects properly, put depending on how simple the first use-case will be, I might still keep it as properties initially. Hopefully this should go faster, now that this is in place.

I'll leave any questions that I had as comments, but I think the biggest one is how I've "solved" the thread checker issue.