### PR TITLE
Bug fixing in Kotlin support + Support of packaging and importing for Kotlin

### DIFF
--- a/.specs/kotlin-for-bluej/diagram/README.md
+++ b/.specs/kotlin-for-bluej/diagram/README.md
@@ -30,7 +30,7 @@ All spokes work identically for Kotlin as for Java/Stride. Modifications are in 
 - **Dependency system is unchanged** -- `KotlinInfoParser` produces standard `ClassInfo` consumed by `analyseDependencies()`
 - **Template substitution** -- Kotlin templates use same `$CLASSNAME`/`$PKGLINE` variables as Java
 - **`canConvertToStride()` returns false** for Kotlin
-- **`enforcePackage()` skips Kotlin** (Java-only; Kotlin-aware enforcement is post-MVP)
+- **`enforcePackage()` rewrites Kotlin package directives** alongside Java. The branch that inserts a missing directive omits the trailing semicolon for Kotlin (Java emits `";\n\n"`, Kotlin emits `"\n\n"`); rename and delete branches reuse the PSI-derived `Selection`s from `KotlinInfoParser`
 
 ### Dependency Editing (UI -> Source)
 

--- a/.specs/kotlin-for-bluej/diagram/README.md
+++ b/.specs/kotlin-for-bluej/diagram/README.md
@@ -33,6 +33,7 @@ All spokes work identically for Kotlin as for Java/Stride. Modifications are in 
 - **`enforcePackage()` rewrites Kotlin package directives** alongside Java. The branch that inserts a missing directive omits the trailing semicolon for Kotlin (Java emits `";\n\n"`, Kotlin emits `"\n\n"`); rename and delete branches reuse the PSI-derived `Selection`s from `KotlinInfoParser`
 - **Package move (`Package.importFile`)** accepts `.kt` alongside `.java` and `.stride` via the shared `stripRecognisedSourceExtension` helper. After the source file is copied to the destination, the standard `addClass` → `analyseSource` flow picks up the right `SourceType.Kotlin`, applies `enforcePackage`, and the next compile in the destination emits the proper `.class` (regular classes) or facade `.class` (top-level functions).
 - **Non-BlueJ project import (`Import.convertNonBlueJ`)** treats `.kt` files as first-class source files: `findInterestingDirectories` marks a directory interesting if it contains any recognised source file (Java, Stride, or Kotlin); `findSourceFiles` (formerly `findJavaFiles`) returns all such files. The mismatch loop dispatches to `KotlinInfoParser.parse` for `.kt` files and `InfoParser.parse` for `.java` files.
+- **Add Class from File…** (`PkgMgrFrame.doAddFromFile`) uses `FileUtility.getSourceFilterFX` (formerly `getJavaStrideSourceFilterFX`) which lists `*.java`, `*.stride`, and `*.kt` in the file picker. The selected files are routed through `Package.importFile`, which is also Kotlin-aware.
 
 ### Dependency Editing (UI -> Source)
 

--- a/.specs/kotlin-for-bluej/diagram/README.md
+++ b/.specs/kotlin-for-bluej/diagram/README.md
@@ -31,6 +31,8 @@ All spokes work identically for Kotlin as for Java/Stride. Modifications are in 
 - **Template substitution** -- Kotlin templates use same `$CLASSNAME`/`$PKGLINE` variables as Java
 - **`canConvertToStride()` returns false** for Kotlin
 - **`enforcePackage()` rewrites Kotlin package directives** alongside Java. The branch that inserts a missing directive omits the trailing semicolon for Kotlin (Java emits `";\n\n"`, Kotlin emits `"\n\n"`); rename and delete branches reuse the PSI-derived `Selection`s from `KotlinInfoParser`
+- **Package move (`Package.importFile`)** accepts `.kt` alongside `.java` and `.stride` via the shared `stripRecognisedSourceExtension` helper. After the source file is copied to the destination, the standard `addClass` → `analyseSource` flow picks up the right `SourceType.Kotlin`, applies `enforcePackage`, and the next compile in the destination emits the proper `.class` (regular classes) or facade `.class` (top-level functions).
+- **Non-BlueJ project import (`Import.convertNonBlueJ`)** treats `.kt` files as first-class source files: `findInterestingDirectories` marks a directory interesting if it contains any recognised source file (Java, Stride, or Kotlin); `findSourceFiles` (formerly `findJavaFiles`) returns all such files. The mismatch loop dispatches to `KotlinInfoParser.parse` for `.kt` files and `InfoParser.parse` for `.java` files.
 
 ### Dependency Editing (UI -> Source)
 

--- a/.specs/kotlin-for-bluej/parser/README.md
+++ b/.specs/kotlin-for-bluej/parser/README.md
@@ -59,6 +59,7 @@
 - PSI-based `ClassInfo` extraction: class name, superclass, interfaces, methods, modifiers, package, type parameters
 - For function-only files: synthesizes `ClassInfo` with `topLevelFunctionsOnly=true`
 - Supertype-editing `Selection` positions derived from `PsiElement.getTextRange()`
+- Package-directive `Selection`s (keyword span + name span + zero-length post-name marker) derived from `KtFile.getPackageDirective()` so `ClassTarget.enforcePackage()` can rewrite the line in place; built via `KotlinParserUtils.packageSelections(ktFile, source)`. The post-name marker takes the place of Java's `;` (Kotlin has no trailing semicolon).
 
 ---
 

--- a/.specs/kotlin-for-bluej/toplevel/README.md
+++ b/.specs/kotlin-for-bluej/toplevel/README.md
@@ -18,14 +18,32 @@ Mixed files (class + top-level functions) are not supported. Extra declarations 
 
 ## Facade Class Naming
 
-Kotlin compiles `Utils.kt` (functions only) to `UtilsKt.class`. The naming mismatch is resolved in `ClassTarget`:
+Kotlin compiles a top-level-functions file into a JVM facade class whose
+name is the source-file stem with its **first letter capitalised** and
+`Kt` appended. The naming mismatch is resolved in `ClassTarget`:
 
-| Concept | Value |
-|---------|-------|
-| Source file / diagram display | `Utils` |
-| Compiled facade class / qualified name | `UtilsKt` |
+| Source file | Compiled facade class |
+|---|---|
+| `Utils.kt` | `UtilsKt` |
+| `utils.kt` | `UtilsKt` (first letter uppercased) |
+| `myUtil.kt` | `MyUtilKt` |
+| `A.kt` / `a.kt` | `AKt` |
 
-`ClassTarget.getQualifiedName()` appends `"Kt"` when role is `KotlinFileRole`. Uses `volatile boolean isKotlinFacade` for thread safety (`getQualifiedName()` is `@OnThread(Tag.Any)` but `role` requires `@FXPlatform`).
+The capitalisation rule lives in one place:
+`bluej.parser.kotlin.KotlinParserUtils.kotlinFacadeClassName(stem)`. Every
+site that needs to derive the compiled facade name from a source stem
+uses that helper:
+
+- `ClassTarget.getQualifiedName()` — class-loader lookup name
+- `ClassTarget.getClassFile()` — `.class` file path
+- `ClassTarget.InnerClassFileFilter` — inner-class match prefix
+- `ClassTarget.removeGeneratedFiles()` — facade `.ctxt` cleanup
+- `Package.findTargets()` — facade-class dedup against the set of
+  expected facade names built from the Kotlin source stems
+
+The class itself stores a `volatile boolean isKotlinFacade` flag so
+`getQualifiedName()` can stay `@OnThread(Tag.Any)` while role assignment
+remains on FXPlatform.
 
 ---
 

--- a/bluej/src/main/java/bluej/parser/kotlin/KotlinInfoParser.java
+++ b/bluej/src/main/java/bluej/parser/kotlin/KotlinInfoParser.java
@@ -128,6 +128,7 @@ public class KotlinInfoParser
 
         FqName packageFqName = ktFile.getPackageFqName();
         String packageName = packageFqName.isRoot() ? "" : packageFqName.asString();
+        Selection[] pkgSelections = KotlinParserUtils.packageSelections(ktFile, source);
 
         KtClassOrObject classOrObject = null;
         for (KtDeclaration decl : ktFile.getDeclarations()) {
@@ -148,7 +149,7 @@ public class KotlinInfoParser
                 return null; // No class AND no functions — truly empty file
             }
             return buildTopLevelFunctionsInfo(
-                topLevelFunctions, ktFile, packageName, targetPkg);
+                topLevelFunctions, ktFile, packageName, pkgSelections, targetPkg);
         }
 
         // Mixed content (class + functions/properties) — return null to prevent file rename
@@ -158,14 +159,15 @@ public class KotlinInfoParser
             }
         }
 
-        return buildClassInfo(classOrObject, ktFile, packageName, targetPkg);
+        return buildClassInfo(classOrObject, ktFile, packageName, pkgSelections, targetPkg);
     }
 
     /**
      * Build a {@link ClassInfo} from a PSI class/object declaration.
      */
     private static ClassInfo buildClassInfo(KtClassOrObject classOrObject,
-            KtFile ktFile, String packageName, String targetPkg)
+            KtFile ktFile, String packageName, Selection[] pkgSelections,
+            String targetPkg)
     {
         ClassInfo info = new ClassInfo();
 
@@ -193,12 +195,12 @@ public class KotlinInfoParser
             info.setEnum(false);
         }
 
-        if (!packageName.isEmpty()) {
+        if (pkgSelections != null) {
             info.setPackageSelections(
-                new Selection(1, 1),   // package statement placeholder
-                new Selection(1, 1),   // package name placeholder
-                packageName,           // the actual package name text
-                new Selection(1, 1)    // semi placeholder (Kotlin has no semicolons)
+                pkgSelections[0],     // package keyword span
+                pkgSelections[1],     // package name span
+                packageName,          // the actual package name text
+                pkgSelections[2]      // zero-length post-name marker (no semicolons in Kotlin)
             );
         }
 
@@ -231,7 +233,8 @@ public class KotlinInfoParser
      */
     private static ClassInfo buildTopLevelFunctionsInfo(
             List<KtNamedFunction> functions,
-            KtFile ktFile, String packageName, String targetPkg)
+            KtFile ktFile, String packageName, Selection[] pkgSelections,
+            String targetPkg)
     {
         ClassInfo info = new ClassInfo();
 
@@ -247,12 +250,12 @@ public class KotlinInfoParser
         info.setEnum(false);
         info.setAbstract(false);
 
-        if (!packageName.isEmpty()) {
+        if (pkgSelections != null) {
             info.setPackageSelections(
-                new Selection(1, 1),   // package statement placeholder
-                new Selection(1, 1),   // package name placeholder
-                packageName,           // the actual package name text
-                new Selection(1, 1)    // semi placeholder (Kotlin has no semicolons)
+                pkgSelections[0],     // package keyword span
+                pkgSelections[1],     // package name span
+                packageName,          // the actual package name text
+                pkgSelections[2]      // zero-length post-name marker (no semicolons in Kotlin)
             );
         }
 

--- a/bluej/src/main/java/bluej/parser/kotlin/KotlinParserUtils.java
+++ b/bluej/src/main/java/bluej/parser/kotlin/KotlinParserUtils.java
@@ -47,6 +47,31 @@ public final class KotlinParserUtils
     }
 
     /**
+     * Compute the JVM facade class name the Kotlin compiler produces for a
+     * top-level-functions file with the given source-file stem.
+     *
+     * <p>K2 capitalises the first letter of the stem and appends {@code "Kt"},
+     * so {@code utils.kt} compiles to {@code UtilsKt.class}, {@code myUtil.kt}
+     * compiles to {@code MyUtilKt.class}, and {@code Utils.kt} compiles to
+     * {@code UtilsKt.class}. The casing of the rest of the stem is preserved.
+     *
+     * <p>This is verified against {@code K2JVMCompiler} 2.1.20 and is consistent
+     * with {@code @file:JvmName} default behaviour. Use this from every site
+     * that needs to derive the facade class name from a source-file stem so
+     * the rule lives in exactly one place.
+     *
+     * @param stem the source-file stem (no extension), e.g. {@code "utils"}
+     * @return the facade class simple name, e.g. {@code "UtilsKt"}
+     */
+    public static String kotlinFacadeClassName(String stem)
+    {
+        if (stem == null || stem.isEmpty()) {
+            return stem;
+        }
+        return Character.toUpperCase(stem.charAt(0)) + stem.substring(1) + "Kt";
+    }
+
+    /**
      * Convert a 0-based character offset within {@code source} to a 1-based
      * {@link Selection}-compatible [line, column] pair. The end of the
      * conversion is inclusive: the returned column is the column of the

--- a/bluej/src/main/java/bluej/parser/kotlin/KotlinParserUtils.java
+++ b/bluej/src/main/java/bluej/parser/kotlin/KotlinParserUtils.java
@@ -24,7 +24,15 @@ package bluej.parser.kotlin;
 import java.io.IOException;
 import java.io.Reader;
 
+import bluej.parser.SourceLocation;
+import bluej.parser.SourceSpan;
 import bluej.parser.nodes.ReparseableDocument;
+import bluej.parser.symtab.Selection;
+
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange;
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement;
+import org.jetbrains.kotlin.psi.KtFile;
+import org.jetbrains.kotlin.psi.KtPackageDirective;
 
 import threadchecker.OnThread;
 import threadchecker.Tag;
@@ -36,6 +44,98 @@ public final class KotlinParserUtils
 {
     private KotlinParserUtils()
     {
+    }
+
+    /**
+     * Convert a 0-based character offset within {@code source} to a 1-based
+     * {@link Selection}-compatible [line, column] pair. The end of the
+     * conversion is inclusive: the returned column is the column of the
+     * character at {@code offset} (or one past the end of the last line if
+     * {@code offset} equals {@code source.length()}).
+     *
+     * @param source the full source text
+     * @param offset 0-based character offset (clamped to {@code source.length()})
+     * @return [line, column], both 1-based
+     */
+    public static int[] offsetToLineColumn(String source, int offset)
+    {
+        if (offset < 0) {
+            offset = 0;
+        }
+        if (offset > source.length()) {
+            offset = source.length();
+        }
+        int line = 1;
+        int column = 1;
+        for (int i = 0; i < offset; i++) {
+            if (source.charAt(i) == '\n') {
+                line++;
+                column = 1;
+            } else {
+                column++;
+            }
+        }
+        return new int[]{line, column};
+    }
+
+    /**
+     * Build a {@link Selection} spanning the 0-based, half-open offset range
+     * {@code [start, end)} in {@code source}.
+     */
+    @OnThread(Tag.FXPlatform)
+    public static Selection rangeToSelection(String source, int start, int end)
+    {
+        int[] startPos = offsetToLineColumn(source, start);
+        int[] endPos = offsetToLineColumn(source, end);
+        SourceLocation startLoc = new SourceLocation(startPos[0], startPos[1]);
+        SourceLocation endLoc = new SourceLocation(endPos[0], endPos[1]);
+        return new Selection(new SourceSpan(startLoc, endLoc));
+    }
+
+    /**
+     * Build the three {@link Selection}s the BlueJ source-rewriter needs for a
+     * Kotlin file's package directive: the {@code package} keyword token, the
+     * package-name expression, and a zero-length sentinel selection used in
+     * place of Java's trailing semicolon (Kotlin has no semicolons after
+     * package directives).
+     *
+     * <p>Positions are derived from the live PSI tree, so the rewriter can
+     * accurately strip or replace the directive via
+     * {@link bluej.pkgmgr.target.ClassTarget#replaceSelection}.
+     *
+     * @param ktFile the parsed Kotlin file
+     * @param source the original source text the file was parsed from
+     * @return three {@link Selection}s for the {@code package} keyword, the
+     *         name, and a zero-length post-name marker; or {@code null} when
+     *         the file has no package directive in source
+     */
+    @OnThread(Tag.FXPlatform)
+    public static Selection[] packageSelections(KtFile ktFile, String source)
+    {
+        KtPackageDirective directive = ktFile.getPackageDirective();
+        if (directive == null) {
+            return null;
+        }
+        PsiElement keyword = directive.getPackageKeyword();
+        PsiElement nameExpr = directive.getPackageNameExpression();
+        if (keyword == null || nameExpr == null) {
+            return null;
+        }
+
+        TextRange keywordRange = keyword.getTextRange();
+        TextRange nameRange = nameExpr.getTextRange();
+
+        Selection pkgStatement = rangeToSelection(source,
+                keywordRange.getStartOffset(), keywordRange.getEndOffset());
+        Selection pkgName = rangeToSelection(source,
+                nameRange.getStartOffset(), nameRange.getEndOffset());
+        // Kotlin has no semicolon; use a zero-length selection right after
+        // the package name so callers that expect a "post-name" cursor still
+        // get a sane position when they ask for it.
+        Selection pkgSemi = rangeToSelection(source,
+                nameRange.getEndOffset(), nameRange.getEndOffset());
+
+        return new Selection[]{pkgStatement, pkgName, pkgSemi};
     }
 
     /**

--- a/bluej/src/main/java/bluej/pkgmgr/Import.java
+++ b/bluej/src/main/java/bluej/pkgmgr/Import.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2014,2016,2019  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2014,2016,2019,2026  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -23,6 +23,7 @@ package bluej.pkgmgr;
 
 import bluej.extensions2.SourceType;
 import bluej.parser.InfoParser;
+import bluej.parser.kotlin.KotlinInfoParser;
 import bluej.parser.symtab.ClassInfo;
 import bluej.utility.Debug;
 import bluej.utility.DialogManager;
@@ -32,7 +33,9 @@ import javafx.stage.Window;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -51,10 +54,10 @@ public class Import
 {
     /**
      * Attempt to convert a non-bluej Path to a Bluej project.
-     * 
-     * <p>If no java source files are found, a warning dialog is displayed and
-     * the conversion doesn't take place.
-     * 
+     *
+     * <p>If no source files (Java, Stride, or Kotlin) are found, a warning
+     * dialog is displayed and the conversion doesn't take place.
+     *
      * <p>If source files are found whose package line mismatches the apparent
      * package, a warning dialog is displayed and the user is prompted to
      * either allow the package line to be corrected, or to cancel the
@@ -66,33 +69,29 @@ public class Import
      */
     public static boolean convertNonBlueJ(FXPlatformSupplier<Window> parentWin, File path)
     {
-        // find all sub directories with Java files in them
-        // then find all the Java files in those directories
+        // find all sub directories with recognised source files,
+        // then find all the source files in those directories
         List<File> interestingDirs = Import.findInterestingDirectories(path);
 
-        // check to make sure the path contains some java source files
+        // check to make sure the path contains some recognised source files
         if (interestingDirs.size() == 0) {
             DialogManager.showErrorFX(parentWin.get(), "open-non-bluej-no-java");
             return false;
         }
 
-        List<File> javaFiles = Import.findJavaFiles(interestingDirs);
+        List<File> sourceFiles = Import.findSourceFiles(interestingDirs);
 
-        // for each Java file, lets check its package line against the
-        // package line we think that it should have
-        // for each mismatch we collect the file, the package line it had,
-        // and what we want to convert it to
+        // for each source file, check its package directive against the
+        // package line we think that it should have. For each mismatch we
+        // collect the file, the package line it had, and what we want
+        // to convert it to.
         List<File> mismatchFiles = new ArrayList<File>();
         List<String> mismatchPackagesOriginal = new ArrayList<String>();
         List<String> mismatchPackagesChanged = new ArrayList<String>();
 
-        Iterator<File> it = javaFiles.iterator();
-
-        while (it.hasNext()) {
-            File f = it.next();
-
+        for (File f : sourceFiles) {
             try {
-                ClassInfo info = InfoParser.parse(f);
+                ClassInfo info = parseSourceFile(f);
                 if (info != null && ! info.hadParseError()) {
 
                     String qf = JavaNames.convertFileToQualifiedName(path, f);
@@ -105,6 +104,7 @@ public class Import
                 }
             }
             catch (FileNotFoundException fnfe) {}
+            catch (IOException ioe) {}
         }
 
         // now ask if they want to continue if we have detected mismatches
@@ -123,11 +123,34 @@ public class Import
     }
 
     /**
+     * Parse a source file via the appropriate parser for its extension.
+     * Returns null for unrecognised extensions or empty files.
+     */
+    private static ClassInfo parseSourceFile(File f) throws IOException
+    {
+        String name = f.getName();
+        if (name.endsWith("." + SourceType.Java.getExtension())) {
+            return InfoParser.parse(f);
+        }
+        if (name.endsWith("." + SourceType.Kotlin.getExtension())) {
+            try (Reader r = new FileReader(f)) {
+                // Pass file name so the parser can derive top-level-functions
+                // file names from the stem; package is the only field we need
+                // here, so targetPkg validation is skipped (null).
+                return KotlinInfoParser.parse(r, null, name);
+            }
+        }
+        // Stride files have generated .java siblings that are picked up
+        // by the .java branch above; we don't need to parse .stride here.
+        return null;
+    }
+
+    /**
      * Find all directories under a certain directory which
      * we deem 'interesting'.
      * An interesting directory is one which either contains
-     * a java source file or contains a directory which in
-     * turn contains a java source file.
+     * a recognised source file (Java, Stride, or Kotlin) or contains
+     * a directory which in turn contains such a source file.
      *
      * @param   dir     the directory to look in
      * @returns         a list of File's representing the
@@ -161,13 +184,13 @@ public class Import
                 }
             }
             else {
-                if (files[i].getName().endsWith("." + SourceType.Java.toString().toLowerCase()))
+                if (hasRecognisedSourceExtension(files[i].getName()))
                     imInteresting = true;
             }
         }
 
-        // if we have found anything of interest (either a java
-        // file or a subdirectory with java files) then we consider
+        // if we have found anything of interest (either a source
+        // file or a subdirectory with source files) then we consider
         // ourselves interesting and add ourselves to the list
         if (imInteresting)
             interesting.add(dir);
@@ -176,32 +199,40 @@ public class Import
     }
 
     /**
-     * Find all Java files contained in a list of
-     * directory paths.
+     * Find all recognised source files (Java, Stride, Kotlin) contained
+     * in a list of directory paths. Stride is included for completeness
+     * but {@link #convertNonBlueJ} only parses Java and Kotlin for
+     * package-mismatch detection.
      */
-    public static List<File> findJavaFiles(List<File> dirs)
+    public static List<File> findSourceFiles(List<File> dirs)
     {
         List<File> interesting = new LinkedList<File>();
 
-        Iterator<File> it = dirs.iterator();
-
-        while(it.hasNext()) {
-            File dir = it.next();
-
+        for (File dir : dirs) {
             File[] files = dir.listFiles();
-
             if (files == null) {
                 continue;
             }
-
-            for (int i=0; i<files.length; i++) {
-                if (files[i].isFile() && files[i].getName().endsWith("." + SourceType.Java.toString().toLowerCase())) {
-                    interesting.add(files[i]);
+            for (File f : files) {
+                if (f.isFile() && hasRecognisedSourceExtension(f.getName())) {
+                    interesting.add(f);
                 }
             }
         }
 
         return interesting;
+    }
+
+    /**
+     * Whether {@code fileName} ends with one of the source extensions we
+     * recognise during non-BlueJ project import: {@code .java},
+     * {@code .stride}, or {@code .kt}.
+     */
+    private static boolean hasRecognisedSourceExtension(String fileName)
+    {
+        return fileName.endsWith("." + SourceType.Java.getExtension())
+            || fileName.endsWith("." + SourceType.Stride.getExtension())
+            || fileName.endsWith("." + SourceType.Kotlin.getExtension());
     }
 
     /**

--- a/bluej/src/main/java/bluej/pkgmgr/NewClassDialog.java
+++ b/bluej/src/main/java/bluej/pkgmgr/NewClassDialog.java
@@ -88,6 +88,7 @@ class NewClassDialog extends Dialog<NewClassDialog.NewClassInfo>
      * The label with the error message.
      */
     private final Label errorLabel;
+    private final ObservableValue<Boolean> isClassContentBoxEnabled;
 
     /**
      * The information selected in the dialog: class name,
@@ -164,7 +165,7 @@ class NewClassDialog extends Dialog<NewClassDialog.NewClassInfo>
         HBox classContentBox = new HBox(new Label(Config.getString("pkgmgr.newClass.content")), classContent);
         classContentBox.setSpacing(10);
         classContentBox.setAlignment(Pos.BASELINE_LEFT);
-        ObservableValue<Boolean> isClassContentBoxEnabled = language.selectedProperty()
+        isClassContentBoxEnabled = language.selectedProperty()
                 .map(language -> language != SourceType.Kotlin);
         classContentBox.visibleProperty().bind(isClassContentBoxEnabled);
         classContentBox.managedProperty().bind(isClassContentBoxEnabled);

--- a/bluej/src/main/java/bluej/pkgmgr/NewClassDialog.java
+++ b/bluej/src/main/java/bluej/pkgmgr/NewClassDialog.java
@@ -34,6 +34,7 @@ import java.util.StringTokenizer;
 
 import bluej.prefmgr.PrefMgr;
 import javafx.application.Platform;
+import javafx.beans.value.ObservableValue;
 import javafx.geometry.Pos;
 import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
@@ -163,6 +164,10 @@ class NewClassDialog extends Dialog<NewClassDialog.NewClassInfo>
         HBox classContentBox = new HBox(new Label(Config.getString("pkgmgr.newClass.content")), classContent);
         classContentBox.setSpacing(10);
         classContentBox.setAlignment(Pos.BASELINE_LEFT);
+        ObservableValue<Boolean> isClassContentBoxEnabled = language.selectedProperty()
+                .map(language -> language != SourceType.Kotlin);
+        classContentBox.visibleProperty().bind(isClassContentBoxEnabled);
+        classContentBox.managedProperty().bind(isClassContentBoxEnabled);
         mainPanel.getChildren().add(classContentBox);
 
 
@@ -181,10 +186,14 @@ class NewClassDialog extends Dialog<NewClassDialog.NewClassInfo>
         setResultConverter(buttonType -> {
             if (buttonType == ButtonType.OK)
             {
+                SourceType selectedLanguage = language.selectedProperty().get();
+                ClassContent selectedContent = selectedLanguage == SourceType.Kotlin
+                        ? ClassContent.FULL
+                        : classContent.getSelectionModel().getSelectedItem();
                 // Save the classContent preference:
-                PrefMgr.setFlag(PrefMgr.NEW_CLASS_FULL_CONTENT, classContent.getSelectionModel().getSelectedItem() == ClassContent.FULL);
+                PrefMgr.setFlag(PrefMgr.NEW_CLASS_FULL_CONTENT, selectedContent == ClassContent.FULL);
 
-                return new NewClassInfo(nameField.getText().trim(), templates.get(templateButtons.getSelectedToggle()).name, language.selectedProperty().get(), classContent.getSelectionModel().getSelectedItem());
+                return new NewClassInfo(nameField.getText().trim(), templates.get(templateButtons.getSelectedToggle()).name, selectedLanguage, selectedContent);
             }
             else {
                 return null;

--- a/bluej/src/main/java/bluej/pkgmgr/Package.java
+++ b/bluej/src/main/java/bluej/pkgmgr/Package.java
@@ -61,6 +61,7 @@ import bluej.extensions2.SourceType;
 import bluej.extensions2.event.CompileEvent;
 import bluej.extensions2.event.CompileEvent.EventType;
 import bluej.extmgr.ExtensionsManager;
+import bluej.parser.kotlin.KotlinParserUtils;
 import bluej.parser.symtab.ClassInfo;
 import bluej.pkgmgr.target.*;
 import bluej.prefmgr.PrefMgr;
@@ -68,7 +69,6 @@ import bluej.utility.*;
 import bluej.utility.filefilter.FrameSourceFilter;
 import bluej.utility.filefilter.JavaClassFilter;
 import bluej.utility.filefilter.JavaSourceFilter;
-import bluej.parser.kotlin.KotlinParserUtils;
 import bluej.utility.filefilter.KotlinSourceFilter;
 import bluej.utility.filefilter.SubPackageFilter;
 import threadchecker.OnThread;
@@ -1361,23 +1361,20 @@ public final class Package
     /**
      * Import a source file into this package as a new class target. Returns an
      * error code: NO_ERROR - everything is fine FILE_NOT_FOUND - file does not
-     * exist ILLEGAL_FORMAT - the file name does not end in ".java" CLASS_EXISTS -
-     * a class with this name already exists COPY_ERROR - could not copy
+     * exist ILLEGAL_FORMAT - the file name does not end in a recognised source
+     * extension (.java, .stride, or .kt) CLASS_EXISTS - a class with this name
+     * already exists COPY_ERROR - could not copy
      */
     public int importFile(File aFile)
     {
-        // check whether specified class exists and is a java file
+        // check whether specified file exists and has a recognised source extension
 
         if (!aFile.exists())
             return FILE_NOT_FOUND;
         String fileName = aFile.getName();
 
-        String className;
-        if (fileName.endsWith("." + SourceType.Java.getExtension())) // it's a Java source file
-            className = fileName.substring(0, fileName.length() - SourceType.Java.getExtension().length() - 1);
-        else if (fileName.endsWith("." + SourceType.Stride.getExtension())) // it's a Stride source file
-            className = fileName.substring(0, fileName.length() - SourceType.Stride.getExtension().length() - 1);
-        else
+        String className = stripRecognisedSourceExtension(fileName);
+        if (className == null)
             return ILLEGAL_FORMAT;
 
         // check whether name is already used
@@ -1412,6 +1409,25 @@ public final class Package
         DataCollector.addClass(this, t);
 
         return NO_ERROR;
+    }
+
+    /**
+     * If {@code fileName} ends with a source extension BlueJ recognises
+     * ({@code .java}, {@code .stride}, or {@code .kt}), return the
+     * stem (file name without extension). Otherwise return {@code null}.
+     *
+     * <p>Used by {@link #importFile(File)} to decide whether an arbitrary
+     * file path can be imported as a class target.
+     */
+    static String stripRecognisedSourceExtension(String fileName)
+    {
+        for (SourceType st : new SourceType[]{SourceType.Java, SourceType.Stride, SourceType.Kotlin}) {
+            String suffix = "." + st.getExtension();
+            if (fileName.endsWith(suffix)) {
+                return fileName.substring(0, fileName.length() - suffix.length());
+            }
+        }
+        return null;
     }
 
     public ClassTarget addClass(String className)

--- a/bluej/src/main/java/bluej/pkgmgr/Package.java
+++ b/bluej/src/main/java/bluej/pkgmgr/Package.java
@@ -68,6 +68,7 @@ import bluej.utility.*;
 import bluej.utility.filefilter.FrameSourceFilter;
 import bluej.utility.filefilter.JavaClassFilter;
 import bluej.utility.filefilter.JavaSourceFilter;
+import bluej.parser.kotlin.KotlinParserUtils;
 import bluej.utility.filefilter.KotlinSourceFilter;
 import bluej.utility.filefilter.SubPackageFilter;
 import threadchecker.OnThread;
@@ -675,6 +676,14 @@ public final class Package
         }
 
         // process all *.kt files
+        // Record the *facade class names* the Kotlin compiler will emit for
+        // each top-level-functions source file. K2 capitalises the stem's
+        // first letter and appends "Kt", so utils.kt → UtilsKt.class. We
+        // need that set later to dedup facade .class files; a naïve
+        // stripSuffix("Kt") on the class name produces the wrong stem for
+        // lowercase sources (UtilsKt → "Utils", which doesn't match the
+        // lowercase "utils" we just added to interestingSet).
+        Set<String> kotlinFacadeNames = new HashSet<String>();
         File kotlinSrcFiles[] = path.listFiles(new KotlinSourceFilter());
         if (kotlinSrcFiles != null)
         {
@@ -694,6 +703,8 @@ public final class Package
                 // to ignore)
                 if (kotlinFileName.indexOf('$') == -1) {
                     interestingSet.add(kotlinFileName);
+                    kotlinFacadeNames.add(
+                            KotlinParserUtils.kotlinFacadeClassName(kotlinFileName));
                 }
             }
         }
@@ -713,10 +724,11 @@ public final class Package
 
             if (classFileName.indexOf('$') == -1) {
                 // skip Kt facade classes that have a corresponding .kt source
-                // (e.g., UtilsKt.class when Utils.kt exists)
-                if (classFileName.endsWith("Kt") && classFileName.length() > 2
-                        && interestingSet.contains(
-                                classFileName.substring(0, classFileName.length() - 2))) {
+                // (e.g., UtilsKt.class when utils.kt or Utils.kt exists).
+                // Match against the precomputed kotlinFacadeNames so the
+                // capitalisation rule lives in one place
+                // (KotlinParserUtils.kotlinFacadeClassName).
+                if (kotlinFacadeNames.contains(classFileName)) {
                     continue;
                 }
                 // add only if there is no corresponding source file

--- a/bluej/src/main/java/bluej/pkgmgr/PkgMgrFrame.java
+++ b/bluej/src/main/java/bluej/pkgmgr/PkgMgrFrame.java
@@ -1867,8 +1867,8 @@ public class PkgMgrFrame
      */
     public void doAddFromFile()
     {
-        // multi selection file dialog that shows .java and .class files
-        List<File> classes = FileUtility.getMultipleFilesFX(getWindow(), Config.getString("pkgmgr.addClass.title"), FileUtility.getJavaStrideSourceFilterFX());
+        // multi selection file dialog showing recognised source files (.java/.stride/.kt)
+        List<File> classes = FileUtility.getMultipleFilesFX(getWindow(), Config.getString("pkgmgr.addClass.title"), FileUtility.getSourceFilterFX());
 
         if (classes == null || classes.isEmpty())
             return;

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -1766,13 +1766,16 @@ public class ClassTarget extends DependentTarget
     public void enforcePackage(String packageName)
         throws IOException
     {
-        if (getSourceType() != SourceType.Java)
+        SourceType st = getSourceType();
+        if (st != SourceType.Java && st != SourceType.Kotlin)
         {
-            // Only force packages in Java files
+            // Stride and other source types are not rewritten this way.
             return;
         }
 
         if (!JavaNames.isQualifiedIdentifier(packageName)) {
+            // Kotlin's qualified-identifier grammar matches Java's for the
+            // purpose of package directives, so the same validator applies.
             throw new IllegalArgumentException();
         }
 
@@ -1780,6 +1783,13 @@ public class ClassTarget extends DependentTarget
         if (info == null) {
             return;
         }
+
+        // Kotlin has no trailing semicolon on package directives; Java does.
+        // This only matters when inserting a missing directive — the rename
+        // and delete branches use either real PSI selections (Kotlin) or the
+        // tokeniser-derived selections (Java) which already span the semicolon.
+        boolean isKotlin = st == SourceType.Kotlin;
+        String semiInsert = isKotlin ? "\n\n" : ";\n\n";
 
         // We may or may not need to change each of the semi colon selection text,
         // package name selection text, and package statement selection text.
@@ -1812,7 +1822,7 @@ public class ClassTarget extends DependentTarget
             }
             else {
                 // we must insert all the "package" statement
-                semiReplacement = ";\n\n";
+                semiReplacement = semiInsert;
                 nameReplacement = packageName;
                 pkgStatementReplacement = "package ";
             }

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -52,6 +52,7 @@ import bluej.parser.context.CompilationUnitContextLoader;
 import bluej.parser.entity.EntityResolver;
 import bluej.parser.entity.PackageResolver;
 import bluej.parser.entity.ParsedReflective;
+import bluej.parser.kotlin.KotlinParserUtils;
 import bluej.parser.nodes.ParsedCUNode;
 import bluej.parser.nodes.ParsedTypeNode;
 import bluej.parser.symtab.ClassInfo;
@@ -383,14 +384,15 @@ public class ClassTarget extends DependentTarget
     public String getQualifiedName()
     {
         String baseName = getBaseName();
-        // Kotlin facade classes are compiled with a "Kt" suffix
-        // (e.g., Utils.kt → UtilsKt.class), so the class loader
-        // needs the suffixed name to find the compiled class.
+        // Kotlin facade classes are compiled with the first letter of the
+        // stem capitalised and a "Kt" suffix appended (e.g. Utils.kt and
+        // utils.kt both → UtilsKt.class). The class loader needs that exact
+        // name; reuse the single source of truth in KotlinParserUtils.
         // Uses volatile isKotlinFacade flag (thread-safe) instead of
         // checking role directly (which requires FXPlatform).
         if (isKotlinFacade)
         {
-            baseName = baseName + "Kt";
+            baseName = KotlinParserUtils.kotlinFacadeClassName(baseName);
         }
         return getPackage().getQualifiedName(baseName);
     }
@@ -1319,10 +1321,12 @@ public class ClassTarget extends DependentTarget
      */
     public File getClassFile()
     {
-        // Kotlin facade classes compile with a "Kt" suffix
+        // Kotlin facade classes compile with the capitalised-stem + "Kt"
+        // facade name; the helper centralises that rule.
         if (isKotlinFacade)
         {
-            return getPackageFile(getBaseName() + "Kt.class");
+            return getPackageFile(
+                KotlinParserUtils.kotlinFacadeClassName(getBaseName()) + ".class");
         }
         return getPackageFile(getBaseName() + ".class");
     }
@@ -1374,9 +1378,10 @@ public class ClassTarget extends DependentTarget
             {
                 return true;
             }
-            // Kotlin facade classes compile as ClassNameKt.class, with
-            // inner/lambda classes as ClassNameKt$lambda.class
-            if (isKotlinFacade && name.startsWith(getBaseName() + "Kt$"))
+            // Kotlin facade classes compile as <CapitalisedStem>Kt.class,
+            // with inner/lambda classes as <CapitalisedStem>Kt$lambda.class.
+            if (isKotlinFacade && name.startsWith(
+                    KotlinParserUtils.kotlinFacadeClassName(getBaseName()) + "$"))
             {
                 return true;
             }
@@ -2577,9 +2582,10 @@ public class ClassTarget extends DependentTarget
     {
         getClassFile().delete();
         getDocumentationFile().delete();
-        // Facade .ctxt files use the "Kt" suffix (matches updateMetadata)
+        // Facade .ctxt files use the capitalised-stem + "Kt" facade name
+        // (matches updateMetadata via getQualifiedName).
         String ctxtName = isKotlinFacade
-            ? getBaseName() + "Kt.ctxt"
+            ? KotlinParserUtils.kotlinFacadeClassName(getBaseName()) + ".ctxt"
             : getBaseName() + ".ctxt";
         getPackageFile(ctxtName).delete();
         getAllSourceFilesJavaLast().forEach(info -> info.file.delete());

--- a/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
+++ b/bluej/src/main/java/bluej/pkgmgr/target/ClassTarget.java
@@ -570,7 +570,7 @@ public class ClassTarget extends DependentTarget
     {
         if (role == null || role.getRoleName() != newRole.getRoleName()) {
             role = newRole;
-            isKotlinFacade = (newRole instanceof KotlinFileRole);
+            isKotlinFacade = (newRole instanceof KotlinFileRole) && !getBaseName().endsWith("Kt");
 
             String select = pseudoFor(role.getClass());
             String stereotype = role.getStereotypeLabel();

--- a/bluej/src/main/java/bluej/utility/FileUtility.java
+++ b/bluej/src/main/java/bluej/utility/FileUtility.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2014,2016,2018,2019,2021  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2014,2016,2018,2019,2021,2026  Michael Kolling and John Rosenberg
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -219,9 +219,12 @@ public class FileUtility
     }
 
     @OnThread(Tag.FX)
-    public static ExtensionFilter getJavaStrideSourceFilterFX()
+    public static ExtensionFilter getSourceFilterFX()
     {
-        return new ExtensionFilter("Java/Stride source", "*." + SourceType.Java.getExtension(), "*." + SourceType.Stride.getExtension());
+        return new ExtensionFilter("Java/Stride/Kotlin source",
+            "*." + SourceType.Java.getExtension(),
+            "*." + SourceType.Stride.getExtension(),
+            "*." + SourceType.Kotlin.getExtension());
     }
 
     /**


### PR DESCRIPTION
Fixed bugs:
- Disabled the minimal version of templates, because we don't support it for Kotlin
- Fixed problems with compilation status for top-level functions

Supported features:
- Package management for Kotlin
- Importing Kotlin projects and files 