### PR TITLE
Threadchecker lambda support

### DIFF
--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testImplementation 'org.testfx:testfx-core:4.0.15-alpha'
     testImplementation 'org.testfx:testfx-junit:4.0.15-alpha'
     testImplementation 'org.testfx:openjfx-monocle:21.0.2'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
 }
 
 compileJava {

--- a/bluej/src/main/java/bluej/utility/javafx/BiConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/BiConsumerThrowing.java
@@ -31,7 +31,7 @@ import threadchecker.Tag;
  * <p>This interface is used as the non-thread-annotated base for
  * {@link FXPlatformBiConsumerThrowing} and {@link FXBiConsumerThrowing},
  * enabling exception-propagating lambdas to be passed to
- * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * {@link JavaFXUtil#runPlatformAndWait} and {@link JavaFXUtil#runPlatformFuture}
  * without requiring callers to wrap checked exceptions manually.</p>
  *
  * @param <T> the type of the first argument to the operation

--- a/bluej/src/main/java/bluej/utility/javafx/BiConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/BiConsumerThrowing.java
@@ -1,0 +1,54 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A thread-agnostic variant of {@link java.util.function.BiConsumer} whose
+ * {@link #accept(Object, Object)} method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is used as the non-thread-annotated base for
+ * {@link FXPlatformBiConsumerThrowing} and {@link FXBiConsumerThrowing},
+ * enabling exception-propagating lambdas to be passed to
+ * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * without requiring callers to wrap checked exceptions manually.</p>
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ * @see FXPlatformBiConsumerThrowing
+ * @see FXBiConsumerThrowing
+ */
+@FunctionalInterface
+public interface BiConsumerThrowing<T, U>
+{
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t the first input argument
+     * @param u the second input argument
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.Any)
+    void accept(T t, U u) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/BiFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/BiFunctionThrowing.java
@@ -31,7 +31,7 @@ import threadchecker.Tag;
  * <p>This interface is used as the non-thread-annotated base for
  * {@link FXPlatformBiFunctionThrowing} and {@link FXBiFunctionThrowing},
  * enabling exception-propagating lambdas to be passed to
- * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * {@link JavaFXUtil#runPlatformAndWait} and {@link JavaFXUtil#runPlatformFuture}
  * without requiring callers to wrap checked exceptions manually.</p>
  *
  * @param <T> the type of the first argument to the function

--- a/bluej/src/main/java/bluej/utility/javafx/BiFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/BiFunctionThrowing.java
@@ -1,0 +1,56 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A thread-agnostic variant of {@link java.util.function.BiFunction} whose
+ * {@link #apply(Object, Object)} method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is used as the non-thread-annotated base for
+ * {@link FXPlatformBiFunctionThrowing} and {@link FXBiFunctionThrowing},
+ * enabling exception-propagating lambdas to be passed to
+ * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * without requiring callers to wrap checked exceptions manually.</p>
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <R> the type of the result of the function
+ * @see FXPlatformBiFunctionThrowing
+ * @see FXBiFunctionThrowing
+ */
+@FunctionalInterface
+public interface BiFunctionThrowing<T, U, R>
+{
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @return the function result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.Any)
+    R apply(T t, U u) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/ConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/ConsumerThrowing.java
@@ -31,7 +31,7 @@ import threadchecker.Tag;
  * <p>This interface is used as the non-thread-annotated base for
  * {@link FXPlatformConsumerThrowing} and {@link FXConsumerThrowing},
  * enabling exception-propagating lambdas to be passed to
- * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * {@link JavaFXUtil#runPlatformAndWait} and {@link JavaFXUtil#runPlatformFuture}
  * without requiring callers to wrap checked exceptions manually.</p>
  *
  * @param <T> the type of the input to the operation

--- a/bluej/src/main/java/bluej/utility/javafx/ConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/ConsumerThrowing.java
@@ -1,0 +1,52 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A thread-agnostic variant of {@link java.util.function.Consumer} whose
+ * {@link #accept(Object)} method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is used as the non-thread-annotated base for
+ * {@link FXPlatformConsumerThrowing} and {@link FXConsumerThrowing},
+ * enabling exception-propagating lambdas to be passed to
+ * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * without requiring callers to wrap checked exceptions manually.</p>
+ *
+ * @param <T> the type of the input to the operation
+ * @see FXPlatformConsumerThrowing
+ * @see FXConsumerThrowing
+ */
+@FunctionalInterface
+public interface ConsumerThrowing<T>
+{
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.Any)
+    void accept(T t) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXBiConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXBiConsumerThrowing.java
@@ -1,0 +1,53 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXBiConsumer} whose {@link #accept(Object, Object)}
+ * method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FX)}, indicating
+ * that its method is intended for use on the broader FX thread. Unlike
+ * {@link FXBiConsumer}, checked exceptions are propagated.</p>
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ * @see FXBiConsumer
+ * @see FXPlatformBiConsumerThrowing
+ * @see BiConsumerThrowing
+ */
+@FunctionalInterface
+public interface FXBiConsumerThrowing<T, U>
+{
+    /**
+     * Performs this operation on the given arguments on the FX thread.
+     *
+     * @param t the first input argument
+     * @param u the second input argument
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FX)
+    void accept(T t, U u) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXBiFunction.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXBiFunction.java
@@ -1,0 +1,53 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * Equivalent to {@link java.util.function.BiFunction}, but clearer (including
+ * to the thread-checker plugin) that it runs on the FX thread.
+ *
+ * <p>This is the {@code Tag.FX}-scoped counterpart of
+ * {@link FXPlatformBiFunction}, following the same relationship pattern as
+ * {@link FXFunction} to {@link FXPlatformFunction}.</p>
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <R> the type of the result of the function
+ * @see FXPlatformBiFunction
+ * @see FXBiFunctionThrowing
+ */
+@FunctionalInterface
+public interface FXBiFunction<T, U, R>
+{
+    /**
+     * Applies this function to the given arguments on the FX thread.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @return the function result
+     */
+    @OnThread(Tag.FX)
+    R apply(T t, U u);
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXBiFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXBiFunctionThrowing.java
@@ -1,0 +1,55 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXBiFunction} whose {@link #apply(Object, Object)}
+ * method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FX)}, indicating
+ * that its method is intended for use on the broader FX thread. Unlike
+ * {@link FXBiFunction}, checked exceptions are propagated.</p>
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <R> the type of the result of the function
+ * @see FXBiFunction
+ * @see FXPlatformBiFunctionThrowing
+ * @see BiFunctionThrowing
+ */
+@FunctionalInterface
+public interface FXBiFunctionThrowing<T, U, R>
+{
+    /**
+     * Applies this function to the given arguments on the FX thread.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @return the function result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FX)
+    R apply(T t, U u) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXConsumerThrowing.java
@@ -1,0 +1,51 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXConsumer} whose {@link #accept(Object)} method is
+ * permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FX)}, indicating
+ * that its method is intended for use on the broader FX thread. Unlike
+ * {@link FXConsumer}, checked exceptions are propagated.</p>
+ *
+ * @param <T> the type of the input to the operation
+ * @see FXConsumer
+ * @see FXPlatformConsumerThrowing
+ * @see ConsumerThrowing
+ */
+@FunctionalInterface
+public interface FXConsumerThrowing<T>
+{
+    /**
+     * Performs this operation on the given argument on the FX thread.
+     *
+     * @param t the input argument
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FX)
+    void accept(T t) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXFunctionThrowing.java
@@ -1,0 +1,53 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXFunction} whose {@link #apply(Object)} method is
+ * permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FX)}, indicating
+ * that its method is intended for use on the broader FX thread. Unlike
+ * {@link FXFunction}, checked exceptions are propagated.</p>
+ *
+ * @param <FROM> the type of the input to the function
+ * @param <TO>   the type of the result of the function
+ * @see FXFunction
+ * @see FXPlatformFunctionThrowing
+ * @see FunctionThrowing
+ */
+@FunctionalInterface
+public interface FXFunctionThrowing<FROM, TO>
+{
+    /**
+     * Applies this function to the given argument on the FX thread.
+     *
+     * @param x the function argument
+     * @return the function result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FX)
+    TO apply(FROM x) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiConsumerThrowing.java
@@ -1,0 +1,60 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXPlatformBiConsumer} whose {@link #accept(Object, Object)}
+ * method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FXPlatform)},
+ * indicating that its method must be called on the JavaFX application thread.
+ * Unlike {@link FXPlatformBiConsumer}, checked exceptions are propagated rather
+ * than requiring the implementor to handle them internally.</p>
+ *
+ * <p>Primary use case: passing exception-throwing lambdas to
+ * {@link JavaFXUtil#runPlatform(FXPlatformBiConsumerThrowing, Object, Object)} and
+ * {@link JavaFXUtil#runPlatformFuture(FXPlatformBiConsumerThrowing, Object, Object)},
+ * which schedule execution on the FX thread with two arguments.</p>
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ * @see FXPlatformBiConsumer
+ * @see FXBiConsumerThrowing
+ * @see BiConsumerThrowing
+ */
+@FunctionalInterface
+@OnThread(Tag.FXPlatform)
+public interface FXPlatformBiConsumerThrowing<T, U>
+{
+    /**
+     * Performs this operation on the given arguments on the JavaFX platform thread.
+     *
+     * @param t the first input argument
+     * @param u the second input argument
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FXPlatform)
+    void accept(T t, U u) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiConsumerThrowing.java
@@ -34,7 +34,7 @@ import threadchecker.Tag;
  * than requiring the implementor to handle them internally.</p>
  *
  * <p>Primary use case: passing exception-throwing lambdas to
- * {@link JavaFXUtil#runPlatform(FXPlatformBiConsumerThrowing, Object, Object)} and
+ * {@link JavaFXUtil#runPlatformAndWait(FXPlatformBiConsumerThrowing, Object, Object)} and
  * {@link JavaFXUtil#runPlatformFuture(FXPlatformBiConsumerThrowing, Object, Object)},
  * which schedule execution on the FX thread with two arguments.</p>
  *

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiFunctionThrowing.java
@@ -34,7 +34,7 @@ import threadchecker.Tag;
  * than requiring the implementor to handle them internally.</p>
  *
  * <p>Primary use case: passing exception-throwing lambdas to
- * {@link JavaFXUtil#runPlatform(FXPlatformBiFunctionThrowing, Object, Object)} and
+ * {@link JavaFXUtil#runPlatformAndWait(FXPlatformBiFunctionThrowing, Object, Object)} and
  * {@link JavaFXUtil#runPlatformFuture(FXPlatformBiFunctionThrowing, Object, Object)},
  * which schedule execution on the FX thread with two arguments and return a result.</p>
  *

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformBiFunctionThrowing.java
@@ -1,0 +1,62 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXPlatformBiFunction} whose {@link #apply(Object, Object)}
+ * method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FXPlatform)},
+ * indicating that its method must be called on the JavaFX application thread.
+ * Unlike {@link FXPlatformBiFunction}, checked exceptions are propagated rather
+ * than requiring the implementor to handle them internally.</p>
+ *
+ * <p>Primary use case: passing exception-throwing lambdas to
+ * {@link JavaFXUtil#runPlatform(FXPlatformBiFunctionThrowing, Object, Object)} and
+ * {@link JavaFXUtil#runPlatformFuture(FXPlatformBiFunctionThrowing, Object, Object)},
+ * which schedule execution on the FX thread with two arguments and return a result.</p>
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <R> the type of the result of the function
+ * @see FXPlatformBiFunction
+ * @see FXBiFunctionThrowing
+ * @see BiFunctionThrowing
+ */
+@FunctionalInterface
+@OnThread(Tag.FXPlatform)
+public interface FXPlatformBiFunctionThrowing<T, U, R>
+{
+    /**
+     * Applies this function to the given arguments on the JavaFX platform thread.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @return the function result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FXPlatform)
+    R apply(T t, U u) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformConsumerThrowing.java
@@ -34,7 +34,7 @@ import threadchecker.Tag;
  * than requiring the implementor to handle them internally.</p>
  *
  * <p>Primary use case: passing exception-throwing lambdas to
- * {@link JavaFXUtil#runPlatform(FXPlatformConsumerThrowing, Object)} and
+ * {@link JavaFXUtil#runPlatformAndWait(FXPlatformConsumerThrowing, Object)} and
  * {@link JavaFXUtil#runPlatformFuture(FXPlatformConsumerThrowing, Object)},
  * which schedule execution on the FX thread with a single argument.</p>
  *

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformConsumerThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformConsumerThrowing.java
@@ -1,0 +1,58 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXPlatformConsumer} whose {@link #accept(Object)} method
+ * is permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FXPlatform)},
+ * indicating that its method must be called on the JavaFX application thread.
+ * Unlike {@link FXPlatformConsumer}, checked exceptions are propagated rather
+ * than requiring the implementor to handle them internally.</p>
+ *
+ * <p>Primary use case: passing exception-throwing lambdas to
+ * {@link JavaFXUtil#runPlatform(FXPlatformConsumerThrowing, Object)} and
+ * {@link JavaFXUtil#runPlatformFuture(FXPlatformConsumerThrowing, Object)},
+ * which schedule execution on the FX thread with a single argument.</p>
+ *
+ * @param <T> the type of the input to the operation
+ * @see FXPlatformConsumer
+ * @see FXConsumerThrowing
+ * @see ConsumerThrowing
+ */
+@FunctionalInterface
+@OnThread(Tag.FXPlatform)
+public interface FXPlatformConsumerThrowing<T>
+{
+    /**
+     * Performs this operation on the given argument on the JavaFX platform thread.
+     *
+     * @param t the input argument
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FXPlatform)
+    void accept(T t) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformFunctionThrowing.java
@@ -34,7 +34,7 @@ import threadchecker.Tag;
  * than requiring the implementor to handle them internally.</p>
  *
  * <p>Primary use case: passing exception-throwing lambdas to
- * {@link JavaFXUtil#runPlatform(FXPlatformFunctionThrowing, Object)} and
+ * {@link JavaFXUtil#runPlatformAndWait(FXPlatformFunctionThrowing, Object)} and
  * {@link JavaFXUtil#runPlatformFuture(FXPlatformFunctionThrowing, Object)},
  * which schedule execution on the FX thread with a single argument and return
  * a result.</p>

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformFunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformFunctionThrowing.java
@@ -1,0 +1,61 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXPlatformFunction} whose {@link #apply(Object)} method
+ * is permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FXPlatform)},
+ * indicating that its method must be called on the JavaFX application thread.
+ * Unlike {@link FXPlatformFunction}, checked exceptions are propagated rather
+ * than requiring the implementor to handle them internally.</p>
+ *
+ * <p>Primary use case: passing exception-throwing lambdas to
+ * {@link JavaFXUtil#runPlatform(FXPlatformFunctionThrowing, Object)} and
+ * {@link JavaFXUtil#runPlatformFuture(FXPlatformFunctionThrowing, Object)},
+ * which schedule execution on the FX thread with a single argument and return
+ * a result.</p>
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ * @see FXPlatformFunction
+ * @see FXFunctionThrowing
+ * @see FunctionThrowing
+ */
+@FunctionalInterface
+@OnThread(Tag.FXPlatform)
+public interface FXPlatformFunctionThrowing<T, R>
+{
+    /**
+     * Applies this function to the given argument on the JavaFX platform thread.
+     *
+     * @param t the function argument
+     * @return the function result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FXPlatform)
+    R apply(T t) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformRunnableThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformRunnableThrowing.java
@@ -35,7 +35,7 @@ import threadchecker.Tag;
  * handle them internally.</p>
  *
  * <p>Primary use case: passing exception-throwing lambdas to
- * {@link JavaFXUtil#runPlatform(FXPlatformRunnableThrowing)} and
+ * {@link JavaFXUtil#runPlatformAndWait(FXPlatformRunnableThrowing)} and
  * {@link JavaFXUtil#runPlatformFuture(FXPlatformRunnableThrowing)}, which
  * schedule execution on the FX thread and propagate exceptions through
  * {@link java.util.concurrent.Future} or {@link RuntimeException}.</p>
@@ -43,7 +43,7 @@ import threadchecker.Tag;
  * @see FXPlatformRunnable
  * @see FXRunnableThrowing
  * @see RunnableThrowing
- * @see JavaFXUtil#runPlatform(FXPlatformRunnableThrowing)
+ * @see JavaFXUtil#runPlatformAndWait(FXPlatformRunnableThrowing)
  * @see JavaFXUtil#runPlatformFuture(FXPlatformRunnableThrowing)
  */
 @FunctionalInterface

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformRunnableThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformRunnableThrowing.java
@@ -1,0 +1,60 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXPlatformRunnable} whose {@link #run()} method is
+ * permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FXPlatform)},
+ * indicating that its {@link #run()} method must be called on the JavaFX
+ * application thread (the "platform" thread). Unlike {@link FXPlatformRunnable},
+ * checked exceptions are propagated rather than requiring the implementor to
+ * handle them internally.</p>
+ *
+ * <p>Primary use case: passing exception-throwing lambdas to
+ * {@link JavaFXUtil#runPlatform(FXPlatformRunnableThrowing)} and
+ * {@link JavaFXUtil#runPlatformFuture(FXPlatformRunnableThrowing)}, which
+ * schedule execution on the FX thread and propagate exceptions through
+ * {@link java.util.concurrent.Future} or {@link RuntimeException}.</p>
+ *
+ * @see FXPlatformRunnable
+ * @see FXRunnableThrowing
+ * @see RunnableThrowing
+ * @see JavaFXUtil#runPlatform(FXPlatformRunnableThrowing)
+ * @see JavaFXUtil#runPlatformFuture(FXPlatformRunnableThrowing)
+ */
+@FunctionalInterface
+@OnThread(Tag.FXPlatform)
+public interface FXPlatformRunnableThrowing
+{
+    /**
+     * Executes the action on the JavaFX platform thread.
+     *
+     * @throws Exception if the action fails
+     */
+    @OnThread(Tag.FXPlatform)
+    void run() throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformSupplierThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformSupplierThrowing.java
@@ -1,0 +1,58 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXPlatformSupplier} whose {@link #get()} method is
+ * permitted to throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FXPlatform)},
+ * indicating that its method must be called on the JavaFX application thread.
+ * Unlike {@link FXPlatformSupplier}, checked exceptions are propagated rather
+ * than requiring the implementor to handle them internally.</p>
+ *
+ * <p>Primary use case: passing exception-throwing lambdas to
+ * {@link JavaFXUtil#runPlatform(FXPlatformSupplierThrowing)} and
+ * {@link JavaFXUtil#runPlatformFuture(FXPlatformSupplierThrowing)},
+ * which schedule execution on the FX thread and return a result.</p>
+ *
+ * @param <T> the type of results supplied by this supplier
+ * @see FXPlatformSupplier
+ * @see FXSupplierThrowing
+ * @see SupplierThrowing
+ */
+@FunctionalInterface
+@OnThread(Tag.FXPlatform)
+public interface FXPlatformSupplierThrowing<T>
+{
+    /**
+     * Gets a result on the JavaFX platform thread.
+     *
+     * @return a result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FXPlatform)
+    T get() throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXPlatformSupplierThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXPlatformSupplierThrowing.java
@@ -34,7 +34,7 @@ import threadchecker.Tag;
  * than requiring the implementor to handle them internally.</p>
  *
  * <p>Primary use case: passing exception-throwing lambdas to
- * {@link JavaFXUtil#runPlatform(FXPlatformSupplierThrowing)} and
+ * {@link JavaFXUtil#runPlatformAndWait(FXPlatformSupplierThrowing)} and
  * {@link JavaFXUtil#runPlatformFuture(FXPlatformSupplierThrowing)},
  * which schedule execution on the FX thread and return a result.</p>
  *

--- a/bluej/src/main/java/bluej/utility/javafx/FXRunnableThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXRunnableThrowing.java
@@ -1,0 +1,52 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXRunnable} whose {@link #run()} method is permitted to
+ * throw checked exceptions. Extends {@link FXPlatformRunnableThrowing} following
+ * the same inheritance pattern as {@link FXRunnable} extends {@link FXPlatformRunnable}.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FX)}, indicating
+ * that its method is intended for use on the broader FX thread (which includes
+ * background FX loading threads, not just the platform thread). Unlike
+ * {@link FXRunnable}, checked exceptions are propagated.</p>
+ *
+ * @see FXRunnable
+ * @see FXPlatformRunnableThrowing
+ * @see RunnableThrowing
+ */
+@FunctionalInterface
+public interface FXRunnableThrowing extends FXPlatformRunnableThrowing
+{
+    /**
+     * Executes the action on the FX thread.
+     *
+     * @throws Exception if the action fails
+     */
+    @Override
+    @OnThread(Tag.FX)
+    void run() throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FXSupplierThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FXSupplierThrowing.java
@@ -1,0 +1,51 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A variant of {@link FXSupplier} whose {@link #get()} method is permitted to
+ * throw checked exceptions.
+ *
+ * <p>This interface is annotated with {@code @OnThread(Tag.FX)}, indicating
+ * that its method is intended for use on the broader FX thread. Unlike
+ * {@link FXSupplier}, checked exceptions are propagated.</p>
+ *
+ * @param <T> the type of results supplied by this supplier
+ * @see FXSupplier
+ * @see FXPlatformSupplierThrowing
+ * @see SupplierThrowing
+ */
+@FunctionalInterface
+public interface FXSupplierThrowing<T>
+{
+    /**
+     * Gets a result on the FX thread.
+     *
+     * @return a result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.FX)
+    T get() throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FunctionThrowing.java
@@ -1,0 +1,54 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A thread-agnostic variant of {@link java.util.function.Function} whose
+ * {@link #apply(Object)} method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is used as the non-thread-annotated base for
+ * {@link FXPlatformFunctionThrowing} and {@link FXFunctionThrowing},
+ * enabling exception-propagating lambdas to be passed to
+ * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * without requiring callers to wrap checked exceptions manually.</p>
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ * @see FXPlatformFunctionThrowing
+ * @see FXFunctionThrowing
+ */
+@FunctionalInterface
+public interface FunctionThrowing<T, R>
+{
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t the function argument
+     * @return the function result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.Any)
+    R apply(T t) throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/FunctionThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/FunctionThrowing.java
@@ -31,7 +31,7 @@ import threadchecker.Tag;
  * <p>This interface is used as the non-thread-annotated base for
  * {@link FXPlatformFunctionThrowing} and {@link FXFunctionThrowing},
  * enabling exception-propagating lambdas to be passed to
- * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * {@link JavaFXUtil#runPlatformAndWait} and {@link JavaFXUtil#runPlatformFuture}
  * without requiring callers to wrap checked exceptions manually.</p>
  *
  * @param <T> the type of the input to the function

--- a/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
+++ b/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 2014,2015,2016,2017,2018,2019,2021,2023 Michael Kölling and John Rosenberg
+ Copyright (C) 2014,2015,2016,2017,2018,2019,2021,2023,2026 Michael Kölling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -85,6 +85,8 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.List;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -1757,6 +1759,448 @@ public class JavaFXUtil
     public static void runPlatformLater(FXPlatformRunnable r)
     {
         Platform.runLater(r::run);
+    }
+
+
+    // ========================================================================
+    // Cross-thread execution: runPlatform (blocking) & runPlatformFuture (async)
+    // ========================================================================
+
+    /**
+     * Executes the given task on the JavaFX platform thread and blocks the
+     * calling thread until the task completes.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the task
+     * is executed synchronously (no scheduling overhead). Otherwise the task is
+     * posted via {@link Platform#runLater} and the caller blocks on the
+     * resulting {@link Future}.</p>
+     *
+     * <p>Any checked exception thrown by the task is wrapped in a
+     * {@link RuntimeException}.</p>
+     *
+     * @param r the task to execute on the FX platform thread
+     * @throws RuntimeException wrapping any exception thrown by the task
+     * @see #runPlatformFuture(FXPlatformRunnableThrowing)
+     */
+    @OnThread(Tag.Any)
+    public static void runPlatform(@OnThread(Tag.FXPlatform) FXPlatformRunnableThrowing r)
+    {
+        try {
+            runPlatformFuture(r).get();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Exception while running task on FX thread", e);
+        }
+    }
+
+    /**
+     * Executes the given supplier on the JavaFX platform thread, blocks the
+     * calling thread until it completes, and returns the result.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * supplier is evaluated synchronously. Otherwise it is posted via
+     * {@link Platform#runLater} and the caller blocks on the resulting
+     * {@link Future}.</p>
+     *
+     * <p>Any checked exception thrown by the supplier is wrapped in a
+     * {@link RuntimeException}.</p>
+     *
+     * @param <T>  the return type of the supplier
+     * @param task the supplier to execute on the FX platform thread
+     * @return the value produced by the supplier
+     * @throws RuntimeException wrapping any exception thrown by the supplier
+     * @see #runPlatformFuture(FXPlatformSupplierThrowing)
+     */
+    @OnThread(Tag.Any)
+    public static <T> T runPlatform(FXPlatformSupplierThrowing<T> task)
+    {
+        try {
+            return runPlatformFuture(task).get();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Exception while running task on FX thread", e);
+        }
+    }
+
+    /**
+     * Executes the given consumer on the JavaFX platform thread with the
+     * provided argument, and blocks the calling thread until completion.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * consumer is invoked synchronously. Otherwise it is posted via
+     * {@link Platform#runLater} and the caller blocks on the resulting
+     * {@link Future}.</p>
+     *
+     * <p>Any checked exception thrown by the consumer is wrapped in a
+     * {@link RuntimeException}.</p>
+     *
+     * @param <T>  the type of the argument
+     * @param task the consumer to execute on the FX platform thread
+     * @param arg  the argument to pass to the consumer
+     * @throws RuntimeException wrapping any exception thrown by the consumer
+     * @see #runPlatformFuture(FXPlatformConsumerThrowing, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T> void runPlatform(FXPlatformConsumerThrowing<T> task, T arg)
+    {
+        try {
+            runPlatformFuture(task, arg).get();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Exception while running task on FX thread", e);
+        }
+    }
+
+    /**
+     * Executes the given function on the JavaFX platform thread with the
+     * provided argument, blocks the calling thread until completion, and
+     * returns the result.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * function is evaluated synchronously. Otherwise it is posted via
+     * {@link Platform#runLater} and the caller blocks on the resulting
+     * {@link Future}.</p>
+     *
+     * <p>Any checked exception thrown by the function is wrapped in a
+     * {@link RuntimeException}.</p>
+     *
+     * @param <T>  the type of the argument
+     * @param <R>  the return type of the function
+     * @param task the function to execute on the FX platform thread
+     * @param arg  the argument to pass to the function
+     * @return the value produced by the function
+     * @throws RuntimeException wrapping any exception thrown by the function
+     * @see #runPlatformFuture(FXPlatformFunctionThrowing, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T, R> R runPlatform(FXPlatformFunctionThrowing<T, R> task, T arg)
+    {
+        try {
+            return runPlatformFuture(task, arg).get();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Exception while running task on FX thread", e);
+        }
+    }
+
+    /**
+     * Executes the given bi-consumer on the JavaFX platform thread with the
+     * provided arguments, and blocks the calling thread until completion.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * bi-consumer is invoked synchronously. Otherwise it is posted via
+     * {@link Platform#runLater} and the caller blocks on the resulting
+     * {@link Future}.</p>
+     *
+     * <p>Any checked exception thrown by the bi-consumer is wrapped in a
+     * {@link RuntimeException}.</p>
+     *
+     * @param <T>  the type of the first argument
+     * @param <U>  the type of the second argument
+     * @param task the bi-consumer to execute on the FX platform thread
+     * @param arg1 the first argument to pass to the bi-consumer
+     * @param arg2 the second argument to pass to the bi-consumer
+     * @throws RuntimeException wrapping any exception thrown by the bi-consumer
+     * @see #runPlatformFuture(FXPlatformBiConsumerThrowing, Object, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T, U> void runPlatform(FXPlatformBiConsumerThrowing<T, U> task, T arg1, U arg2)
+    {
+        try {
+            runPlatformFuture(task, arg1, arg2).get();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Exception while running task on FX thread", e);
+        }
+    }
+
+    /**
+     * Executes the given bi-function on the JavaFX platform thread with the
+     * provided arguments, blocks the calling thread until completion, and
+     * returns the result.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * bi-function is evaluated synchronously. Otherwise it is posted via
+     * {@link Platform#runLater} and the caller blocks on the resulting
+     * {@link Future}.</p>
+     *
+     * <p>Any checked exception thrown by the bi-function is wrapped in a
+     * {@link RuntimeException}.</p>
+     *
+     * @param <T>  the type of the first argument
+     * @param <U>  the type of the second argument
+     * @param <R>  the return type of the bi-function
+     * @param task the bi-function to execute on the FX platform thread
+     * @param arg1 the first argument to pass to the bi-function
+     * @param arg2 the second argument to pass to the bi-function
+     * @return the value produced by the bi-function
+     * @throws RuntimeException wrapping any exception thrown by the bi-function
+     * @see #runPlatformFuture(FXPlatformBiFunctionThrowing, Object, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T, U, R> R runPlatform(FXPlatformBiFunctionThrowing<T, U, R> task, T arg1, U arg2)
+    {
+        try {
+            return runPlatformFuture(task, arg1, arg2).get();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Exception while running task on FX thread", e);
+        }
+    }
+
+    /**
+     * Schedules the given task for execution on the JavaFX platform thread and
+     * returns a {@link Future} representing its completion.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the task
+     * is executed synchronously and the returned future is already completed.
+     * Otherwise the task is posted via {@link Platform#runLater}.</p>
+     *
+     * <p>Any exception thrown by the task is captured in the returned future
+     * (accessible via {@link Future#get()}).</p>
+     *
+     * @param task the task to execute on the FX platform thread
+     * @return a {@link Future}{@code <Void>} representing the task completion
+     * @see #runPlatform(FXPlatformRunnableThrowing)
+     */
+    @OnThread(Tag.Any)
+    public static Future<Void> runPlatformFuture(FXPlatformRunnableThrowing task) {
+        if (Platform.isFxApplicationThread()) {
+            try {
+                // Cast to suppress threadchecker, as we are sure we're on the right thread
+                ((RunnableThrowing) task::run).run();
+                return CompletableFuture.completedFuture(null);
+            } catch (Exception ex) {
+                return CompletableFuture.failedFuture(ex);
+            }
+        } else {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            Platform.runLater(() -> {
+                try {
+                    task.run();
+                    future.complete(null);
+                } catch (Throwable ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
+    }
+
+    /**
+     * Schedules the given supplier for execution on the JavaFX platform thread
+     * and returns a {@link Future} representing its result.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * supplier is evaluated synchronously and the returned future is already
+     * completed with the result. Otherwise the supplier is posted via
+     * {@link Platform#runLater}.</p>
+     *
+     * <p>Any exception thrown by the supplier is captured in the returned
+     * future.</p>
+     *
+     * @param <T>  the return type of the supplier
+     * @param task the supplier to execute on the FX platform thread
+     * @return a {@link Future}{@code <T>} representing the supplier's result
+     * @see #runPlatform(FXPlatformSupplierThrowing)
+     */
+    @OnThread(Tag.Any)
+    public static <T> Future<T> runPlatformFuture(FXPlatformSupplierThrowing<T> task) {
+        if (Platform.isFxApplicationThread()) {
+            try {
+                // Cast to suppress threadchecker, as we are sure we're on the right thread
+                var value = ((SupplierThrowing<T>) task::get).get();
+                return CompletableFuture.completedFuture(value);
+            } catch (Exception ex) {
+                return CompletableFuture.failedFuture(ex);
+            }
+        } else {
+            CompletableFuture<T> future = new CompletableFuture<>();
+            Platform.runLater(() -> {
+                try {
+                    future.complete(task.get());
+                } catch (Throwable ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
+    }
+
+    /**
+     * Schedules the given consumer for execution on the JavaFX platform thread
+     * with the provided argument, and returns a {@link Future} representing
+     * completion.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * consumer is invoked synchronously and the returned future is already
+     * completed. Otherwise the consumer is posted via
+     * {@link Platform#runLater}.</p>
+     *
+     * <p>Any exception thrown by the consumer is captured in the returned
+     * future.</p>
+     *
+     * @param <T>  the type of the argument
+     * @param task the consumer to execute on the FX platform thread
+     * @param arg  the argument to pass to the consumer
+     * @return a {@link Future}{@code <Void>} representing the task completion
+     * @see #runPlatform(FXPlatformConsumerThrowing, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T> Future<Void> runPlatformFuture(FXPlatformConsumerThrowing<T> task, T arg) {
+        if (Platform.isFxApplicationThread()) {
+            try {
+                // Cast to suppress threadchecker, as we are sure we're on the right thread
+                ((ConsumerThrowing<T>) task::accept).accept(arg);
+                return CompletableFuture.completedFuture(null);
+            } catch (Exception ex) {
+                return CompletableFuture.failedFuture(ex);
+            }
+        } else {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            Platform.runLater(() -> {
+                try {
+                    task.accept(arg);
+                    future.complete(null);
+                } catch (Throwable ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
+    }
+
+    /**
+     * Schedules the given function for execution on the JavaFX platform thread
+     * with the provided argument, and returns a {@link Future} representing
+     * the result.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * function is evaluated synchronously and the returned future is already
+     * completed. Otherwise the function is posted via
+     * {@link Platform#runLater}.</p>
+     *
+     * <p>Any exception thrown by the function is captured in the returned
+     * future.</p>
+     *
+     * @param <T>  the type of the argument
+     * @param <R>  the return type of the function
+     * @param task the function to execute on the FX platform thread
+     * @param arg  the argument to pass to the function
+     * @return a {@link Future}{@code <R>} representing the function's result
+     * @see #runPlatform(FXPlatformFunctionThrowing, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T, R> Future<R> runPlatformFuture(FXPlatformFunctionThrowing<T, R> task, T arg) {
+        if (Platform.isFxApplicationThread()) {
+            try {
+                // Cast to suppress threadchecker, as we are sure we're on the right thread
+                var value = ((FunctionThrowing<T, R>) task::apply).apply(arg);
+                return CompletableFuture.completedFuture(value);
+            } catch (Exception ex) {
+                return CompletableFuture.failedFuture(ex);
+            }
+        } else {
+            CompletableFuture<R> future = new CompletableFuture<>();
+            Platform.runLater(() -> {
+                try {
+                    future.complete(task.apply(arg));
+                } catch (Throwable ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
+    }
+
+    /**
+     * Schedules the given bi-consumer for execution on the JavaFX platform
+     * thread with the provided arguments, and returns a {@link Future}
+     * representing completion.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * bi-consumer is invoked synchronously and the returned future is already
+     * completed. Otherwise the bi-consumer is posted via
+     * {@link Platform#runLater}.</p>
+     *
+     * <p>Any exception thrown by the bi-consumer is captured in the returned
+     * future.</p>
+     *
+     * @param <T>  the type of the first argument
+     * @param <U>  the type of the second argument
+     * @param task the bi-consumer to execute on the FX platform thread
+     * @param arg1 the first argument to pass to the bi-consumer
+     * @param arg2 the second argument to pass to the bi-consumer
+     * @return a {@link Future}{@code <Void>} representing the task completion
+     * @see #runPlatform(FXPlatformBiConsumerThrowing, Object, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T, U> Future<Void> runPlatformFuture(FXPlatformBiConsumerThrowing<T, U> task, T arg1, U arg2) {
+        if (Platform.isFxApplicationThread()) {
+            try {
+                // Cast to suppress threadchecker, as we are sure we're on the right thread
+                ((BiConsumerThrowing<T, U>) task::accept).accept(arg1, arg2);
+                return CompletableFuture.completedFuture(null);
+            } catch (Exception ex) {
+                return CompletableFuture.failedFuture(ex);
+            }
+        } else {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            Platform.runLater(() -> {
+                try {
+                    task.accept(arg1, arg2);
+                    future.complete(null);
+                } catch (Throwable ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
+    }
+
+    /**
+     * Schedules the given bi-function for execution on the JavaFX platform
+     * thread with the provided arguments, and returns a {@link Future}
+     * representing the result.
+     *
+     * <p>If the calling thread <em>is</em> the FX application thread, the
+     * bi-function is evaluated synchronously and the returned future is
+     * already completed. Otherwise the bi-function is posted via
+     * {@link Platform#runLater}.</p>
+     *
+     * <p>Any exception thrown by the bi-function is captured in the returned
+     * future.</p>
+     *
+     * @param <T>  the type of the first argument
+     * @param <U>  the type of the second argument
+     * @param <R>  the return type of the bi-function
+     * @param task the bi-function to execute on the FX platform thread
+     * @param arg1 the first argument to pass to the bi-function
+     * @param arg2 the second argument to pass to the bi-function
+     * @return a {@link Future}{@code <R>} representing the bi-function's result
+     * @see #runPlatform(FXPlatformBiFunctionThrowing, Object, Object)
+     */
+    @OnThread(Tag.Any)
+    public static <T, U, R> Future<R> runPlatformFuture(FXPlatformBiFunctionThrowing<T, U, R> task, T arg1, U arg2) {
+        if (Platform.isFxApplicationThread()) {
+            try {
+                // Cast to suppress threadchecker, as we are sure we're on the right thread
+                var value = ((BiFunctionThrowing<T, U, R>) task::apply).apply(arg1, arg2);
+                return CompletableFuture.completedFuture(value);
+            } catch (Exception ex) {
+                return CompletableFuture.failedFuture(ex);
+            }
+        } else {
+            CompletableFuture<R> future = new CompletableFuture<>();
+            Platform.runLater(() -> {
+                try {
+                    future.complete(task.apply(arg1, arg2));
+                } catch (Throwable ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
     }
 
     /**

--- a/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
+++ b/bluej/src/main/java/bluej/utility/javafx/JavaFXUtil.java
@@ -1763,7 +1763,7 @@ public class JavaFXUtil
 
 
     // ========================================================================
-    // Cross-thread execution: runPlatform (blocking) & runPlatformFuture (async)
+    // Cross-thread execution: runPlatformAndWait (blocking) & runPlatformFuture (async)
     // ========================================================================
 
     /**
@@ -1778,12 +1778,18 @@ public class JavaFXUtil
      * <p>Any checked exception thrown by the task is wrapped in a
      * {@link RuntimeException}.</p>
      *
+     * <p><strong>Warning:</strong> Do not call this from a thread that the FX
+     * platform thread is waiting on, as this would cause a deadlock.  This is
+     * unusual because we normally don't want the GUI thread to block, but if it
+     * does, calling this method from the thread it is waiting on will
+     * deadlock.</p>
+     *
      * @param r the task to execute on the FX platform thread
      * @throws RuntimeException wrapping any exception thrown by the task
      * @see #runPlatformFuture(FXPlatformRunnableThrowing)
      */
     @OnThread(Tag.Any)
-    public static void runPlatform(@OnThread(Tag.FXPlatform) FXPlatformRunnableThrowing r)
+    public static void runPlatformAndWait(FXPlatformRunnableThrowing r)
     {
         try {
             runPlatformFuture(r).get();
@@ -1805,6 +1811,12 @@ public class JavaFXUtil
      * <p>Any checked exception thrown by the supplier is wrapped in a
      * {@link RuntimeException}.</p>
      *
+     * <p><strong>Warning:</strong> Do not call this from a thread that the FX
+     * platform thread is waiting on, as this would cause a deadlock.  This is
+     * unusual because we normally don't want the GUI thread to block, but if it
+     * does, calling this method from the thread it is waiting on will
+     * deadlock.</p>
+     *
      * @param <T>  the return type of the supplier
      * @param task the supplier to execute on the FX platform thread
      * @return the value produced by the supplier
@@ -1812,7 +1824,7 @@ public class JavaFXUtil
      * @see #runPlatformFuture(FXPlatformSupplierThrowing)
      */
     @OnThread(Tag.Any)
-    public static <T> T runPlatform(FXPlatformSupplierThrowing<T> task)
+    public static <T> T runPlatformAndWait(FXPlatformSupplierThrowing<T> task)
     {
         try {
             return runPlatformFuture(task).get();
@@ -1834,6 +1846,12 @@ public class JavaFXUtil
      * <p>Any checked exception thrown by the consumer is wrapped in a
      * {@link RuntimeException}.</p>
      *
+     * <p><strong>Warning:</strong> Do not call this from a thread that the FX
+     * platform thread is waiting on, as this would cause a deadlock.  This is
+     * unusual because we normally don't want the GUI thread to block, but if it
+     * does, calling this method from the thread it is waiting on will
+     * deadlock.</p>
+     *
      * @param <T>  the type of the argument
      * @param task the consumer to execute on the FX platform thread
      * @param arg  the argument to pass to the consumer
@@ -1841,7 +1859,7 @@ public class JavaFXUtil
      * @see #runPlatformFuture(FXPlatformConsumerThrowing, Object)
      */
     @OnThread(Tag.Any)
-    public static <T> void runPlatform(FXPlatformConsumerThrowing<T> task, T arg)
+    public static <T> void runPlatformAndWait(FXPlatformConsumerThrowing<T> task, T arg)
     {
         try {
             runPlatformFuture(task, arg).get();
@@ -1864,6 +1882,12 @@ public class JavaFXUtil
      * <p>Any checked exception thrown by the function is wrapped in a
      * {@link RuntimeException}.</p>
      *
+     * <p><strong>Warning:</strong> Do not call this from a thread that the FX
+     * platform thread is waiting on, as this would cause a deadlock.  This is
+     * unusual because we normally don't want the GUI thread to block, but if it
+     * does, calling this method from the thread it is waiting on will
+     * deadlock.</p>
+     *
      * @param <T>  the type of the argument
      * @param <R>  the return type of the function
      * @param task the function to execute on the FX platform thread
@@ -1873,7 +1897,7 @@ public class JavaFXUtil
      * @see #runPlatformFuture(FXPlatformFunctionThrowing, Object)
      */
     @OnThread(Tag.Any)
-    public static <T, R> R runPlatform(FXPlatformFunctionThrowing<T, R> task, T arg)
+    public static <T, R> R runPlatformAndWait(FXPlatformFunctionThrowing<T, R> task, T arg)
     {
         try {
             return runPlatformFuture(task, arg).get();
@@ -1895,6 +1919,12 @@ public class JavaFXUtil
      * <p>Any checked exception thrown by the bi-consumer is wrapped in a
      * {@link RuntimeException}.</p>
      *
+     * <p><strong>Warning:</strong> Do not call this from a thread that the FX
+     * platform thread is waiting on, as this would cause a deadlock.  This is
+     * unusual because we normally don't want the GUI thread to block, but if it
+     * does, calling this method from the thread it is waiting on will
+     * deadlock.</p>
+     *
      * @param <T>  the type of the first argument
      * @param <U>  the type of the second argument
      * @param task the bi-consumer to execute on the FX platform thread
@@ -1904,7 +1934,7 @@ public class JavaFXUtil
      * @see #runPlatformFuture(FXPlatformBiConsumerThrowing, Object, Object)
      */
     @OnThread(Tag.Any)
-    public static <T, U> void runPlatform(FXPlatformBiConsumerThrowing<T, U> task, T arg1, U arg2)
+    public static <T, U> void runPlatformAndWait(FXPlatformBiConsumerThrowing<T, U> task, T arg1, U arg2)
     {
         try {
             runPlatformFuture(task, arg1, arg2).get();
@@ -1927,6 +1957,12 @@ public class JavaFXUtil
      * <p>Any checked exception thrown by the bi-function is wrapped in a
      * {@link RuntimeException}.</p>
      *
+     * <p><strong>Warning:</strong> Do not call this from a thread that the FX
+     * platform thread is waiting on, as this would cause a deadlock.  This is
+     * unusual because we normally don't want the GUI thread to block, but if it
+     * does, calling this method from the thread it is waiting on will
+     * deadlock.</p>
+     *
      * @param <T>  the type of the first argument
      * @param <U>  the type of the second argument
      * @param <R>  the return type of the bi-function
@@ -1938,7 +1974,7 @@ public class JavaFXUtil
      * @see #runPlatformFuture(FXPlatformBiFunctionThrowing, Object, Object)
      */
     @OnThread(Tag.Any)
-    public static <T, U, R> R runPlatform(FXPlatformBiFunctionThrowing<T, U, R> task, T arg1, U arg2)
+    public static <T, U, R> R runPlatformAndWait(FXPlatformBiFunctionThrowing<T, U, R> task, T arg1, U arg2)
     {
         try {
             return runPlatformFuture(task, arg1, arg2).get();
@@ -1961,7 +1997,7 @@ public class JavaFXUtil
      *
      * @param task the task to execute on the FX platform thread
      * @return a {@link Future}{@code <Void>} representing the task completion
-     * @see #runPlatform(FXPlatformRunnableThrowing)
+     * @see #runPlatformAndWait(FXPlatformRunnableThrowing)
      */
     @OnThread(Tag.Any)
     public static Future<Void> runPlatformFuture(FXPlatformRunnableThrowing task) {
@@ -2002,7 +2038,7 @@ public class JavaFXUtil
      * @param <T>  the return type of the supplier
      * @param task the supplier to execute on the FX platform thread
      * @return a {@link Future}{@code <T>} representing the supplier's result
-     * @see #runPlatform(FXPlatformSupplierThrowing)
+     * @see #runPlatformAndWait(FXPlatformSupplierThrowing)
      */
     @OnThread(Tag.Any)
     public static <T> Future<T> runPlatformFuture(FXPlatformSupplierThrowing<T> task) {
@@ -2044,7 +2080,7 @@ public class JavaFXUtil
      * @param task the consumer to execute on the FX platform thread
      * @param arg  the argument to pass to the consumer
      * @return a {@link Future}{@code <Void>} representing the task completion
-     * @see #runPlatform(FXPlatformConsumerThrowing, Object)
+     * @see #runPlatformAndWait(FXPlatformConsumerThrowing, Object)
      */
     @OnThread(Tag.Any)
     public static <T> Future<Void> runPlatformFuture(FXPlatformConsumerThrowing<T> task, T arg) {
@@ -2088,7 +2124,7 @@ public class JavaFXUtil
      * @param task the function to execute on the FX platform thread
      * @param arg  the argument to pass to the function
      * @return a {@link Future}{@code <R>} representing the function's result
-     * @see #runPlatform(FXPlatformFunctionThrowing, Object)
+     * @see #runPlatformAndWait(FXPlatformFunctionThrowing, Object)
      */
     @OnThread(Tag.Any)
     public static <T, R> Future<R> runPlatformFuture(FXPlatformFunctionThrowing<T, R> task, T arg) {
@@ -2132,7 +2168,7 @@ public class JavaFXUtil
      * @param arg1 the first argument to pass to the bi-consumer
      * @param arg2 the second argument to pass to the bi-consumer
      * @return a {@link Future}{@code <Void>} representing the task completion
-     * @see #runPlatform(FXPlatformBiConsumerThrowing, Object, Object)
+     * @see #runPlatformAndWait(FXPlatformBiConsumerThrowing, Object, Object)
      */
     @OnThread(Tag.Any)
     public static <T, U> Future<Void> runPlatformFuture(FXPlatformBiConsumerThrowing<T, U> task, T arg1, U arg2) {
@@ -2178,7 +2214,7 @@ public class JavaFXUtil
      * @param arg1 the first argument to pass to the bi-function
      * @param arg2 the second argument to pass to the bi-function
      * @return a {@link Future}{@code <R>} representing the bi-function's result
-     * @see #runPlatform(FXPlatformBiFunctionThrowing, Object, Object)
+     * @see #runPlatformAndWait(FXPlatformBiFunctionThrowing, Object, Object)
      */
     @OnThread(Tag.Any)
     public static <T, U, R> Future<R> runPlatformFuture(FXPlatformBiFunctionThrowing<T, U, R> task, T arg1, U arg2) {

--- a/bluej/src/main/java/bluej/utility/javafx/RunnableThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/RunnableThrowing.java
@@ -31,7 +31,7 @@ import threadchecker.Tag;
  * <p>This interface is used as the non-thread-annotated base for
  * {@link FXPlatformRunnableThrowing} and {@link FXRunnableThrowing},
  * enabling exception-propagating lambdas to be passed to
- * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * {@link JavaFXUtil#runPlatformAndWait} and {@link JavaFXUtil#runPlatformFuture}
  * without requiring callers to wrap checked exceptions manually.</p>
  *
  * @see FXPlatformRunnableThrowing

--- a/bluej/src/main/java/bluej/utility/javafx/RunnableThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/RunnableThrowing.java
@@ -1,0 +1,50 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A thread-agnostic variant of {@link Runnable} whose {@link #run()} method
+ * is permitted to throw checked exceptions.
+ *
+ * <p>This interface is used as the non-thread-annotated base for
+ * {@link FXPlatformRunnableThrowing} and {@link FXRunnableThrowing},
+ * enabling exception-propagating lambdas to be passed to
+ * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * without requiring callers to wrap checked exceptions manually.</p>
+ *
+ * @see FXPlatformRunnableThrowing
+ * @see FXRunnableThrowing
+ */
+@FunctionalInterface
+public interface RunnableThrowing
+{
+    /**
+     * Executes the action.
+     *
+     * @throws Exception if the action fails
+     */
+    @OnThread(Tag.Any)
+    void run() throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/SupplierThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/SupplierThrowing.java
@@ -1,0 +1,52 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import threadchecker.OnThread;
+import threadchecker.Tag;
+
+/**
+ * A thread-agnostic variant of {@link java.util.function.Supplier} whose
+ * {@link #get()} method is permitted to throw checked exceptions.
+ *
+ * <p>This interface is used as the non-thread-annotated base for
+ * {@link FXPlatformSupplierThrowing} and {@link FXSupplierThrowing},
+ * enabling exception-propagating lambdas to be passed to
+ * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * without requiring callers to wrap checked exceptions manually.</p>
+ *
+ * @param <T> the type of results supplied by this supplier
+ * @see FXPlatformSupplierThrowing
+ * @see FXSupplierThrowing
+ */
+@FunctionalInterface
+public interface SupplierThrowing<T>
+{
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     * @throws Exception if the operation fails
+     */
+    @OnThread(Tag.Any)
+    T get() throws Exception;
+}

--- a/bluej/src/main/java/bluej/utility/javafx/SupplierThrowing.java
+++ b/bluej/src/main/java/bluej/utility/javafx/SupplierThrowing.java
@@ -31,7 +31,7 @@ import threadchecker.Tag;
  * <p>This interface is used as the non-thread-annotated base for
  * {@link FXPlatformSupplierThrowing} and {@link FXSupplierThrowing},
  * enabling exception-propagating lambdas to be passed to
- * {@link JavaFXUtil#runPlatform} and {@link JavaFXUtil#runPlatformFuture}
+ * {@link JavaFXUtil#runPlatformAndWait} and {@link JavaFXUtil#runPlatformFuture}
  * without requiring callers to wrap checked exceptions manually.</p>
  *
  * @param <T> the type of results supplied by this supplier

--- a/bluej/src/test/java/bluej/utility/javafx/JavaFXUtilTest.java
+++ b/bluej/src/test/java/bluej/utility/javafx/JavaFXUtilTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link JavaFXUtil}'s cross-thread execution methods:
- * {@code runPlatform} (blocking) and {@code runPlatformFuture} (async).
+ * {@code runPlatformAndWait} (blocking) and {@code runPlatformFuture} (async).
  *
  * <p>Covers all functional interface variants (Runnable, Supplier, Consumer,
  * Function, BiConsumer, BiFunction), testing both on-FX-thread (direct
@@ -75,7 +75,7 @@ public class JavaFXUtilTest extends ApplicationTest {
     }
 
     // ========================================================================
-    // 1. FXPlatformRunnableThrowing — runPlatform / runPlatformFuture
+    // 1. FXPlatformRunnableThrowing — runPlatformAndWait / runPlatformFuture
     // ========================================================================
 
     @Test
@@ -84,7 +84,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         runOffFxThread(() -> {
-            JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+            JavaFXUtil.runPlatformAndWait((FXPlatformRunnableThrowing) () -> {
                 Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 runOrder.add("inside");
@@ -129,7 +129,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         CompletableFuture<Void> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
-                JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                JavaFXUtil.runPlatformAndWait((FXPlatformRunnableThrowing) () -> {
                     Thread.sleep(100);
                     runOrder.add("inside");
                     threadIds.add(Thread.currentThread().threadId());
@@ -151,7 +151,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
-                JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                JavaFXUtil.runPlatformAndWait((FXPlatformRunnableThrowing) () -> {
                     throw new IOException("test exception");
                 });
                 fail("Should have thrown RuntimeException");
@@ -161,7 +161,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         });
         assertNotNull(caught.get(), "Should have caught RuntimeException");
         // The IOException is wrapped in ExecutionException by Future.get(),
-        // then wrapped in RuntimeException by runPlatform
+        // then wrapped in RuntimeException by runPlatformAndWait
         assertTrue(findCause(caught.get(), IOException.class), "Root cause chain should contain IOException");
     }
 
@@ -185,7 +185,7 @@ public class JavaFXUtilTest extends ApplicationTest {
     }
 
     // ========================================================================
-    // 2. FXPlatformSupplierThrowing — runPlatform / runPlatformFuture
+    // 2. FXPlatformSupplierThrowing — runPlatformAndWait / runPlatformFuture
     // ========================================================================
 
     @Test
@@ -195,7 +195,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<String> result = new AtomicReference<>();
         runOffFxThread(() -> {
-            String value = JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+            String value = JavaFXUtil.runPlatformAndWait((FXPlatformSupplierThrowing<String>) () -> {
                 Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 runOrder.add("inside");
@@ -246,7 +246,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         CompletableFuture<String> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
-                String value = JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+                String value = JavaFXUtil.runPlatformAndWait((FXPlatformSupplierThrowing<String>) () -> {
                     Thread.sleep(100);
                     runOrder.add("inside");
                     threadIds.add(Thread.currentThread().threadId());
@@ -269,7 +269,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
-                JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+                JavaFXUtil.runPlatformAndWait((FXPlatformSupplierThrowing<String>) () -> {
                     throw new IOException("supplier error");
                 });
                 fail("Should have thrown");
@@ -282,7 +282,7 @@ public class JavaFXUtilTest extends ApplicationTest {
     }
 
     // ========================================================================
-    // 3. FXPlatformConsumerThrowing — runPlatform / runPlatformFuture
+    // 3. FXPlatformConsumerThrowing — runPlatformAndWait / runPlatformFuture
     // ========================================================================
 
     @Test
@@ -292,7 +292,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<String> consumed = new AtomicReference<>();
         runOffFxThread(() -> {
-            JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+            JavaFXUtil.runPlatformAndWait((FXPlatformConsumerThrowing<String>) s -> {
                 Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 consumed.set(s);
@@ -342,7 +342,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         CompletableFuture<Void> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
-                JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                JavaFXUtil.runPlatformAndWait((FXPlatformConsumerThrowing<String>) s -> {
                     Thread.sleep(100);
                     runOrder.add("inside");
                     threadIds.add(Thread.currentThread().threadId());
@@ -364,7 +364,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
-                JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                JavaFXUtil.runPlatformAndWait((FXPlatformConsumerThrowing<String>) s -> {
                     throw new IOException("consumer error: " + s);
                 }, "arg");
                 fail("Should have thrown");
@@ -377,7 +377,7 @@ public class JavaFXUtilTest extends ApplicationTest {
     }
 
     // ========================================================================
-    // 4. FXPlatformFunctionThrowing — runPlatform / runPlatformFuture
+    // 4. FXPlatformFunctionThrowing — runPlatformAndWait / runPlatformFuture
     // ========================================================================
 
     @Test
@@ -387,7 +387,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<Integer> result = new AtomicReference<>();
         runOffFxThread(() -> {
-            int value = JavaFXUtil.runPlatform(
+            int value = JavaFXUtil.runPlatformAndWait(
                     (FXPlatformFunctionThrowing<String, Integer>) s -> {
                         Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
@@ -440,7 +440,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         CompletableFuture<Integer> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
-                int value = JavaFXUtil.runPlatform(
+                int value = JavaFXUtil.runPlatformAndWait(
                         (FXPlatformFunctionThrowing<String, Integer>) s -> {
                             Thread.sleep(100);
                             runOrder.add("inside");
@@ -464,7 +464,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
-                JavaFXUtil.runPlatform((FXPlatformFunctionThrowing<String, Integer>) s -> {
+                JavaFXUtil.runPlatformAndWait((FXPlatformFunctionThrowing<String, Integer>) s -> {
                     throw new IOException("function error");
                 }, "x");
                 fail("Should have thrown");
@@ -477,7 +477,7 @@ public class JavaFXUtilTest extends ApplicationTest {
     }
 
     // ========================================================================
-    // 5. FXPlatformBiConsumerThrowing — runPlatform / runPlatformFuture
+    // 5. FXPlatformBiConsumerThrowing — runPlatformAndWait / runPlatformFuture
     // ========================================================================
 
     @Test
@@ -487,7 +487,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<String> consumed = new AtomicReference<>();
         runOffFxThread(() -> {
-            JavaFXUtil.runPlatform(
+            JavaFXUtil.runPlatformAndWait(
                     (FXPlatformBiConsumerThrowing<String, Integer>) (s, i) -> {
                         Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
@@ -540,7 +540,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         CompletableFuture<Void> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
-                JavaFXUtil.runPlatform(
+                JavaFXUtil.runPlatformAndWait(
                         (FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
                             Thread.sleep(100);
                             runOrder.add("inside");
@@ -564,7 +564,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
-                JavaFXUtil.runPlatform(
+                JavaFXUtil.runPlatformAndWait(
                         (FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
                             throw new IOException("biconsumer error");
                         }, "a", "b");
@@ -578,7 +578,7 @@ public class JavaFXUtilTest extends ApplicationTest {
     }
 
     // ========================================================================
-    // 6. FXPlatformBiFunctionThrowing — runPlatform / runPlatformFuture
+    // 6. FXPlatformBiFunctionThrowing — runPlatformAndWait / runPlatformFuture
     // ========================================================================
 
     @Test
@@ -588,7 +588,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<String> result = new AtomicReference<>();
         runOffFxThread(() -> {
-            String value = JavaFXUtil.runPlatform(
+            String value = JavaFXUtil.runPlatformAndWait(
                     (FXPlatformBiFunctionThrowing<String, Integer, String>) (s, i) -> {
                         Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
@@ -643,7 +643,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         CompletableFuture<Integer> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
-                int value = JavaFXUtil.runPlatform(
+                int value = JavaFXUtil.runPlatformAndWait(
                         (FXPlatformBiFunctionThrowing<Integer, Integer, Integer>) (a, b) -> {
                             Thread.sleep(100);
                             runOrder.add("inside");
@@ -668,7 +668,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
-                JavaFXUtil.runPlatform(
+                JavaFXUtil.runPlatformAndWait(
                         (FXPlatformBiFunctionThrowing<String, String, String>) (a, b) -> {
                             throw new IOException("bifunction error");
                         }, "a", "b");
@@ -754,7 +754,7 @@ public class JavaFXUtilTest extends ApplicationTest {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
-                JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                JavaFXUtil.runPlatformAndWait((FXPlatformRunnableThrowing) () -> {
                     throw new IllegalStateException("unchecked");
                 });
                 fail("Should have thrown");
@@ -778,34 +778,34 @@ public class JavaFXUtilTest extends ApplicationTest {
             assertFalse(Platform.isFxApplicationThread(), "Test should not be on FX thread");
 
             // Runnable
-            JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+            JavaFXUtil.runPlatformAndWait((FXPlatformRunnableThrowing) () -> {
                 if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
             });
 
             // Supplier
-            JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<Boolean>) () -> {
+            JavaFXUtil.runPlatformAndWait((FXPlatformSupplierThrowing<Boolean>) () -> {
                 if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
                 return true;
             });
 
             // Consumer
-            JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+            JavaFXUtil.runPlatformAndWait((FXPlatformConsumerThrowing<String>) s -> {
                 if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
             }, "x");
 
             // Function
-            JavaFXUtil.runPlatform((FXPlatformFunctionThrowing<String, Integer>) s -> {
+            JavaFXUtil.runPlatformAndWait((FXPlatformFunctionThrowing<String, Integer>) s -> {
                 if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
                 return 0;
             }, "x");
 
             // BiConsumer
-            JavaFXUtil.runPlatform((FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
+            JavaFXUtil.runPlatformAndWait((FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
                 if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
             }, "a", "b");
 
             // BiFunction
-            JavaFXUtil.runPlatform(
+            JavaFXUtil.runPlatformAndWait(
                     (FXPlatformBiFunctionThrowing<String, String, Integer>) (a, b) -> {
                         if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
                         return 0;
@@ -855,7 +855,7 @@ public class JavaFXUtilTest extends ApplicationTest {
      * Tests that thread-checker tag inference works when a lambda is assigned
      * to a variable with an explicit functional interface type. The tag should
      * be inferred from the target type (e.g. FXPlatformRunnableThrowing →
-     * Tag.FXPlatform). These lambdas should then be accepted by runPlatform.
+     * Tag.FXPlatform). These lambdas should then be accepted by runPlatformAndWait.
      */
     @Test
     public void testLambdaTagInference_explicitType() throws Exception {
@@ -868,17 +868,17 @@ public class JavaFXUtilTest extends ApplicationTest {
         FXPlatformBiConsumerThrowing<String, Integer> biConsumer = (s, i) -> {};
         FXPlatformBiFunctionThrowing<String, Integer, String> biFunction = (s, i) -> s.repeat(i);
 
-        // Verify they work when passed to runPlatform from off-FX thread
+        // Verify they work when passed to runPlatformAndWait from off-FX thread
         AtomicReference<String> result = new AtomicReference<>();
         runOffFxThread(() -> {
-            JavaFXUtil.runPlatform(runnable);
-            String s = JavaFXUtil.runPlatform(supplier);
+            JavaFXUtil.runPlatformAndWait(runnable);
+            String s = JavaFXUtil.runPlatformAndWait(supplier);
             assertEquals("typed", s);
-            JavaFXUtil.runPlatform(consumer, "x");
-            int len = JavaFXUtil.runPlatform(function, "hello");
+            JavaFXUtil.runPlatformAndWait(consumer, "x");
+            int len = JavaFXUtil.runPlatformAndWait(function, "hello");
             assertEquals(5, len);
-            JavaFXUtil.runPlatform(biConsumer, "a", 1);
-            result.set(JavaFXUtil.runPlatform(biFunction, "ab", 3));
+            JavaFXUtil.runPlatformAndWait(biConsumer, "a", 1);
+            result.set(JavaFXUtil.runPlatformAndWait(biFunction, "ab", 3));
         });
         assertEquals("ababab", result.get());
     }
@@ -900,17 +900,17 @@ public class JavaFXUtilTest extends ApplicationTest {
         var biConsumer = (FXPlatformBiConsumerThrowing<String, Integer>) (String s, Integer i) -> {};
         var biFunction = (FXPlatformBiFunctionThrowing<String, Integer, String>) String::repeat;
 
-        // Verify they work when passed to runPlatform off the FX thread
+        // Verify they work when passed to runPlatformAndWait off the FX thread
         AtomicReference<String> result = new AtomicReference<>();
         runOffFxThread(() -> {
-            JavaFXUtil.runPlatform(runnable);
-            String s = JavaFXUtil.runPlatform(supplier);
+            JavaFXUtil.runPlatformAndWait(runnable);
+            String s = JavaFXUtil.runPlatformAndWait(supplier);
             assertEquals("var-typed", s);
-            JavaFXUtil.runPlatform(consumer, "x");
-            int len = JavaFXUtil.runPlatform(function, "hello");
+            JavaFXUtil.runPlatformAndWait(consumer, "x");
+            int len = JavaFXUtil.runPlatformAndWait(function, "hello");
             assertEquals(5, len);
-            JavaFXUtil.runPlatform(biConsumer, "a", 1);
-            result.set(JavaFXUtil.runPlatform(biFunction, "ab", 3));
+            JavaFXUtil.runPlatformAndWait(biConsumer, "a", 1);
+            result.set(JavaFXUtil.runPlatformAndWait(biFunction, "ab", 3));
         });
         assertEquals("ababab", result.get());
     }

--- a/bluej/src/test/java/bluej/utility/javafx/JavaFXUtilTest.java
+++ b/bluej/src/test/java/bluej/utility/javafx/JavaFXUtilTest.java
@@ -45,11 +45,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * <p>Extends {@link ApplicationTest} to ensure the JavaFX toolkit is
  * initialised before tests run.</p>
  */
-public class JavaFXUtilTest extends ApplicationTest
-{
+public class JavaFXUtilTest extends ApplicationTest {
     @Override
-    public void start(Stage stage) throws Exception
-    {
+    public void start(Stage stage) throws Exception {
         // No UI needed; we just require the FX toolkit to be initialised.
     }
 
@@ -57,8 +55,7 @@ public class JavaFXUtilTest extends ApplicationTest
     // Helper: run a Runnable from a non-FX thread and wait for its result
     // ========================================================================
 
-    private void runOffFxThread(RunnableThrowing action) throws Exception
-    {
+    private void runOffFxThread(RunnableThrowing action) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Throwable> error = new AtomicReference<>();
         Thread t = new Thread(() -> {
@@ -82,13 +79,13 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformRunnable_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformRunnable_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         runOffFxThread(() -> {
             JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 runOrder.add("inside");
                 threadIds.add(Thread.currentThread().threadId());
@@ -102,13 +99,13 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureRunnable_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformFutureRunnable_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         runOffFxThread(() -> {
             Future<Void> future = JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
+                Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 runOrder.add("inside");
                 threadIds.add(Thread.currentThread().threadId());
@@ -125,8 +122,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformRunnable_directOnFxThread() throws Exception
-    {
+    public void testRunPlatformRunnable_directOnFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         // Run from FX thread to test direct execution path
@@ -134,6 +130,7 @@ public class JavaFXUtilTest extends ApplicationTest
         Platform.runLater(() -> {
             try {
                 JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                    Thread.sleep(100);
                     runOrder.add("inside");
                     threadIds.add(Thread.currentThread().threadId());
                 });
@@ -150,8 +147,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformRunnable_exceptionPropagation() throws Exception
-    {
+    public void testRunPlatformRunnable_exceptionPropagation() throws Exception {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
@@ -170,8 +166,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureRunnable_exceptionPropagation() throws Exception
-    {
+    public void testRunPlatformFutureRunnable_exceptionPropagation() throws Exception {
         AtomicReference<Future<Void>> futureRef = new AtomicReference<>();
         runOffFxThread(() -> {
             futureRef.set(JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
@@ -194,14 +189,14 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformSupplier_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformSupplier_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<String> result = new AtomicReference<>();
         runOffFxThread(() -> {
             String value = JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+                Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 runOrder.add("inside");
                 threadIds.add(Thread.currentThread().threadId());
@@ -218,14 +213,14 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureSupplier_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformFutureSupplier_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<Future<Integer>> futureRef = new AtomicReference<>();
         runOffFxThread(() -> {
             Future<Integer> future = JavaFXUtil.runPlatformFuture((FXPlatformSupplierThrowing<Integer>) () -> {
+                Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 runOrder.add("inside");
                 threadIds.add(Thread.currentThread().threadId());
@@ -245,14 +240,14 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformSupplier_directOnFxThread() throws Exception
-    {
+    public void testRunPlatformSupplier_directOnFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         CompletableFuture<String> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
                 String value = JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+                    Thread.sleep(100);
                     runOrder.add("inside");
                     threadIds.add(Thread.currentThread().threadId());
                     return "direct";
@@ -270,8 +265,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformSupplier_exceptionPropagation() throws Exception
-    {
+    public void testRunPlatformSupplier_exceptionPropagation() throws Exception {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
@@ -292,14 +286,14 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformConsumer_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformConsumer_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
         AtomicReference<String> consumed = new AtomicReference<>();
         runOffFxThread(() -> {
             JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                Thread.sleep(100);
                 wasOnFxThread.set(Platform.isFxApplicationThread());
                 consumed.set(s);
                 runOrder.add("inside");
@@ -315,8 +309,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureConsumer_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformFutureConsumer_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
@@ -324,6 +317,7 @@ public class JavaFXUtilTest extends ApplicationTest
         runOffFxThread(() -> {
             Future<Void> future = JavaFXUtil.runPlatformFuture(
                     (FXPlatformConsumerThrowing<Integer>) i -> {
+                        Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
                         consumed.set(i);
                         runOrder.add("inside");
@@ -342,14 +336,14 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformConsumer_directOnFxThread() throws Exception
-    {
+    public void testRunPlatformConsumer_directOnFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         CompletableFuture<Void> done = new CompletableFuture<>();
         Platform.runLater(() -> {
             try {
                 JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                    Thread.sleep(100);
                     runOrder.add("inside");
                     threadIds.add(Thread.currentThread().threadId());
                 }, "fx-direct");
@@ -366,8 +360,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformConsumer_exceptionPropagation() throws Exception
-    {
+    public void testRunPlatformConsumer_exceptionPropagation() throws Exception {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
@@ -388,8 +381,7 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformFunction_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformFunction_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
@@ -397,6 +389,7 @@ public class JavaFXUtilTest extends ApplicationTest
         runOffFxThread(() -> {
             int value = JavaFXUtil.runPlatform(
                     (FXPlatformFunctionThrowing<String, Integer>) s -> {
+                        Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
                         runOrder.add("inside");
                         threadIds.add(Thread.currentThread().threadId());
@@ -413,8 +406,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureFunction_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformFutureFunction_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
@@ -422,6 +414,7 @@ public class JavaFXUtilTest extends ApplicationTest
         runOffFxThread(() -> {
             Future<String> future = JavaFXUtil.runPlatformFuture(
                     (FXPlatformFunctionThrowing<Integer, String>) i -> {
+                        Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
                         runOrder.add("inside");
                         threadIds.add(Thread.currentThread().threadId());
@@ -441,8 +434,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFunction_directOnFxThread() throws Exception
-    {
+    public void testRunPlatformFunction_directOnFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         CompletableFuture<Integer> done = new CompletableFuture<>();
@@ -450,6 +442,7 @@ public class JavaFXUtilTest extends ApplicationTest
             try {
                 int value = JavaFXUtil.runPlatform(
                         (FXPlatformFunctionThrowing<String, Integer>) s -> {
+                            Thread.sleep(100);
                             runOrder.add("inside");
                             threadIds.add(Thread.currentThread().threadId());
                             return s.length();
@@ -467,8 +460,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFunction_exceptionPropagation() throws Exception
-    {
+    public void testRunPlatformFunction_exceptionPropagation() throws Exception {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
@@ -489,8 +481,7 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformBiConsumer_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformBiConsumer_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
@@ -498,6 +489,7 @@ public class JavaFXUtilTest extends ApplicationTest
         runOffFxThread(() -> {
             JavaFXUtil.runPlatform(
                     (FXPlatformBiConsumerThrowing<String, Integer>) (s, i) -> {
+                        Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
                         consumed.set(s + ":" + i);
                         runOrder.add("inside");
@@ -514,8 +506,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureBiConsumer_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformFutureBiConsumer_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
@@ -523,6 +514,7 @@ public class JavaFXUtilTest extends ApplicationTest
         runOffFxThread(() -> {
             Future<Void> future = JavaFXUtil.runPlatformFuture(
                     (FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
+                        Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
                         consumed.set(a + b);
                         runOrder.add("inside");
@@ -542,8 +534,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformBiConsumer_directOnFxThread() throws Exception
-    {
+    public void testRunPlatformBiConsumer_directOnFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         CompletableFuture<Void> done = new CompletableFuture<>();
@@ -551,6 +542,7 @@ public class JavaFXUtilTest extends ApplicationTest
             try {
                 JavaFXUtil.runPlatform(
                         (FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
+                            Thread.sleep(100);
                             runOrder.add("inside");
                             threadIds.add(Thread.currentThread().threadId());
                         },
@@ -568,8 +560,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformBiConsumer_exceptionPropagation() throws Exception
-    {
+    public void testRunPlatformBiConsumer_exceptionPropagation() throws Exception {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
@@ -591,8 +582,7 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformBiFunction_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformBiFunction_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
@@ -600,6 +590,7 @@ public class JavaFXUtilTest extends ApplicationTest
         runOffFxThread(() -> {
             String value = JavaFXUtil.runPlatform(
                     (FXPlatformBiFunctionThrowing<String, Integer, String>) (s, i) -> {
+                        Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
                         runOrder.add("inside");
                         threadIds.add(Thread.currentThread().threadId());
@@ -617,8 +608,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureBiFunction_fromNonFxThread() throws Exception
-    {
+    public void testRunPlatformFutureBiFunction_fromNonFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
@@ -626,6 +616,7 @@ public class JavaFXUtilTest extends ApplicationTest
         runOffFxThread(() -> {
             Future<Integer> future = JavaFXUtil.runPlatformFuture(
                     (FXPlatformBiFunctionThrowing<Integer, Integer, Integer>) (a, b) -> {
+                        Thread.sleep(100);
                         wasOnFxThread.set(Platform.isFxApplicationThread());
                         runOrder.add("inside");
                         threadIds.add(Thread.currentThread().threadId());
@@ -646,8 +637,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformBiFunction_directOnFxThread() throws Exception
-    {
+    public void testRunPlatformBiFunction_directOnFxThread() throws Exception {
         ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
         CompletableFuture<Integer> done = new CompletableFuture<>();
@@ -655,6 +645,7 @@ public class JavaFXUtilTest extends ApplicationTest
             try {
                 int value = JavaFXUtil.runPlatform(
                         (FXPlatformBiFunctionThrowing<Integer, Integer, Integer>) (a, b) -> {
+                            Thread.sleep(100);
                             runOrder.add("inside");
                             threadIds.add(Thread.currentThread().threadId());
                             return Integer.sum(a, b);
@@ -673,8 +664,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformBiFunction_exceptionPropagation() throws Exception
-    {
+    public void testRunPlatformBiFunction_exceptionPropagation() throws Exception {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
@@ -696,11 +686,11 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformFutureRunnable_completedFutureOnFxThread() throws Exception
-    {
+    public void testRunPlatformFutureRunnable_completedFutureOnFxThread() throws Exception {
         CompletableFuture<Boolean> isDone = new CompletableFuture<>();
         Platform.runLater(() -> {
             Future<Void> future = JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
+                Thread.sleep(100);
                 // no-op
             });
             isDone.complete(future.isDone());
@@ -709,32 +699,35 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testRunPlatformFutureSupplier_completedFutureOnFxThread() throws Exception
-    {
+    public void testRunPlatformFutureSupplier_completedFutureOnFxThread() throws Exception {
         CompletableFuture<Boolean> isDone = new CompletableFuture<>();
         Platform.runLater(() -> {
             Future<String> future = JavaFXUtil.runPlatformFuture(
-                    (FXPlatformSupplierThrowing<String>) () -> "sync");
+                    (FXPlatformSupplierThrowing<String>) () -> {
+                        Thread.sleep(100);
+                        return "sync";
+                    });
             isDone.complete(future.isDone());
         });
         assertTrue(isDone.get(5, TimeUnit.SECONDS), "Future should be immediately done when called from FX thread");
     }
 
     @Test
-    public void testRunPlatformFutureFunction_completedFutureOnFxThread() throws Exception
-    {
+    public void testRunPlatformFutureFunction_completedFutureOnFxThread() throws Exception {
         CompletableFuture<Boolean> isDone = new CompletableFuture<>();
         Platform.runLater(() -> {
             Future<Integer> future = JavaFXUtil.runPlatformFuture(
-                    (FXPlatformFunctionThrowing<String, Integer>) String::length, "test");
+                    (FXPlatformFunctionThrowing<String, Integer>) (string) -> {
+                        Thread.sleep(100);
+                        return string.length();
+                    }, "test");
             isDone.complete(future.isDone());
         });
         assertTrue(isDone.get(5, TimeUnit.SECONDS), "Future should be immediately done when called from FX thread");
     }
 
     @Test
-    public void testRunPlatformFutureRunnable_failedFutureOnFxThread() throws Exception
-    {
+    public void testRunPlatformFutureRunnable_failedFutureOnFxThread() throws Exception {
         CompletableFuture<Future<Void>> futureRef = new CompletableFuture<>();
         Platform.runLater(() -> {
             Future<Void> future = JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
@@ -757,8 +750,7 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testRunPlatformRunnable_uncheckedExceptionPropagation() throws Exception
-    {
+    public void testRunPlatformRunnable_uncheckedExceptionPropagation() throws Exception {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         runOffFxThread(() -> {
             try {
@@ -779,8 +771,7 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testAllVariants_executeOnFxThread() throws Exception
-    {
+    public void testAllVariants_executeOnFxThread() throws Exception {
         AtomicInteger fxThreadCount = new AtomicInteger(0);
 
         runOffFxThread(() -> {
@@ -829,13 +820,14 @@ public class JavaFXUtilTest extends ApplicationTest
     // ========================================================================
 
     @Test
-    public void testFunctionalInterfaceSmokeTest_generics() throws Exception
-    {
+    public void testFunctionalInterfaceSmokeTest_generics() throws Exception {
         // Verify generic throwing interfaces compile and work correctly
-        RunnableThrowing rt = () -> {};
+        RunnableThrowing rt = () -> {
+        };
         rt.run();
 
-        ConsumerThrowing<String> ct = s -> {};
+        ConsumerThrowing<String> ct = s -> {
+        };
         ct.accept("test");
 
         SupplierThrowing<Integer> st = () -> 42;
@@ -844,7 +836,8 @@ public class JavaFXUtilTest extends ApplicationTest
         FunctionThrowing<String, Integer> ft = String::length;
         assertEquals(Integer.valueOf(3), ft.apply("abc"));
 
-        BiConsumerThrowing<String, Integer> bct = (s, i) -> {};
+        BiConsumerThrowing<String, Integer> bct = (s, i) -> {
+        };
         bct.accept("a", 1);
 
         BiFunctionThrowing<String, Integer, String> bft = (s, i) -> s + i;
@@ -852,8 +845,7 @@ public class JavaFXUtilTest extends ApplicationTest
     }
 
     @Test
-    public void testFunctionalInterfaceSmokeTest_fxBiFunction()
-    {
+    public void testFunctionalInterfaceSmokeTest_fxBiFunction() {
         // Verify the newly created FXBiFunction compiles and works
         FXBiFunction<String, Integer, String> fn = String::repeat;
         assertEquals("aaa", fn.apply("a", 3));
@@ -866,8 +858,7 @@ public class JavaFXUtilTest extends ApplicationTest
      * Tag.FXPlatform). These lambdas should then be accepted by runPlatform.
      */
     @Test
-    public void testLambdaTagInference_explicitType() throws Exception
-    {
+    public void testLambdaTagInference_explicitType() throws Exception {
         // Explicit type: the thread checker sees the target type and infers
         // the lambda's tag from the interface annotation.
         FXPlatformRunnableThrowing runnable = () -> {};
@@ -899,18 +890,17 @@ public class JavaFXUtilTest extends ApplicationTest
      * This verifies the inferred type retains its thread tag.
      */
     @Test
-    public void testLambdaTagInference_varType() throws Exception
-    {
+    public void testLambdaTagInference_varType() throws Exception {
         // var type: requires a cast to guide type inference, but the thread
         // checker should still see the inferred functional interface type.
         var runnable = (FXPlatformRunnableThrowing) () -> {};
         var supplier = (FXPlatformSupplierThrowing<String>) () -> "var-typed";
         var consumer = (FXPlatformConsumerThrowing<String>) (String s) -> {};
-        var function = (FXPlatformFunctionThrowing<String, Integer>) (String s) -> s.length();
+        var function = (FXPlatformFunctionThrowing<String, Integer>) String::length;
         var biConsumer = (FXPlatformBiConsumerThrowing<String, Integer>) (String s, Integer i) -> {};
-        var biFunction = (FXPlatformBiFunctionThrowing<String, Integer, String>) (String s, Integer i) -> s.repeat(i);
+        var biFunction = (FXPlatformBiFunctionThrowing<String, Integer, String>) String::repeat;
 
-        // Verify they work when passed to runPlatform from off-FX thread
+        // Verify they work when passed to runPlatform off the FX thread
         AtomicReference<String> result = new AtomicReference<>();
         runOffFxThread(() -> {
             JavaFXUtil.runPlatform(runnable);
@@ -933,8 +923,7 @@ public class JavaFXUtilTest extends ApplicationTest
      * Walks the cause chain of the given throwable looking for an instance of
      * the expected class.
      */
-    private boolean findCause(Throwable throwable, Class<? extends Throwable> expected)
-    {
+    private boolean findCause(Throwable throwable, Class<? extends Throwable> expected) {
         Throwable current = throwable;
         while (current != null) {
             if (expected.isInstance(current)) {

--- a/bluej/src/test/java/bluej/utility/javafx/JavaFXUtilTest.java
+++ b/bluej/src/test/java/bluej/utility/javafx/JavaFXUtilTest.java
@@ -1,0 +1,947 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026 Michael Kölling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej.utility.javafx;
+
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import org.junit.Test;
+import org.testfx.framework.junit.ApplicationTest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link JavaFXUtil}'s cross-thread execution methods:
+ * {@code runPlatform} (blocking) and {@code runPlatformFuture} (async).
+ *
+ * <p>Covers all functional interface variants (Runnable, Supplier, Consumer,
+ * Function, BiConsumer, BiFunction), testing both on-FX-thread (direct
+ * execution) and off-FX-thread (scheduled execution) scenarios, as well as
+ * exception propagation for checked and unchecked exceptions.</p>
+ *
+ * <p>Extends {@link ApplicationTest} to ensure the JavaFX toolkit is
+ * initialised before tests run.</p>
+ */
+public class JavaFXUtilTest extends ApplicationTest
+{
+    @Override
+    public void start(Stage stage) throws Exception
+    {
+        // No UI needed; we just require the FX toolkit to be initialised.
+    }
+
+    // ========================================================================
+    // Helper: run a Runnable from a non-FX thread and wait for its result
+    // ========================================================================
+
+    private void runOffFxThread(RunnableThrowing action) throws Exception
+    {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                action.run();
+            } catch (Throwable ex) {
+                error.set(ex);
+            } finally {
+                latch.countDown();
+            }
+        });
+        t.start();
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "Test thread timed out");
+        if (error.get() != null) {
+            throw new RuntimeException("Off-FX thread threw", error.get());
+        }
+    }
+
+    // ========================================================================
+    // 1. FXPlatformRunnableThrowing — runPlatform / runPlatformFuture
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformRunnable_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        runOffFxThread(() -> {
+            JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                wasOnFxThread.set(Platform.isFxApplicationThread());
+                runOrder.add("inside");
+                threadIds.add(Thread.currentThread().threadId());
+            });
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+        });
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Task should have run on FX thread");
+    }
+
+    @Test
+    public void testRunPlatformFutureRunnable_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        runOffFxThread(() -> {
+            Future<Void> future = JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
+                wasOnFxThread.set(Platform.isFxApplicationThread());
+                runOrder.add("inside");
+                threadIds.add(Thread.currentThread().threadId());
+            });
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            assertFalse(future.isDone(), "Future should not be immediately done from non-FX thread");
+
+            future.get(5, TimeUnit.SECONDS);
+        });
+        assertIterableEquals(List.of("outside", "inside"), runOrder, "Task should have run asynchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Task should have run on FX thread");
+    }
+
+    @Test
+    public void testRunPlatformRunnable_directOnFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        // Run from FX thread to test direct execution path
+        CompletableFuture<Void> done = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            try {
+                JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                    runOrder.add("inside");
+                    threadIds.add(Thread.currentThread().threadId());
+                });
+                runOrder.add("outside");
+                threadIds.add(Thread.currentThread().threadId());
+                done.complete(null);
+            } catch (Exception e) {
+                done.completeExceptionally(e);
+            }
+        });
+        done.get(5, TimeUnit.SECONDS);
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(1, threadIds.stream().distinct().count(), "Task should have run on the same thread");
+    }
+
+    @Test
+    public void testRunPlatformRunnable_exceptionPropagation() throws Exception
+    {
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+        runOffFxThread(() -> {
+            try {
+                JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                    throw new IOException("test exception");
+                });
+                fail("Should have thrown RuntimeException");
+            } catch (RuntimeException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull(caught.get(), "Should have caught RuntimeException");
+        // The IOException is wrapped in ExecutionException by Future.get(),
+        // then wrapped in RuntimeException by runPlatform
+        assertTrue(findCause(caught.get(), IOException.class), "Root cause chain should contain IOException");
+    }
+
+    @Test
+    public void testRunPlatformFutureRunnable_exceptionPropagation() throws Exception
+    {
+        AtomicReference<Future<Void>> futureRef = new AtomicReference<>();
+        runOffFxThread(() -> {
+            futureRef.set(JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
+                throw new IOException("async test exception");
+            }));
+        });
+        Future<Void> future = futureRef.get();
+        assertNotNull(future);
+        try {
+            future.get(5, TimeUnit.SECONDS);
+            fail("Future.get() should have thrown ExecutionException");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IOException, "Cause should be IOException");
+            assertEquals("async test exception", e.getCause().getMessage());
+        }
+    }
+
+    // ========================================================================
+    // 2. FXPlatformSupplierThrowing — runPlatform / runPlatformFuture
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformSupplier_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<String> result = new AtomicReference<>();
+        runOffFxThread(() -> {
+            String value = JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+                wasOnFxThread.set(Platform.isFxApplicationThread());
+                runOrder.add("inside");
+                threadIds.add(Thread.currentThread().threadId());
+                return "hello there";
+            });
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            result.set(value);
+        });
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Supplier should have run on FX thread");
+        assertEquals("hello there", result.get());
+    }
+
+    @Test
+    public void testRunPlatformFutureSupplier_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<Future<Integer>> futureRef = new AtomicReference<>();
+        runOffFxThread(() -> {
+            Future<Integer> future = JavaFXUtil.runPlatformFuture((FXPlatformSupplierThrowing<Integer>) () -> {
+                wasOnFxThread.set(Platform.isFxApplicationThread());
+                runOrder.add("inside");
+                threadIds.add(Thread.currentThread().threadId());
+                return 42;
+            });
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            assertFalse(future.isDone(), "Future should not be immediately done from non-FX thread");
+            futureRef.set(future);
+
+            future.get(5, TimeUnit.SECONDS);
+        });
+        assertIterableEquals(List.of("outside", "inside"), runOrder, "Task should have run asynchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Supplier should have run on FX thread");
+        assertEquals(Integer.valueOf(42), futureRef.get().get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testRunPlatformSupplier_directOnFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        CompletableFuture<String> done = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            try {
+                String value = JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+                    runOrder.add("inside");
+                    threadIds.add(Thread.currentThread().threadId());
+                    return "direct";
+                });
+                runOrder.add("outside");
+                threadIds.add(Thread.currentThread().threadId());
+                done.complete(value);
+            } catch (Exception e) {
+                done.completeExceptionally(e);
+            }
+        });
+        assertEquals("direct", done.get(5, TimeUnit.SECONDS));
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(1, threadIds.stream().distinct().count(), "Task should have run on the same thread");
+    }
+
+    @Test
+    public void testRunPlatformSupplier_exceptionPropagation() throws Exception
+    {
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+        runOffFxThread(() -> {
+            try {
+                JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<String>) () -> {
+                    throw new IOException("supplier error");
+                });
+                fail("Should have thrown");
+            } catch (RuntimeException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull(caught.get());
+        assertTrue(findCause(caught.get(), IOException.class));
+    }
+
+    // ========================================================================
+    // 3. FXPlatformConsumerThrowing — runPlatform / runPlatformFuture
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformConsumer_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<String> consumed = new AtomicReference<>();
+        runOffFxThread(() -> {
+            JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                wasOnFxThread.set(Platform.isFxApplicationThread());
+                consumed.set(s);
+                runOrder.add("inside");
+                threadIds.add(Thread.currentThread().threadId());
+            }, "world");
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+        });
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Consumer should have run on FX thread");
+        assertEquals("world", consumed.get());
+    }
+
+    @Test
+    public void testRunPlatformFutureConsumer_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<Integer> consumed = new AtomicReference<>();
+        runOffFxThread(() -> {
+            Future<Void> future = JavaFXUtil.runPlatformFuture(
+                    (FXPlatformConsumerThrowing<Integer>) i -> {
+                        wasOnFxThread.set(Platform.isFxApplicationThread());
+                        consumed.set(i);
+                        runOrder.add("inside");
+                        threadIds.add(Thread.currentThread().threadId());
+                    }, 99);
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            assertFalse(future.isDone(), "Future should not be immediately done from non-FX thread");
+
+            future.get(5, TimeUnit.SECONDS);
+        });
+        assertIterableEquals(List.of("outside", "inside"), runOrder, "Task should have run asynchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Consumer should have run on FX thread");
+        assertEquals(Integer.valueOf(99), consumed.get());
+    }
+
+    @Test
+    public void testRunPlatformConsumer_directOnFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Void> done = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            try {
+                JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                    runOrder.add("inside");
+                    threadIds.add(Thread.currentThread().threadId());
+                }, "fx-direct");
+                runOrder.add("outside");
+                threadIds.add(Thread.currentThread().threadId());
+                done.complete(null);
+            } catch (Exception e) {
+                done.completeExceptionally(e);
+            }
+        });
+        done.get(5, TimeUnit.SECONDS);
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(1, threadIds.stream().distinct().count(), "Task should have run on the same thread");
+    }
+
+    @Test
+    public void testRunPlatformConsumer_exceptionPropagation() throws Exception
+    {
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+        runOffFxThread(() -> {
+            try {
+                JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                    throw new IOException("consumer error: " + s);
+                }, "arg");
+                fail("Should have thrown");
+            } catch (RuntimeException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull(caught.get());
+        assertTrue(findCause(caught.get(), IOException.class));
+    }
+
+    // ========================================================================
+    // 4. FXPlatformFunctionThrowing — runPlatform / runPlatformFuture
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformFunction_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<Integer> result = new AtomicReference<>();
+        runOffFxThread(() -> {
+            int value = JavaFXUtil.runPlatform(
+                    (FXPlatformFunctionThrowing<String, Integer>) s -> {
+                        wasOnFxThread.set(Platform.isFxApplicationThread());
+                        runOrder.add("inside");
+                        threadIds.add(Thread.currentThread().threadId());
+                        return s.length();
+                    }, "hello");
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            result.set(value);
+        });
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Function should have run on FX thread");
+        assertEquals(Integer.valueOf(5), result.get());
+    }
+
+    @Test
+    public void testRunPlatformFutureFunction_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<Future<String>> futureRef = new AtomicReference<>();
+        runOffFxThread(() -> {
+            Future<String> future = JavaFXUtil.runPlatformFuture(
+                    (FXPlatformFunctionThrowing<Integer, String>) i -> {
+                        wasOnFxThread.set(Platform.isFxApplicationThread());
+                        runOrder.add("inside");
+                        threadIds.add(Thread.currentThread().threadId());
+                        return "num:" + i;
+                    }, 7);
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            assertFalse(future.isDone(), "Future should not be immediately done from non-FX thread");
+            futureRef.set(future);
+
+            future.get(5, TimeUnit.SECONDS);
+        });
+        assertIterableEquals(List.of("outside", "inside"), runOrder, "Task should have run asynchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "Function should have run on FX thread");
+        assertEquals("num:7", futureRef.get().get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testRunPlatformFunction_directOnFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Integer> done = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            try {
+                int value = JavaFXUtil.runPlatform(
+                        (FXPlatformFunctionThrowing<String, Integer>) s -> {
+                            runOrder.add("inside");
+                            threadIds.add(Thread.currentThread().threadId());
+                            return s.length();
+                        }, "ab");
+                runOrder.add("outside");
+                threadIds.add(Thread.currentThread().threadId());
+                done.complete(value);
+            } catch (Exception e) {
+                done.completeExceptionally(e);
+            }
+        });
+        assertEquals(Integer.valueOf(2), done.get(5, TimeUnit.SECONDS));
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(1, threadIds.stream().distinct().count(), "Task should have run on the same thread");
+    }
+
+    @Test
+    public void testRunPlatformFunction_exceptionPropagation() throws Exception
+    {
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+        runOffFxThread(() -> {
+            try {
+                JavaFXUtil.runPlatform((FXPlatformFunctionThrowing<String, Integer>) s -> {
+                    throw new IOException("function error");
+                }, "x");
+                fail("Should have thrown");
+            } catch (RuntimeException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull(caught.get());
+        assertTrue(findCause(caught.get(), IOException.class));
+    }
+
+    // ========================================================================
+    // 5. FXPlatformBiConsumerThrowing — runPlatform / runPlatformFuture
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformBiConsumer_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<String> consumed = new AtomicReference<>();
+        runOffFxThread(() -> {
+            JavaFXUtil.runPlatform(
+                    (FXPlatformBiConsumerThrowing<String, Integer>) (s, i) -> {
+                        wasOnFxThread.set(Platform.isFxApplicationThread());
+                        consumed.set(s + ":" + i);
+                        runOrder.add("inside");
+                        threadIds.add(Thread.currentThread().threadId());
+                    },
+                    "key", 42);
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+        });
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "BiConsumer should have run on FX thread");
+        assertEquals("key:42", consumed.get());
+    }
+
+    @Test
+    public void testRunPlatformFutureBiConsumer_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<String> consumed = new AtomicReference<>();
+        runOffFxThread(() -> {
+            Future<Void> future = JavaFXUtil.runPlatformFuture(
+                    (FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
+                        wasOnFxThread.set(Platform.isFxApplicationThread());
+                        consumed.set(a + b);
+                        runOrder.add("inside");
+                        threadIds.add(Thread.currentThread().threadId());
+                    },
+                    "foo", "bar");
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            assertFalse(future.isDone(), "Future should not be immediately done from non-FX thread");
+
+            future.get(5, TimeUnit.SECONDS);
+        });
+        assertIterableEquals(List.of("outside", "inside"), runOrder, "Task should have run asynchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "BiConsumer should have run on FX thread");
+        assertEquals("foobar", consumed.get());
+    }
+
+    @Test
+    public void testRunPlatformBiConsumer_directOnFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Void> done = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            try {
+                JavaFXUtil.runPlatform(
+                        (FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
+                            runOrder.add("inside");
+                            threadIds.add(Thread.currentThread().threadId());
+                        },
+                        "left", "right");
+                runOrder.add("outside");
+                threadIds.add(Thread.currentThread().threadId());
+                done.complete(null);
+            } catch (Exception e) {
+                done.completeExceptionally(e);
+            }
+        });
+        done.get(5, TimeUnit.SECONDS);
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(1, threadIds.stream().distinct().count(), "Task should have run on the same thread");
+    }
+
+    @Test
+    public void testRunPlatformBiConsumer_exceptionPropagation() throws Exception
+    {
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+        runOffFxThread(() -> {
+            try {
+                JavaFXUtil.runPlatform(
+                        (FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
+                            throw new IOException("biconsumer error");
+                        }, "a", "b");
+                fail("Should have thrown");
+            } catch (RuntimeException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull(caught.get());
+        assertTrue(findCause(caught.get(), IOException.class));
+    }
+
+    // ========================================================================
+    // 6. FXPlatformBiFunctionThrowing — runPlatform / runPlatformFuture
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformBiFunction_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<String> result = new AtomicReference<>();
+        runOffFxThread(() -> {
+            String value = JavaFXUtil.runPlatform(
+                    (FXPlatformBiFunctionThrowing<String, Integer, String>) (s, i) -> {
+                        wasOnFxThread.set(Platform.isFxApplicationThread());
+                        runOrder.add("inside");
+                        threadIds.add(Thread.currentThread().threadId());
+                        return s.repeat(i);
+                    },
+                    "ab", 3);
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            result.set(value);
+        });
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "BiFunction should have run on FX thread");
+        assertEquals("ababab", result.get());
+    }
+
+    @Test
+    public void testRunPlatformFutureBiFunction_fromNonFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        AtomicBoolean wasOnFxThread = new AtomicBoolean(false);
+        AtomicReference<Future<Integer>> futureRef = new AtomicReference<>();
+        runOffFxThread(() -> {
+            Future<Integer> future = JavaFXUtil.runPlatformFuture(
+                    (FXPlatformBiFunctionThrowing<Integer, Integer, Integer>) (a, b) -> {
+                        wasOnFxThread.set(Platform.isFxApplicationThread());
+                        runOrder.add("inside");
+                        threadIds.add(Thread.currentThread().threadId());
+                        return Integer.sum(a, b);
+                    },
+                    10, 20);
+            runOrder.add("outside");
+            threadIds.add(Thread.currentThread().threadId());
+            assertFalse(future.isDone(), "Future should not be immediately done from non-FX thread");
+            futureRef.set(future);
+
+            future.get(5, TimeUnit.SECONDS);
+        });
+        assertIterableEquals(List.of("outside", "inside"), runOrder, "Task should have run asynchronously");
+        assertEquals(2, threadIds.stream().distinct().count(), "Task should have run on a different thread");
+        assertTrue(wasOnFxThread.get(), "BiFunction should have run on FX thread");
+        assertEquals(Integer.valueOf(30), futureRef.get().get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testRunPlatformBiFunction_directOnFxThread() throws Exception
+    {
+        ConcurrentLinkedQueue<String> runOrder = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> threadIds = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Integer> done = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            try {
+                int value = JavaFXUtil.runPlatform(
+                        (FXPlatformBiFunctionThrowing<Integer, Integer, Integer>) (a, b) -> {
+                            runOrder.add("inside");
+                            threadIds.add(Thread.currentThread().threadId());
+                            return Integer.sum(a, b);
+                        },
+                        3, 4);
+                runOrder.add("outside");
+                threadIds.add(Thread.currentThread().threadId());
+                done.complete(value);
+            } catch (Exception e) {
+                done.completeExceptionally(e);
+            }
+        });
+        assertEquals(Integer.valueOf(7), done.get(5, TimeUnit.SECONDS));
+        assertIterableEquals(List.of("inside", "outside"), runOrder, "Task should have run synchronously");
+        assertEquals(1, threadIds.stream().distinct().count(), "Task should have run on the same thread");
+    }
+
+    @Test
+    public void testRunPlatformBiFunction_exceptionPropagation() throws Exception
+    {
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+        runOffFxThread(() -> {
+            try {
+                JavaFXUtil.runPlatform(
+                        (FXPlatformBiFunctionThrowing<String, String, String>) (a, b) -> {
+                            throw new IOException("bifunction error");
+                        }, "a", "b");
+                fail("Should have thrown");
+            } catch (RuntimeException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull(caught.get());
+        assertTrue(findCause(caught.get(), IOException.class));
+    }
+
+    // ========================================================================
+    // 7. Future-specific behaviour tests
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformFutureRunnable_completedFutureOnFxThread() throws Exception
+    {
+        CompletableFuture<Boolean> isDone = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            Future<Void> future = JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
+                // no-op
+            });
+            isDone.complete(future.isDone());
+        });
+        assertTrue(isDone.get(5, TimeUnit.SECONDS), "Future should be immediately done when called from FX thread");
+    }
+
+    @Test
+    public void testRunPlatformFutureSupplier_completedFutureOnFxThread() throws Exception
+    {
+        CompletableFuture<Boolean> isDone = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            Future<String> future = JavaFXUtil.runPlatformFuture(
+                    (FXPlatformSupplierThrowing<String>) () -> "sync");
+            isDone.complete(future.isDone());
+        });
+        assertTrue(isDone.get(5, TimeUnit.SECONDS), "Future should be immediately done when called from FX thread");
+    }
+
+    @Test
+    public void testRunPlatformFutureFunction_completedFutureOnFxThread() throws Exception
+    {
+        CompletableFuture<Boolean> isDone = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            Future<Integer> future = JavaFXUtil.runPlatformFuture(
+                    (FXPlatformFunctionThrowing<String, Integer>) String::length, "test");
+            isDone.complete(future.isDone());
+        });
+        assertTrue(isDone.get(5, TimeUnit.SECONDS), "Future should be immediately done when called from FX thread");
+    }
+
+    @Test
+    public void testRunPlatformFutureRunnable_failedFutureOnFxThread() throws Exception
+    {
+        CompletableFuture<Future<Void>> futureRef = new CompletableFuture<>();
+        Platform.runLater(() -> {
+            Future<Void> future = JavaFXUtil.runPlatformFuture((FXPlatformRunnableThrowing) () -> {
+                throw new IOException("direct-fail");
+            });
+            futureRef.complete(future);
+        });
+        Future<Void> future = futureRef.get(5, TimeUnit.SECONDS);
+        assertTrue(future.isDone(), "Failed future should be done");
+        try {
+            future.get();
+            fail("Should have thrown ExecutionException");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IOException);
+        }
+    }
+
+    // ========================================================================
+    // 8. Unchecked (RuntimeException) propagation
+    // ========================================================================
+
+    @Test
+    public void testRunPlatformRunnable_uncheckedExceptionPropagation() throws Exception
+    {
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+        runOffFxThread(() -> {
+            try {
+                JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                    throw new IllegalStateException("unchecked");
+                });
+                fail("Should have thrown");
+            } catch (RuntimeException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull(caught.get());
+        assertTrue(findCause(caught.get(), IllegalStateException.class));
+    }
+
+    // ========================================================================
+    // 9. Thread verification — tasks always execute on FX thread
+    // ========================================================================
+
+    @Test
+    public void testAllVariants_executeOnFxThread() throws Exception
+    {
+        AtomicInteger fxThreadCount = new AtomicInteger(0);
+
+        runOffFxThread(() -> {
+            assertFalse(Platform.isFxApplicationThread(), "Test should not be on FX thread");
+
+            // Runnable
+            JavaFXUtil.runPlatform((FXPlatformRunnableThrowing) () -> {
+                if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
+            });
+
+            // Supplier
+            JavaFXUtil.runPlatform((FXPlatformSupplierThrowing<Boolean>) () -> {
+                if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
+                return true;
+            });
+
+            // Consumer
+            JavaFXUtil.runPlatform((FXPlatformConsumerThrowing<String>) s -> {
+                if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
+            }, "x");
+
+            // Function
+            JavaFXUtil.runPlatform((FXPlatformFunctionThrowing<String, Integer>) s -> {
+                if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
+                return 0;
+            }, "x");
+
+            // BiConsumer
+            JavaFXUtil.runPlatform((FXPlatformBiConsumerThrowing<String, String>) (a, b) -> {
+                if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
+            }, "a", "b");
+
+            // BiFunction
+            JavaFXUtil.runPlatform(
+                    (FXPlatformBiFunctionThrowing<String, String, Integer>) (a, b) -> {
+                        if (Platform.isFxApplicationThread()) fxThreadCount.incrementAndGet();
+                        return 0;
+                    }, "a", "b");
+        });
+
+        assertEquals(6, fxThreadCount.get(), "All 6 variants should have run on FX thread");
+    }
+
+    // ========================================================================
+    // 10. Functional interface compilation / type-checking smoke tests
+    // ========================================================================
+
+    @Test
+    public void testFunctionalInterfaceSmokeTest_generics() throws Exception
+    {
+        // Verify generic throwing interfaces compile and work correctly
+        RunnableThrowing rt = () -> {};
+        rt.run();
+
+        ConsumerThrowing<String> ct = s -> {};
+        ct.accept("test");
+
+        SupplierThrowing<Integer> st = () -> 42;
+        assertEquals(Integer.valueOf(42), st.get());
+
+        FunctionThrowing<String, Integer> ft = String::length;
+        assertEquals(Integer.valueOf(3), ft.apply("abc"));
+
+        BiConsumerThrowing<String, Integer> bct = (s, i) -> {};
+        bct.accept("a", 1);
+
+        BiFunctionThrowing<String, Integer, String> bft = (s, i) -> s + i;
+        assertEquals("x1", bft.apply("x", 1));
+    }
+
+    @Test
+    public void testFunctionalInterfaceSmokeTest_fxBiFunction()
+    {
+        // Verify the newly created FXBiFunction compiles and works
+        FXBiFunction<String, Integer, String> fn = String::repeat;
+        assertEquals("aaa", fn.apply("a", 3));
+    }
+
+    /**
+     * Tests that thread-checker tag inference works when a lambda is assigned
+     * to a variable with an explicit functional interface type. The tag should
+     * be inferred from the target type (e.g. FXPlatformRunnableThrowing →
+     * Tag.FXPlatform). These lambdas should then be accepted by runPlatform.
+     */
+    @Test
+    public void testLambdaTagInference_explicitType() throws Exception
+    {
+        // Explicit type: the thread checker sees the target type and infers
+        // the lambda's tag from the interface annotation.
+        FXPlatformRunnableThrowing runnable = () -> {};
+        FXPlatformSupplierThrowing<String> supplier = () -> "typed";
+        FXPlatformConsumerThrowing<String> consumer = s -> {};
+        FXPlatformFunctionThrowing<String, Integer> function = String::length;
+        FXPlatformBiConsumerThrowing<String, Integer> biConsumer = (s, i) -> {};
+        FXPlatformBiFunctionThrowing<String, Integer, String> biFunction = (s, i) -> s.repeat(i);
+
+        // Verify they work when passed to runPlatform from off-FX thread
+        AtomicReference<String> result = new AtomicReference<>();
+        runOffFxThread(() -> {
+            JavaFXUtil.runPlatform(runnable);
+            String s = JavaFXUtil.runPlatform(supplier);
+            assertEquals("typed", s);
+            JavaFXUtil.runPlatform(consumer, "x");
+            int len = JavaFXUtil.runPlatform(function, "hello");
+            assertEquals(5, len);
+            JavaFXUtil.runPlatform(biConsumer, "a", 1);
+            result.set(JavaFXUtil.runPlatform(biFunction, "ab", 3));
+        });
+        assertEquals("ababab", result.get());
+    }
+
+    /**
+     * Tests that thread-checker tag inference works when a lambda is assigned
+     * to a {@code var} variable. With {@code var}, the compiler infers the
+     * type from the cast expression (e.g. {@code var r = (FXPlatformRunnableThrowing) () -> {}}).
+     * This verifies the inferred type retains its thread tag.
+     */
+    @Test
+    public void testLambdaTagInference_varType() throws Exception
+    {
+        // var type: requires a cast to guide type inference, but the thread
+        // checker should still see the inferred functional interface type.
+        var runnable = (FXPlatformRunnableThrowing) () -> {};
+        var supplier = (FXPlatformSupplierThrowing<String>) () -> "var-typed";
+        var consumer = (FXPlatformConsumerThrowing<String>) (String s) -> {};
+        var function = (FXPlatformFunctionThrowing<String, Integer>) (String s) -> s.length();
+        var biConsumer = (FXPlatformBiConsumerThrowing<String, Integer>) (String s, Integer i) -> {};
+        var biFunction = (FXPlatformBiFunctionThrowing<String, Integer, String>) (String s, Integer i) -> s.repeat(i);
+
+        // Verify they work when passed to runPlatform from off-FX thread
+        AtomicReference<String> result = new AtomicReference<>();
+        runOffFxThread(() -> {
+            JavaFXUtil.runPlatform(runnable);
+            String s = JavaFXUtil.runPlatform(supplier);
+            assertEquals("var-typed", s);
+            JavaFXUtil.runPlatform(consumer, "x");
+            int len = JavaFXUtil.runPlatform(function, "hello");
+            assertEquals(5, len);
+            JavaFXUtil.runPlatform(biConsumer, "a", 1);
+            result.set(JavaFXUtil.runPlatform(biFunction, "ab", 3));
+        });
+        assertEquals("ababab", result.get());
+    }
+
+    // ========================================================================
+    // Utility
+    // ========================================================================
+
+    /**
+     * Walks the cause chain of the given throwable looking for an instance of
+     * the expected class.
+     */
+    private boolean findCause(Throwable throwable, Class<? extends Throwable> expected)
+    {
+        Throwable current = throwable;
+        while (current != null) {
+            if (expected.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/threadchecker/build.gradle
+++ b/threadchecker/build.gradle
@@ -1,7 +1,28 @@
 apply plugin: 'java-library'
+apply plugin: 'org.openjfx.javafxplugin'
+
+repositories {
+    mavenCentral()
+}
+
+// JavaFX is needed at test time because TCScanner's constructor resolves
+// JavaFX types (e.g. ObjectPropertyBase, SwingNode, Application) when
+// building its set of known library annotations.
+javafx {
+    version = "23.0.2"  // javafx_version_setting <-- The Github Actions on Linux uses this to find and replace this line
+    modules = ['javafx.base', 'javafx.graphics', 'javafx.swing']
+    configuration = 'testImplementation'
+}
 
 dependencies {
     compileOnly project(':anns-threadchecker')
+    testImplementation project(':anns-threadchecker')
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 group = 'org.bluej'

--- a/threadchecker/src/main/java/threadchecker/TCScanner.java
+++ b/threadchecker/src/main/java/threadchecker/TCScanner.java
@@ -44,6 +44,7 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ErrorType;
@@ -116,6 +117,11 @@ class TCScanner extends TreePathScanner<Void, Void>
     // So we keep a stack of the nested types and methods:
     // List of package names to exclude from the analysis:
     private final List<String> ignorePackages;
+    // Stack of argument type lists for the method invocations we are currently
+    // inside.  Each entry corresponds to a method call whose arguments are being
+    // visited.  Used by calculatedExpectedLambdaType to determine what functional
+    // interface type a lambda argument is expected to be.  A null entry means the
+    // method could not be resolved (defaultReturn case).
     private final LinkedList<List<TypeMirror>> callingMethodStack = new LinkedList<>();
     private final WrapDescent defaultReturn = new WrapDescent(
             () -> { callingMethodStack.addLast(null); },
@@ -695,8 +701,23 @@ class TCScanner extends TreePathScanner<Void, Void>
                             
                             for (int i = 0; i < invokeArgTypes.size(); i++)
                             {
-                                if (!types.isAssignable(types.capture(invokeArgTypes.get(i)), el.getParameters().get(i).asType()))
-                                    return false;
+                                TypeMirror argType = types.capture(invokeArgTypes.get(i));
+                                TypeMirror paramType = el.getParameters().get(i).asType();
+                                if (!types.isAssignable(argType, paramType))
+                                {
+                                    // For parameters with unresolved type variables
+                                    // (e.g. Supplier<T> where T is a method type
+                                    // parameter), exact assignability fails because
+                                    // the type variable is not yet bound.  Fall back
+                                    // to erasure comparison in that case only (this returns
+                                    // the upper bound of the type variable, so `T extends Type`
+                                    // should also work properly).
+                                    // For concrete generic types (e.g. Comparable<Integer>),
+                                    // the exact check is authoritative.
+                                    if (!hasTypeVariables(paramType)
+                                            || !types.isAssignable(types.erasure(argType), types.erasure(paramType)))
+                                        return false;
+                                }
                             }
                             return true;
                         })
@@ -1211,10 +1232,30 @@ class TCScanner extends TreePathScanner<Void, Void>
         return tags.isEmpty() ? null : tags.get(0);
     }
     
+    /**
+     * Visits a lambda expression and resolves its thread tag.  The tag is
+     * determined by the functional interface type that the lambda implements:
+     *
+     * <ol>
+     *   <li>{@link #calculatedExpectedLambdaType} determines the functional
+     *       interface type (e.g. FXPlatformRunnable) from the calling context
+     *       (method argument position, variable assignment, or return type).</li>
+     *   <li>{@link #lambdaClassToAnn} resolves the tag from that interface:
+     *       first checking special methods (Platform.runLater etc.), then the
+     *       interface's abstract method annotation, then class/package tags.</li>
+     * </ol>
+     *
+     * <p>The resolved tag (or null if none found) is pushed onto
+     * {@link #lambdaScopeStack} for the duration of the lambda body visit.
+     * A null entry means "no tag determined" and causes
+     * {@link #getCurrentTag} to walk backwards through the stack looking for
+     * the nearest non-null enclosing lambda tag.</p>
+     */
     @Override
     public Void visitLambdaExpression(LambdaExpressionTree node, Void p)
     {
         Tree parent = getCurrentPath().getParentPath().getLeaf();
+        
         TypeMirror lambdaClassType = calculatedExpectedLambdaType(parent, node);
         if (inDebugClass())
         {
@@ -1236,14 +1277,24 @@ class TCScanner extends TreePathScanner<Void, Void>
         lambdaScopeStack.removeLast();
         return r;
     }
+    
 
     private boolean inDebugClass()
     {
         return false; //typeScopeStack.stream().anyMatch(pa -> pa.item.getSimpleName().toString().contains("CreateTestAction"));
     }
 
-    // Null if error,
-    // non-null empty if just not found
+    /**
+     * Resolves the thread tag for a lambda from its functional interface type.
+     * Checks (in priority order): special methods like Platform.runLater,
+     * the interface's single abstract method annotation, the interface class
+     * annotation, and the interface's package annotation.
+     *
+     * @return {@code Optional.of(tag)} if a tag was found,
+     *         {@code Optional.empty()} if no tag applies (lambda inherits
+     *         from surrounding context), or {@code null} if an error occurred
+     *         (e.g. the interface has multiple abstract methods)
+     */
     private Optional<LocatedTag> lambdaClassToAnn(Tree parent, TypeMirror lambdaClassType, Tree errorLocation, boolean issueError)
     {
         lambdaClassType = types.capture(lambdaClassType);
@@ -1663,5 +1714,34 @@ class TCScanner extends TreePathScanner<Void, Void>
         return types.isSameType(a, b)
              || a.toString().equals(b.toString());
 
+    }
+
+    /**
+     * Returns true if the given type contains any unresolved type variables,
+     * either directly (the type itself is a TypeVariable) or nested inside
+     * type arguments, wildcard bounds, or array component types.
+     */
+    private boolean hasTypeVariables(TypeMirror type)
+    {
+        if (type == null)
+            return false;
+        if (type.getKind() == TypeKind.TYPEVAR)
+            return true;
+        if (type instanceof DeclaredType)
+        {
+            return ((DeclaredType) type).getTypeArguments().stream()
+                .anyMatch(this::hasTypeVariables);
+        }
+        if (type instanceof WildcardType)
+        {
+            WildcardType wt = (WildcardType) type;
+            return hasTypeVariables(wt.getExtendsBound())
+                || hasTypeVariables(wt.getSuperBound());
+        }
+        if (type instanceof ArrayType)
+        {
+            return hasTypeVariables(((ArrayType) type).getComponentType());
+        }
+        return false;
     }
 }

--- a/threadchecker/src/test/java/threadchecker/FunctionalInterfaceLambdaTagInferenceTest.java
+++ b/threadchecker/src/test/java/threadchecker/FunctionalInterfaceLambdaTagInferenceTest.java
@@ -1,0 +1,1227 @@
+/*
+ This file is part of the BlueJ program.
+ Copyright (C) 2024,2025,2026 Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ This file is subject to the Classpath exception as provided in the
+ LICENSE.txt file that accompanied this code.
+*/
+package threadchecker;
+
+import com.sun.source.util.JavacTask;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the threadchecker's lambda thread-tag inference.
+ *
+ * <p>The threadchecker infers a lambda's thread tag from the
+ * {@code @OnThread} annotation on the functional interface's abstract
+ * method.  These tests verify that this inference works correctly
+ * across various scenarios: simple interfaces, generics, throwing
+ * interfaces, overloaded methods, nested lambdas, and chained calls.</p>
+ *
+ * <p>Each test compiles a Java source snippet with the threadchecker
+ * plugin enabled and verifies that the expected compilation errors (or
+ * absence thereof) occur.</p>
+ */
+class FunctionalInterfaceLambdaTagInferenceTest
+{
+    @TempDir
+    Path tempDir;
+
+    // ---------------------------------------------------------------
+    //  Type inference from annotated functional interfaces
+    // ---------------------------------------------------------------
+
+    /**
+     * A lambda passed to a method taking an annotated functional interface
+     * should inherit the tag from the interface's abstract method.
+     */
+    @Test
+    void annotatedInterface_lambdaCallsMatchingThread_shouldSucceed()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    runOnFX(() -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda should inherit FXPlatform from annotated interface, "
+            + "but got errors:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * A lambda inheriting FXPlatform from the interface must NOT be
+     * allowed to call Worker methods.
+     */
+    @Test
+    void annotatedInterface_lambdaCallsWrongThread_shouldFail()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.Worker)
+                public static void workerMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    runOnFX(() -> workerMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertFalse(result.success,
+            "Lambda inheriting FXPlatform should not call Worker methods");
+        assertTrue(result.hasErrorContaining("workerMethod"),
+            "Error should mention workerMethod, actual errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * The interface annotation should override the surrounding method's
+     * thread context.
+     */
+    @Test
+    void annotatedInterface_overridesSurroundingMethodContext()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+
+                @OnThread(Tag.Worker)
+                public void test() {
+                    runOnFX(() -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Interface annotation should override surrounding method's "
+            + "Worker tag, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Interface annotation should work when the lambda is not the first
+     * parameter.
+     */
+    @Test
+    void annotatedInterface_atSecondParameter_shouldSucceed()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static void schedule(int delayMs,
+                        FXRunnable action) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    schedule(100, () -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda at second parameter position should inherit tag "
+            + "from interface, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Interface annotation should work when the lambda is passed to a
+     * constructor.
+     */
+    @Test
+    void annotatedInterface_onConstructor_shouldSucceed()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static class TaskRunner {
+                    public TaskRunner(FXRunnable task) {}
+                }
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    new TaskRunner(() -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda passed to constructor should inherit tag from "
+            + "interface, but got errors:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * Generic annotated interface: type inference should still resolve
+     * the tag when generics are involved.
+     */
+    @Test
+    void annotatedGenericInterface_lambdaInheritsTag()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXSupplier<T> {
+                    @OnThread(Tag.FXPlatform) T get();
+                }
+
+                public static <T> T compute(FXSupplier<T> supplier) {
+                    return null;
+                }
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    compute(() -> {
+                        fxPlatformMethod();
+                        return "result";
+                    });
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda should inherit FXPlatform from generic annotated "
+            + "interface, but got errors:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * Without any annotation on the interface or the surrounding context,
+     * the lambda inherits from the enclosing method.
+     */
+    @Test
+    void unannotatedInterface_inheritsFromEnclosingMethod()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                public static void acceptRunnable(Runnable r) {}
+
+                @OnThread(Tag.FXPlatform)
+                public void test() {
+                    acceptRunnable(() -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda with unannotated interface should inherit from "
+            + "enclosing method, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    // ---------------------------------------------------------------
+    //  Throwing generic interface (real-world pattern)
+    // ---------------------------------------------------------------
+
+    /**
+     * A generic throwing functional interface used with an expression
+     * lambda.  The {@code throws Exception} clause should not prevent
+     * type inference from resolving the tag.
+     */
+    @Test
+    void throwingGenericInterface_expressionLambda_typeInference()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static String fxPlatformMethod() { return ""; }
+
+                @FunctionalInterface
+                public interface FXSupplierThrowing<T> {
+                    @OnThread(Tag.FXPlatform) T get() throws Exception;
+                }
+
+                @OnThread(Tag.Any)
+                public static <T> T runPlatformUnchecked(
+                        FXSupplierThrowing<T> task) {
+                    return null;
+                }
+
+                @OnThread(value = Tag.Any, ignoreParent = true)
+                public String test() {
+                    return runPlatformUnchecked(
+                        () -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda should inherit FXPlatform from throwing generic "
+            + "interface, but got errors:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * Overloaded methods where one takes a generic throwing interface
+     * and the other takes a non-generic one.  The erasure fallback in
+     * overload resolution must correctly keep the generic candidate.
+     */
+    @Test
+    void throwingGenericInterface_withOverload_typeInference()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static String fxPlatformMethod() { return ""; }
+
+                @FunctionalInterface
+                public interface FXSupplierThrowing<T> {
+                    @OnThread(Tag.FXPlatform) T get() throws Exception;
+                }
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                @OnThread(Tag.Any)
+                public static <T> T runPlatformUnchecked(
+                        FXSupplierThrowing<T> task) {
+                    return null;
+                }
+
+                @OnThread(Tag.Any)
+                @SuppressWarnings("threadchecker")
+                public static void runPlatformUnchecked(FXRunnable r) {}
+
+                @OnThread(value = Tag.Any, ignoreParent = true)
+                public String test() {
+                    return runPlatformUnchecked(
+                        () -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda should inherit FXPlatform from throwing generic "
+            + "interface even with overloaded method, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Chained method calls inside an expression lambda, matching the
+     * real-world pattern where the original failure occurred.
+     */
+    @Test
+    void throwingGenericInterface_chainedCalls_typeInference()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public String getName() { return ""; }
+
+                @OnThread(Tag.FXPlatform)
+                public TestCase getChild(String name) { return this; }
+
+                @FunctionalInterface
+                public interface FXSupplierThrowing<T> {
+                    @OnThread(Tag.FXPlatform) T get() throws Exception;
+                }
+
+                @OnThread(Tag.Any)
+                public static <T> T runPlatformUnchecked(
+                        FXSupplierThrowing<T> task) {
+                    return null;
+                }
+
+                @OnThread(value = Tag.Any, ignoreParent = true)
+                public TestCase test() {
+                    TestCase self = this;
+                    return runPlatformUnchecked(
+                        () -> self.getChild(self.getName()));
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda with chained FXPlatform calls should inherit "
+            + "FXPlatform from throwing generic interface, but got "
+            + "errors:\n" + result.getErrorMessages());
+    }
+
+    // ---------------------------------------------------------------
+    //  Nested lambda scenarios
+    // ---------------------------------------------------------------
+
+    /**
+     * When a lambda is passed to an unannotated method inside a tagged
+     * lambda, the inner lambda should inherit the outer lambda's tag via
+     * the backwards walk through {@code lambdaScopeStack}.
+     */
+    @Test
+    void nestedLambda_innerUntagged_inheritsFromOuterLambda()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+                public static void doForEach(Runnable action) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    runOnFX(() -> {
+                        doForEach(() -> {
+                            fxPlatformMethod();
+                        });
+                    });
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Inner untagged lambda should inherit FXPlatform from outer "
+            + "lambda, but got errors:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * Same nesting scenario, but the inner lambda tries to call a method
+     * tagged for a different thread.
+     */
+    @Test
+    void nestedLambda_innerUntagged_cannotCallWrongThread()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.Worker)
+                public static void workerMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+                public static void doForEach(Runnable action) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    runOnFX(() -> {
+                        doForEach(() -> {
+                            workerMethod();
+                        });
+                    });
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertFalse(result.success,
+            "Inner untagged lambda inheriting FXPlatform should not "
+            + "call Worker methods");
+        assertTrue(result.hasErrorContaining("workerMethod"),
+            "Error should mention workerMethod, actual errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * An inner lambda whose annotated interface carries a different tag
+     * should override the outer lambda's tag.
+     */
+    @Test
+    void nestedLambda_innerAnnotatedWorker_overridesOuterFXPlatform()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.Worker)
+                public static void workerMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                @FunctionalInterface
+                public interface WorkerRunnable {
+                    @OnThread(Tag.Worker) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+                public static void runInBackground(WorkerRunnable r) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    runOnFX(() -> {
+                        runInBackground(() -> {
+                            workerMethod();
+                        });
+                    });
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Inner lambda with Worker interface should call Worker "
+            + "methods, but got errors:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * An inner lambda with Worker interface cannot call FXPlatform
+     * methods, even when the outer lambda is FXPlatform.
+     */
+    @Test
+    void nestedLambda_innerAnnotatedWorker_cannotCallFXPlatform()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                @FunctionalInterface
+                public interface WorkerRunnable {
+                    @OnThread(Tag.Worker) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+                public static void runInBackground(WorkerRunnable r) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    runOnFX(() -> {
+                        runInBackground(() -> {
+                            fxPlatformMethod();
+                        });
+                    });
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertFalse(result.success,
+            "Inner lambda with Worker interface should not call "
+            + "FXPlatform methods");
+        assertTrue(result.hasErrorContaining("fxPlatformMethod"),
+            "Error should mention fxPlatformMethod, actual errors:\n"
+            + result.getErrorMessages());
+    }
+
+    // ---------------------------------------------------------------
+    //  Known gaps and promise verification
+    // ---------------------------------------------------------------
+
+    /**
+     * Method references ({@code this::method}) are not handled by the
+     * lambda type inference logic.  This test documents the gap.
+     */
+    @Test
+    void methodReference_notCheckedByTypeInference()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.Worker)
+                public void workerMethod() {}
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                public static void runOnFX(FXRunnable r) {}
+
+                @OnThread(Tag.Any)
+                public void test() {
+                    // Semantically equivalent to:
+                    //   runOnFX(() -> workerMethod())
+                    // which WOULD be caught.  But the method reference
+                    // bypasses visitLambdaExpression entirely.
+                    runOnFX(this::workerMethod);
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        // Documents current behaviour: method references are NOT checked.
+        assertTrue(result.success,
+            "Method references are not currently checked against "
+            + "interface annotations (known gap), but compilation "
+            + "unexpectedly failed:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * When the functional interface's abstract method IS annotated,
+     * calling it from the wrong thread inside the method body IS caught.
+     * This provides callee-side promise verification.
+     */
+    @Test
+    void promiseVerified_annotatedFunctionalInterfaceMethod()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @FunctionalInterface
+                public interface FXTask {
+                    @OnThread(Tag.FXPlatform) void execute();
+                }
+
+                @OnThread(Tag.Worker)
+                public static void brokenPromise(FXTask r) {
+                    r.execute();
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertFalse(result.success,
+            "Calling annotated interface method from wrong thread "
+            + "should be caught");
+        assertTrue(result.hasErrorContaining("execute"),
+            "Error should mention 'execute', actual errors:\n"
+            + result.getErrorMessages());
+    }
+
+    // ---------------------------------------------------------------
+    //  Overload resolution: erasure fallback for type variables
+    // ---------------------------------------------------------------
+
+    /**
+     * Chained call on the generic return type after erasure-fallback
+     * overload resolution: the resolved type must be correct.
+     */
+    @Test
+    void overloadErasureFallback_chainedCall_retainsType_shouldSucceed()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                public static class Result {
+                    @OnThread(Tag.Worker)
+                    public void processOnWorker() {}
+                }
+
+                @OnThread(Tag.FXPlatform)
+                public static Result getResult() { return null; }
+
+                @FunctionalInterface
+                public interface FXSupplierThrowing<T> {
+                    @OnThread(Tag.FXPlatform) T get() throws Exception;
+                }
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                @OnThread(Tag.Any)
+                public static <T> T runPlatformUnchecked(
+                        FXSupplierThrowing<T> task) {
+                    return null;
+                }
+
+                @OnThread(Tag.Any)
+                @SuppressWarnings("threadchecker")
+                public static void runPlatformUnchecked(FXRunnable r) {}
+
+                @OnThread(Tag.Worker)
+                public void test() {
+                    runPlatformUnchecked(() -> getResult())
+                        .processOnWorker();
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Chained Worker method on generic return type should work "
+            + "from Worker context, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Negative counterpart: chained method on the generic return type
+     * must still be checked against the calling context's thread tag.
+     */
+    @Test
+    void overloadErasureFallback_chainedCall_wrongThread_shouldFail()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                public static class Result {
+                    @OnThread(Tag.FXPlatform)
+                    public void processOnFX() {}
+                }
+
+                @OnThread(Tag.FXPlatform)
+                public static Result getResult() { return null; }
+
+                @FunctionalInterface
+                public interface FXSupplierThrowing<T> {
+                    @OnThread(Tag.FXPlatform) T get() throws Exception;
+                }
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                @OnThread(Tag.Any)
+                public static <T> T runPlatformUnchecked(
+                        FXSupplierThrowing<T> task) {
+                    return null;
+                }
+
+                @OnThread(Tag.Any)
+                @SuppressWarnings("threadchecker")
+                public static void runPlatformUnchecked(FXRunnable r) {}
+
+                @OnThread(Tag.Worker)
+                public void test() {
+                    runPlatformUnchecked(() -> getResult())
+                        .processOnFX();
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertFalse(result.success,
+            "Chained FXPlatform method called from Worker context "
+            + "should fail");
+        assertTrue(result.hasErrorContaining("processOnFX"),
+            "Error should mention processOnFX, actual errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Concrete generic types (no type variables) should NOT trigger
+     * the erasure fallback.
+     */
+    @Test
+    void erasureFallback_concreteGeneric_noFalseAmbiguity()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.Worker)
+                public static void process(Comparable<Integer> x) {}
+
+                @OnThread(Tag.FXPlatform)
+                public static void process(java.io.Serializable x) {}
+
+                @OnThread(Tag.FXPlatform)
+                public void test() {
+                    process("hello");
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Concrete generic overload should be correctly filtered "
+            + "without false ambiguity, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Same-tag overloads that both survive erasure fallback should be
+     * accepted without error.
+     */
+    @Test
+    void erasureFallback_sameTag_succeeds()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void process(Comparable<Integer> x) {}
+
+                @OnThread(Tag.FXPlatform)
+                public static void process(java.io.Serializable x) {}
+
+                @OnThread(Tag.FXPlatform)
+                public void test() {
+                    process("hello");
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Same-tag overloads should be accepted, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Unrelated erased types should be correctly filtered out.
+     */
+    @Test
+    void erasureFallback_unrelatedTypes_correctlyFiltered()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @FunctionalInterface
+                public interface FXSupplierThrowing<T> {
+                    @OnThread(Tag.FXPlatform) T get() throws Exception;
+                }
+
+                @OnThread(Tag.Worker)
+                public static void compute(int value) {}
+
+                @OnThread(Tag.Any)
+                public static <T> T compute(
+                        FXSupplierThrowing<T> task) {
+                    return null;
+                }
+
+                @OnThread(Tag.Any)
+                public String test() {
+                    return compute(() -> {
+                        fxPlatformMethod();
+                        return "result";
+                    });
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Lambda should match FXSupplierThrowing overload, not the "
+            + "int overload, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    // ---------------------------------------------------------------
+    //  Erasure fallback with generic bounds
+    // ---------------------------------------------------------------
+
+    /**
+     * Bounded type variable: {@code <T extends Number>}.
+     */
+    @Test
+    void erasureFallback_boundedTypeVariable_correctlyResolved()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static Integer fxPlatformMethod() { return 0; }
+
+                @FunctionalInterface
+                public interface FXSupplierThrowing<T> {
+                    @OnThread(Tag.FXPlatform) T get() throws Exception;
+                }
+
+                @FunctionalInterface
+                public interface FXRunnable {
+                    @OnThread(Tag.FXPlatform) void run();
+                }
+
+                @OnThread(Tag.Any)
+                public static <T extends Number> T runPlatformUnchecked(
+                        FXSupplierThrowing<T> task) {
+                    return null;
+                }
+
+                @OnThread(Tag.Any)
+                @SuppressWarnings("threadchecker")
+                public static void runPlatformUnchecked(FXRunnable r) {}
+
+                @OnThread(value = Tag.Any, ignoreParent = true)
+                public Integer test() {
+                    return runPlatformUnchecked(
+                        () -> fxPlatformMethod());
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Bounded type variable should still trigger erasure "
+            + "fallback, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Wildcard bound containing a type variable:
+     * {@code List<? extends T>}.
+     */
+    @Test
+    void erasureFallback_wildcardWithTypeVariable_correctlyResolved()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+            import java.util.List;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @OnThread(Tag.FXPlatform)
+                public static <T> void processList(
+                        List<? extends T> items) {}
+
+                @OnThread(Tag.Worker)
+                public static void processList(String item) {}
+
+                @OnThread(Tag.FXPlatform)
+                public void test() {
+                    List<String> names = null;
+                    processList(names);
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Wildcard with type variable should trigger erasure "
+            + "fallback, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    /**
+     * Concrete wildcard (no type variables): {@code List<? extends Number>}.
+     */
+    @Test
+    void erasureFallback_concreteWildcard_usesExactCheck()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+            import java.util.List;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void processNumbers(
+                        List<? extends Number> items) {}
+
+                @OnThread(Tag.Worker)
+                public static void processNumbers(String item) {}
+
+                @OnThread(Tag.FXPlatform)
+                public void test() {
+                    List<Integer> ints = null;
+                    processNumbers(ints);
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Concrete wildcard should work via exact check, but got "
+            + "errors:\n" + result.getErrorMessages());
+    }
+
+    /**
+     * Partially concrete generic: {@code Map<String, V>}.
+     */
+    @Test
+    void erasureFallback_partiallyConcreteGeneric_correctlyResolved()
+    {
+        String source = """
+            package testcases;
+            import threadchecker.OnThread;
+            import threadchecker.Tag;
+            import java.util.Map;
+
+            public class TestCase {
+                @OnThread(Tag.FXPlatform)
+                public static void fxPlatformMethod() {}
+
+                @OnThread(Tag.FXPlatform)
+                public static <V> void processMap(Map<String, V> map) {}
+
+                @OnThread(Tag.Worker)
+                public static void processMap(String item) {}
+
+                @OnThread(Tag.FXPlatform)
+                public void test() {
+                    Map<String, Integer> data = null;
+                    processMap(data);
+                }
+            }
+            """;
+
+        CompilationResult result = compileWithThreadChecker(source);
+        assertTrue(result.success,
+            "Partially concrete generic with type variable should "
+            + "trigger erasure fallback, but got errors:\n"
+            + result.getErrorMessages());
+    }
+
+    // ---------------------------------------------------------------
+    //  Test infrastructure
+    // ---------------------------------------------------------------
+
+    /**
+     * Compiles the given source code with the threadchecker plugin
+     * enabled and returns the compilation result including diagnostics.
+     */
+    private CompilationResult compileWithThreadChecker(String sourceCode)
+    {
+        return compileWithThreadChecker(sourceCode, "TestCase");
+    }
+
+    private CompilationResult compileWithThreadChecker(
+            String sourceCode, String className)
+    {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler,
+            "System Java compiler not available -- a full JDK is required");
+
+        DiagnosticCollector<JavaFileObject> diagnostics =
+            new DiagnosticCollector<>();
+
+        try (StandardJavaFileManager fileManager =
+                compiler.getStandardFileManager(diagnostics, null, null))
+        {
+            JavaFileObject source = new SimpleJavaFileObject(
+                URI.create("string:///testcases/" + className + ".java"),
+                JavaFileObject.Kind.SOURCE)
+            {
+                @Override
+                public CharSequence getCharContent(
+                        boolean ignoreEncodingErrors)
+                {
+                    return sourceCode;
+                }
+            };
+
+            String classpath = System.getProperty("java.class.path");
+            List<String> options = Arrays.asList(
+                "-classpath", classpath,
+                "-d", tempDir.toString()
+            );
+
+            JavaCompiler.CompilationTask task = compiler.getTask(
+                null, fileManager, diagnostics,
+                options, null, Collections.singletonList(source));
+
+            JavacTask javacTask = (JavacTask) task;
+            new TCPlugin().init(javacTask);
+
+            boolean success = task.call();
+            return new CompilationResult(success, diagnostics.getDiagnostics());
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static class CompilationResult
+    {
+        final boolean success;
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics;
+
+        CompilationResult(boolean success,
+                List<Diagnostic<? extends JavaFileObject>> diagnostics)
+        {
+            this.success = success;
+            this.diagnostics = diagnostics;
+        }
+
+        List<Diagnostic<? extends JavaFileObject>> getErrors()
+        {
+            return diagnostics.stream()
+                .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+                .collect(Collectors.toList());
+        }
+
+        boolean hasErrorContaining(String text)
+        {
+            return diagnostics.stream()
+                .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+                .anyMatch(d -> d.getMessage(null).contains(text));
+        }
+
+        String getErrorMessages()
+        {
+            return diagnostics.stream()
+                .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+                .map(d -> d.getMessage(null))
+                .collect(Collectors.joining("\n"));
+        }
+    }
+}


### PR DESCRIPTION
This improves support for lambdas in the threadchecker and adds the threading utilities I needed it for.

I originally implemented this as a parameter annotation, but at some point I noticed that the interface tag is taken into account, just doesn't work in all cases and fixed that instead.