### PR TITLE
Add support for building flatpak from source

### DIFF
--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -201,6 +201,17 @@ task packageBlueJLinux(type: Exec) {
 }
 packageBlueJLinux.dependsOn assemble
 
+task packageBlueJPreDist(type: Exec) {
+    workingDir "package"
+    commandLine toolProps["ant_exe"], "pre-dist", "-Dmingw_jdk=",
+            "-Dbuild_java_home=" + System.getProperty('java.home'),
+            "-Ddeb_bundled_jdk_path=" + System.getProperty('java.home'),
+            "-Dbluej.version=" + bluejVersion,
+            "-Dbluej.rcsuffix=" + bluejRCSuffix,
+            "-Dbluej_home=" + projectDir.getAbsoluteFile()
+}
+packageBlueJPreDist.dependsOn assemble
+
 task urlsRC(type: Exec) {
     workingDir "package"
     commandLine toolProps["ant_exe"], "-S", "urls-rc",

--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java-library'
 	id 'org.openjfx.javafxplugin'
 	id 'application'
+	id 'io.github.jwharm.flatpak-gradle-generator' version '1.6.0'
 }
 
 dependencies {
@@ -41,6 +42,15 @@ dependencies {
     testImplementation 'org.testfx:testfx-junit:4.0.15-alpha'
     testImplementation 'org.testfx:openjfx-monocle:21.0.2'
     testImplementation 'junit:junit:4.13.2'
+}
+
+tasks.flatpakGradleGenerator {
+    def out = "${rootDir.absolutePath}/${flatpakDir}/dependencies.json"
+    description = "Collect dependencies for Flatpak"
+    outputFile = file(out)
+    downloadDirectory = "./offline-repository"
+    doFirst { println "Generating dependencies.json for flatpak in " + out}
+    doLast { println "Generated dependencies.json for flatpak" }
 }
 
 compileJava {
@@ -85,6 +95,10 @@ test {
 }
 
 repositories {
+    maven {
+        name 'Offline repository for flatpak'
+        url '../offline-repository'
+    }
     mavenCentral()
 }
 

--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'java-library'
-apply plugin: 'org.openjfx.javafxplugin'
-apply plugin: 'application'
+plugins {
+	id 'java-library'
+	id 'org.openjfx.javafxplugin'
+	id 'application'
+}
 
 dependencies {
     annotationProcessor project(':anns-threadchecker')

--- a/boot/build.gradle
+++ b/boot/build.gradle
@@ -9,6 +9,10 @@ dependencies {
 }
 
 repositories {
+    maven {
+        name 'Offline repository for flatpak'
+        url '../offline-repository'
+    }
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,15 @@
 plugins {
     id 'org.openjfx.javafxplugin' version '0.1.0' apply false
 }
+
+repositories {
+    maven {
+        name 'Offline repository for flatpak'
+        url './offline-repository'
+    }
+    mavenCentral()
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
     options.release = 21

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# for flatpakGradleGenerator: output directory where
+# https://github.com/flathub/org.bluej.BlueJ is checked out
+flatpakDir=../org.bluej.BlueJ

--- a/greenfoot/build.gradle
+++ b/greenfoot/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 }
 
 repositories {
+    maven {
+        name 'Offline repository for flatpak'
+        url '../offline-repository'
+    }
     mavenCentral()
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,9 @@
+pluginManagement {
+  repositories {
+    maven { url="offline-repository" }
+    gradlePluginPortal()
+  }
+}
 rootProject.name = 'bluej-greenfoot'
 include(':anns-threadchecker')
 include(':boot')


### PR DESCRIPTION
Currently BlueJ for Linux is only avaiable as `.deb` file for Ubuntu / Debian, which is not useful for users of non-Debian distirbutions such as Fedora, openSUSE or Arch. 

A [flatpak](https://github.com/flathub/org.bluej.BlueJ) package exists, but is hasn't been updated for several years and is still at version 5.2.1. Also, the flatpak package simply re-packages the BlueJ binary, which is not state of the art for flatpak. It is better to build the application from source in flatpak-builder.

This PR provides the means for creating an improved flatpak package, which would also be much easier to update. It adds the [flatpak-gradle-generator](https://github.com/jwharm/flatpak-gradle-generator) gradle plugin, obtains a list of all build dependencies automatically. This list is written to a file `dependencies.json`, which can directly be added to the Flatpak manifest. flatpak-builder downloads all files to a local cache, from which it can be pulled in by gradle when the application is built. To make this work, the local repository path is added to `settings.gradle` and `build.gradle`.

Note that because flatpak-builder needs to pull from official git repositories, this PR temporarily uses my fork of the k-pet-group/BlueJ-Greenfoot repo as git source (if the sources were pulled from the official repository, the flatpak build would fail without the `build.gradle` modifications). A final PR would of course use the official repositiory again.

To see how the resulting flathub repository would look like, check out [my fork](https://github.com/mwilck/org.bluej.BlueJ) of the org.bluej.BlueJ flathub repository. I also added a Workflow to build the flatpak package. A BlueJ 5.5 flatpak can be obtained from the [workflow run page](https://github.com/mwilck/org.bluej.BlueJ/actions/runs/21787631461).