### PR TITLE
bluej/build.gradle: Add aarch64 support for flatpakGradleGenerator

### DIFF
--- a/bluej/build.gradle
+++ b/bluej/build.gradle
@@ -49,8 +49,25 @@ tasks.flatpakGradleGenerator {
     description = "Collect dependencies for Flatpak"
     outputFile = file(out)
     downloadDirectory = "./offline-repository"
-    doFirst { println "Generating dependencies.json for flatpak in " + out}
-    doLast { println "Generated dependencies.json for flatpak" }
+    onlyArches = 'x86_64'
+}
+
+tasks.register("flatpakGradleGeneratorAarch64", io.github.jwharm.flatpakgradlegenerator.FlatpakGradleGeneratorTask) {
+    def out = "${rootDir.absolutePath}/${flatpakDir}/dependencies-aarch64.json"
+    description = "Collect dependencies for Flatpak (aarch64)"
+    outputFile = file(out)
+    downloadDirectory = "./offline-repository"
+    onlyArches = 'aarch64'
+}
+
+tasks.register("flatpak") {
+    description = "Collect dependencies for Flatpak (architecture-aware)"
+    def arch = System.getProperty("os.arch")
+    if (arch == "aarch64") {
+        dependsOn("flatpakGradleGeneratorAarch64")
+    } else {
+        dependsOn("flatpakGradleGenerator")
+    }
 }
 
 compileJava {


### PR DESCRIPTION
072ea4c ("bluej/build.gradle: Add support for running flatpakGradleGenerator") added support for creating the list of dependencies for gradle, but only for x86_64. This commit adds support for aarch64 by adding a task flatpakGradleGeneratorAarch64.

To simplify usage, another task "flatpak" is added which runs the flatpakGradleGenerator task matching the current architecture.

In order to create a full set of dependencies, `./gradlew flatpak` must be run on an x86_64 and an aarch64 host, and the files `dependencies.json` and `dependencies-aarch64.json` must both be updated in the org.bluej.BlueJ flatpak package.

With this change, the flathub [test build](https://github.com/flathub-infra/vorarbeiter/actions/runs/22905362060) from [my flathub PR](https://github.com/flathub/org.bluej.BlueJ/pull/20) succeeded for both x86_64 and aarch64 architectures. I hadn't been able to test this before because test builds on Flathub were disabled for a few weeks.
