### PR TITLE
Count Kotlin editor opens and report kotlineditors= in usage stats

### DIFF
--- a/.specs/AGENTS.md
+++ b/.specs/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Coding Guidelines for BlueJ-Greenfoot
+# AGENTS.md — Coding Guidelines for BlueJ-Greenfoot
 
 ## Project Overview
 
@@ -310,7 +310,7 @@ public String getName() { ... }
 private boolean paused;  // Requires synchronized(this) to access
 ```
 
-**Thread tags** (in order of prevalence — 2,889 annotations across 616 files):
+**Thread tags** (in order of prevalence):
 
 | Tag | Usage | Meaning |
 |-----|-------|---------|
@@ -518,9 +518,18 @@ When adding support for a new source language (e.g., Kotlin alongside Java/Strid
 
 ## Specifications
 
-Design documentation is maintained in `.specs/`.
+Design documentation is maintained in `.specs/`. Every spec file carries YAML frontmatter (`id`, `type`, `title`, `status`, `parent`, `depends-on`, …) that registers it in the project's spec-graph. Discover and navigate specs through the spec-graph tools (`spec_grep`, `spec_get`, `spec_graph`) rather than by directory listing.
 
 ### Spec Writing Rules
+
+#### Registration (Frontmatter)
+
+Every spec file must begin with YAML frontmatter that registers it in the spec-graph:
+
+- Required: unique `id`, `type` (`goal-and-requirements` | `architecture-design` | `module-design` | `submodule-design` | `task-spec`), `title`.
+- Link it into the graph: `parent` mirrors the `.specs/` directory tree; `depends-on` records real design dependencies on other specs.
+- Run `spec_validate` after adding, moving, or restructuring specs.
+- Avoid directory names that file-walkers skip by default (e.g. `build`) — a spec in such a directory silently disappears from the index. This is why the build spec lives in `.specs/kotlin-for-bluej/distribution/`.
 
 #### What a Spec Is For
 
@@ -569,7 +578,7 @@ When a module spec notes a component is "unchanged", verify this by tracing the 
 | Debug Manager (UI) | `.specs/bluej/debugmgr/README.md` | Shell generation, Invoker lifecycle, ResultWatcher hierarchy, ObjectBench |
 | Runtime (ExecServer) | `.specs/bluej/runtime/README.md` | Debug VM two-thread model, static field IPC, breakpoint sync, thread-target dispatch |
 | Compiler | `.specs/bluej/compiler/README.md` | Single-thread compilation queue, producer-consumer, observer adapters |
-| Package Manager | `.specs/bluej/pkgmgr/README.md` | Central orchestrator, compilation batching, 42 synchronized blocks |
+| Package Manager | `.specs/bluej/pkgmgr/README.md` | Central orchestrator, compilation batching, synchronization strategy |
 | Source Code Editor | `.specs/bluej/editor/README.md` | Dual editor modes, FXPlatform enforcement, EditorWatcher contract |
 | Utility Library | `.specs/bluej/utility/README.md` | 8-thread background pool, FX/Worker bridge, CompletableFuture patterns |
 | Terminal | `.specs/bluej/terminal/README.md` | Cross-thread I/O, InputBuffer thread safety |
@@ -582,7 +591,7 @@ When a module spec notes a component is "unchanged", verify this by tracing the 
 | VM Communication | `.specs/greenfoot/vmcomm/README.md` | Shared memory IPC, 3-lock protocol, image double-buffering, command reliability |
 | Audio System | `.specs/greenfoot/sound/README.md` | 6 thread types, ClipProcess/ClipCloser threads, deadlock avoidance |
 
-Run `ls .specs/` for the full list of 54 specifications covering all modules and submodules.
+These tables list only the most load-bearing specs. The full set — covering all modules and submodules — is the spec-graph itself: walk it with `spec_graph` from the root (`goal-and-requirements`), or search it with `spec_grep`.
 
 ---
 

--- a/.specs/DESIGN_DOC.md
+++ b/.specs/DESIGN_DOC.md
@@ -1,3 +1,11 @@
+---
+id: bluej-greenfoot-architecture
+type: architecture-design
+title: "BlueJ-Greenfoot Architecture Design"
+status: active
+parent: goal-and-requirements
+---
+
 # BlueJ-Greenfoot Architecture Design
 
 BlueJ and Greenfoot are educational Java IDEs sharing a monorepo. BlueJ is a general-purpose pedagogical IDE; Greenfoot extends it for 2D game/simulation programming. Built with Gradle, targeting Java 21 and JavaFX 23.0.2.

--- a/.specs/GOAL&REQUIREMENTS.md
+++ b/.specs/GOAL&REQUIREMENTS.md
@@ -1,3 +1,12 @@
+---
+id: goal-and-requirements
+type: goal-and-requirements
+title: "Kotlin for BlueJ — Goal & Requirements"
+status: active
+tags:
+  - kotlin
+---
+
 # Kotlin for BlueJ
 
 * Project\Feature name: Kotlin for BlueJ
@@ -82,7 +91,3 @@ Kotlin files (.kt) will be compiled via `kotlin-compiler-embeddable` invoked pro
 | `break` & `continue` | Loop control |
 | Object inspection in BlueJ object view | Inspect/modify Kotlin property values |
 | Java ↔ Kotlin interop | Mixed projects with cross-language references |
-
-### Reference
-
-See [.specs/external notes/Kotlin in BlueJ.md](.specs/external%20notes/Kotlin%20in%20BlueJ.md) for the original feature subset analysis and pedagogical comparison table.

--- a/.specs/anns-threadchecker/README.md
+++ b/.specs/anns-threadchecker/README.md
@@ -1,3 +1,11 @@
+---
+id: anns-threadchecker
+type: module-design
+title: "Thread-Checker Annotations"
+status: active
+parent: bluej-greenfoot-architecture
+---
+
 # Thread-Checker Annotations
 
 Pure annotation definitions used by the `threadchecker` compiler plugin and all other modules. Declares which thread a method, class, or package should execute on. Zero external dependencies.

--- a/.specs/bluej/README.md
+++ b/.specs/bluej/README.md
@@ -1,3 +1,13 @@
+---
+id: bluej
+type: module-design
+title: "BlueJ Core IDE"
+status: active
+parent: bluej-greenfoot-architecture
+depends-on:
+  - lang-stride
+---
+
 # BlueJ Core IDE
 
 BlueJ is an educational Java IDE providing compilation, debugging, code editing (text and block-based Stride), project management, version control, and an extension system. It is the foundation upon which Greenfoot is built.

--- a/.specs/bluej/README.md
+++ b/.specs/bluej/README.md
@@ -77,6 +77,20 @@ Property hierarchy (each layer overrides the previous):
 
 ---
 
+## Usage Statistics (two separate systems)
+
+1. **Launch ping** (`Main.updateStats()`): once per launch, a background thread sends one anonymous
+   HTTP GET to `stats.bluej.org` (or `stats.greenfoot.org`) with OS, app/Java version, UI language,
+   and per-language editor-open counts. Counts are accumulated across sessions by
+   `Config.recordEditorOpen` (called from `ClassTarget` on first editor show) in `userProps` keys
+   `session.numeditors.{java,stride,kotlin}`, then sent and reset on the next launch. Editor counts
+   are only included when all three properties exist (`getEditorCount != -1` for each). Opt-out:
+   set the `bluej.uid`/`greenfoot.uid` property to `private`.
+2. **Blackbox** (`collect/`): opt-in fine-grained research data collection — unrelated to the
+   launch ping.
+
+---
+
 ## Threading Model
 
 Compile-time-enforced thread safety via `@OnThread` annotations, checked by the `threadchecker` annotation processor.

--- a/.specs/bluej/classmgr/README.md
+++ b/.specs/bluej/classmgr/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-classmgr
+type: submodule-design
+title: "Class Manager"
+status: active
+parent: bluej
+---
+
 # Class Manager
 
 Dynamic class loading for BlueJ projects (3 files).

--- a/.specs/bluej/collect/README.md
+++ b/.specs/bluej/collect/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-collect
+type: submodule-design
+title: "Data Collection"
+status: active
+parent: bluej
+---
+
 # Data Collection
 
 Anonymous, opt-in usage statistics collection system (15 files). Tracks IDE interactions (compilations, method calls, test runs, edits) and submits anonymized events to a remote server via HTTP.

--- a/.specs/bluej/compiler/README.md
+++ b/.specs/bluej/compiler/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-compiler
+type: submodule-design
+title: "Compiler"
+status: active
+parent: bluej
+---
+
 # Compiler
 
 Single-threaded compilation queue (14 files) using the javax.tools Java Compiler API.

--- a/.specs/bluej/debugger/README.md
+++ b/.specs/bluej/debugger/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-debugger
+type: submodule-design
+title: "Debugger (JDI)"
+status: active
+parent: bluej
+---
+
 # Debugger (JDI)
 
 Abstract debugger interface with a JDI (Java Debug Interface) implementation (59 files). Manages a debug VM where user code runs, handling breakpoints, stepping, variable inspection, and object creation.

--- a/.specs/bluej/debugmgr/README.md
+++ b/.specs/bluej/debugmgr/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-debugmgr
+type: submodule-design
+title: "Debug Manager (UI)"
+status: active
+parent: bluej
+---
+
 # Debug Manager (UI)
 
 User-facing debugging interface (~41 files). Provides the Object Bench for storing live objects, inspectors for viewing object state, a code pad for expression evaluation, and execution controls. Orchestrates the full invocation lifecycle: shell code generation -> compilation -> execution in the debug VM -> result unwrapping.

--- a/.specs/bluej/editor/README.md
+++ b/.specs/bluej/editor/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-editor
+type: submodule-design
+title: "Source Code Editor"
+status: active
+parent: bluej
+---
+
 # Source Code Editor
 
 Text and frame-based source code editing (67 files, 4 sub-packages). Supports dual editing modes: traditional text editing with syntax highlighting (Java), and Stride frame-based visual editing.

--- a/.specs/bluej/editor/base/README.md
+++ b/.specs/bluej/editor/base/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-editor-base
+type: submodule-design
+title: "Editor Base Components"
+status: active
+parent: bluej-editor
+---
+
 # Editor Base Components
 
 Low-level editor rendering foundation (7 files). Provides a custom virtualized text editor built on JavaFX primitives (Region, TextFlow, Text nodes) -- NOT using JavaFX TextArea. Used by both the code editor (`FlowEditorPane`) and the terminal (`TerminalTextPane`).

--- a/.specs/bluej/editor/fixes/README.md
+++ b/.specs/bluej/editor/fixes/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-editor-fixes
+type: submodule-design
+title: "Quick Fixes"
+status: active
+parent: bluej-editor
+---
+
 # Quick Fixes
 
 Code fix suggestions triggered by compiler diagnostics (8 files). Provides "did you mean?" corrections, import suggestions, and error-specific quick fixes. Also contains the code completion popup (`SuggestionList`).

--- a/.specs/bluej/editor/flow/README.md
+++ b/.specs/bluej/editor/flow/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-editor-flow
+type: submodule-design
+title: "Flow Text Editor"
+status: active
+parent: bluej-editor
+---
+
 # Flow Text Editor
 
 The traditional text-based Java editor (27 files). Implements the `TextEditor` interface with a custom document model (gap buffer), undo/redo, syntax and scope coloring, find/replace, and incremental parser integration.

--- a/.specs/bluej/editor/highlighting/README.md
+++ b/.specs/bluej/editor/highlighting/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-editor-highlighting
+type: submodule-design
+title: "Java Code Highlighting"
+status: active
+parent: bluej-editor
+---
+
 # Java Code Highlighting
 
 Token-level syntax coloring and structural scope background highlighting in the BlueJ Java editor.

--- a/.specs/bluej/editor/stride/README.md
+++ b/.specs/bluej/editor/stride/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-editor-stride
+type: submodule-design
+title: "Stride Editor Integration"
+status: active
+parent: bluej-editor
+---
+
 # Stride Editor Integration
 
 Integrates the Stride block-based editor into BlueJ's editor framework (21 files). Provides tabbed editing (shared with Java text editors), frame catalogue (block palette), frame shelf (saved blocks), bird's eye view, overlay panes, and error overview bar.

--- a/.specs/bluej/extensions2/README.md
+++ b/.specs/bluej/extensions2/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-extensions2
+type: submodule-design
+title: "Extensions API"
+status: active
+parent: bluej
+---
+
 # Extensions API
 
 The official third-party plugin API (47 files, v3.4). Extensions are loaded from `~/.bluej/extensions2` and can add menu items, respond to IDE events, and interact with projects, packages, and classes through bridge wrapper objects.

--- a/.specs/bluej/extmgr/README.md
+++ b/.specs/bluej/extmgr/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-extmgr
+type: submodule-design
+title: "Extension Manager"
+status: active
+parent: bluej
+---
+
 # Extension Manager
 
 Extension lifecycle management (12 files). Discovers, loads, wraps, and manages third-party extensions from `~/.bluej/extensions2/`.

--- a/.specs/bluej/graph/README.md
+++ b/.specs/bluej/graph/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-graph
+type: submodule-design
+title: "Graph (Class Diagram)"
+status: active
+parent: bluej
+---
+
 # Graph (Class Diagram)
 
 Class diagram interaction layer (6 files). Manages selection, marquee selection, and keyboard navigation within the visual class dependency diagram.

--- a/.specs/bluej/groupwork/README.md
+++ b/.specs/bluej/groupwork/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-groupwork
+type: submodule-design
+title: "Groupwork (Version Control)"
+status: active
+parent: bluej
+---
+
 # Groupwork (Version Control)
 
 Git-based collaboration and version control (67 files). Provides commit, push, pull, merge, and conflict resolution through an abstracted `Repository` interface implemented with Eclipse JGit.

--- a/.specs/bluej/parser/README.md
+++ b/.specs/bluej/parser/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-parser
+type: submodule-design
+title: "Java Parser"
+status: active
+parent: bluej
+---
+
 # Java Parser
 
 An incremental Java parser (103 files) that builds and maintains a scope-based syntax tree for the editor. Provides syntax highlighting, code completion, symbol resolution, and class metadata extraction.

--- a/.specs/bluej/parser/context/README.md
+++ b/.specs/bluej/parser/context/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-parser-context
+type: submodule-design
+title: "Compilation Context"
+status: active
+parent: bluej-parser
+---
+
 # Compilation Context
 
 Persisted metadata about compilation units (5 files). Preserves javadoc comments, parameter names, and documentation in `.ctxt` files alongside compiled classes -- information lost in `.class` bytecode.

--- a/.specs/bluej/parser/entity/README.md
+++ b/.specs/bluej/parser/entity/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-parser-entity
+type: submodule-design
+title: "Entity Resolution"
+status: active
+parent: bluej-parser
+---
+
 # Entity Resolution
 
 Resolves Java identifiers to their semantic meaning (29 files). Implements a type hierarchy for entities: packages, classes, values, type parameters, wildcards, and constants. Supports **lazy resolution** -- entities are created as `UnresolvedEntity` and resolved on demand.

--- a/.specs/bluej/parser/lexer/README.md
+++ b/.specs/bluej/parser/lexer/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-parser-lexer
+type: submodule-design
+title: "Lexer (Tokenizer)"
+status: active
+parent: bluej-parser
+---
+
 # Lexer (Tokenizer)
 
 Java source tokenization (5 files). Converts raw text into a stream of located tokens for the parser.

--- a/.specs/bluej/parser/nodes/README.md
+++ b/.specs/bluej/parser/nodes/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-parser-nodes
+type: submodule-design
+title: "Parse Tree Nodes"
+status: active
+parent: bluej-parser
+---
+
 # Parse Tree Nodes
 
 A scope-oriented parse tree (25 files) for incremental reparsing and editor features. **Not a full AST** -- nodes represent scope boundaries (compilation units, types, methods, blocks) rather than individual expressions. Child nodes are stored in a red-black tree keyed by relative document offset.

--- a/.specs/bluej/parser/symtab/README.md
+++ b/.specs/bluej/parser/symtab/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-parser-symtab
+type: submodule-design
+title: "Symbol Table"
+status: active
+parent: bluej-parser
+---
+
 # Symbol Table
 
 Class metadata extraction and source position tracking (3 files).

--- a/.specs/bluej/pkgmgr/README.md
+++ b/.specs/bluej/pkgmgr/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-pkgmgr
+type: submodule-design
+title: "Package Manager (Central Orchestrator)"
+status: active
+parent: bluej
+---
+
 # Package Manager (Central Orchestrator)
 
 The central orchestrator of BlueJ (115 files). Manages projects, packages, class targets, and the visual class diagram. Nearly every other subsystem connects through pkgmgr.

--- a/.specs/bluej/pkgmgr/actions/README.md
+++ b/.specs/bluej/pkgmgr/actions/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-pkgmgr-actions
+type: submodule-design
+title: "Package Manager Actions"
+status: active
+parent: bluej-pkgmgr
+---
+
 # Package Manager Actions
 
 Menu and toolbar actions for the main IDE window (38 files). Uses the Command pattern with a `PkgMgrAction` base class. Actions are configuration-driven via `Config.getString()` for labels and shortcuts.

--- a/.specs/bluej/pkgmgr/dependency/README.md
+++ b/.specs/bluej/pkgmgr/dependency/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-pkgmgr-dependency
+type: submodule-design
+title: "Dependency Graph"
+status: active
+parent: bluej-pkgmgr
+---
+
 # Dependency Graph
 
 Models class relationships for the visual dependency diagram (7 files).

--- a/.specs/bluej/pkgmgr/target/README.md
+++ b/.specs/bluej/pkgmgr/target/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-pkgmgr-target
+type: submodule-design
+title: "Class Targets & Roles"
+status: active
+parent: bluej-pkgmgr
+---
+
 # Class Targets & Roles
 
 Represents compilable classes and other project elements in the class diagram. Uses a hierarchy of `Target` -> `EditableTarget` -> `ClassTarget`, with a Strategy pattern for class roles.

--- a/.specs/bluej/prefmgr/README.md
+++ b/.specs/bluej/prefmgr/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-prefmgr
+type: submodule-design
+title: "Preferences Manager"
+status: active
+parent: bluej
+---
+
 # Preferences Manager
 
 Persistent user preferences system (7 files). Stores editor settings, compiler options, and UI preferences using JavaFX observable properties for reactive UI binding. Preferences persist to `~/.bluej/bluej.properties`.

--- a/.specs/bluej/runtime/README.md
+++ b/.specs/bluej/runtime/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-runtime
+type: submodule-design
+title: "Runtime (ExecServer)"
+status: active
+parent: bluej
+---
+
 # Runtime (ExecServer)
 
 Debug VM execution environment (5 files). Runs inside the debug VM and provides the two-threaded execution model that BlueJ's debugger controls via JDI.

--- a/.specs/bluej/stride/README.md
+++ b/.specs/bluej/stride/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-stride
+type: submodule-design
+title: "Stride Block-Based Editor"
+status: active
+parent: bluej
+---
+
 # Stride Block-Based Editor
 
 The largest subsystem in BlueJ (223 files). Implements the Stride language -- a block-based visual programming interface that generates Java code. Students manipulate visual "frames" instead of typing text, with editable "slots" for expressions and identifiers.

--- a/.specs/bluej/terminal/README.md
+++ b/.specs/bluej/terminal/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-terminal
+type: submodule-design
+title: "Terminal"
+status: active
+parent: bluej
+---
+
 # Terminal
 
 Interactive I/O console (6 files) connected to the debug VM.

--- a/.specs/bluej/testmgr/README.md
+++ b/.specs/bluej/testmgr/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-testmgr
+type: submodule-design
+title: "Test Manager"
+status: active
+parent: bluej
+---
+
 # Test Manager
 
 Unit test recording and replay system (14 files). Provides a UI for viewing test results and a recording subsystem that captures user interactions (object creation, method calls, inspections) as replayable JUnit test fixtures.

--- a/.specs/bluej/utility/README.md
+++ b/.specs/bluej/utility/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-utility
+type: submodule-design
+title: "Utility Library"
+status: active
+parent: bluej
+---
+
 # Utility Library
 
 Shared utility classes used across all BlueJ packages (91 files). Provides JavaFX helpers, file operations, dialog management, debug logging, and observable bindings.

--- a/.specs/bluej/utility/filefilter/README.md
+++ b/.specs/bluej/utility/filefilter/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-utility-filefilter
+type: submodule-design
+title: "File Filters"
+status: active
+parent: bluej-utility
+---
+
 # File Filters
 
 Strategy-pattern file filters for directory traversal (5 files): `JavaSourceFilter` (`.java`), `JavaClassFilter` (`.class`), `DirectoryFilter`, `SubPackageFilter`, `FrameSourceFilter` (Stride).

--- a/.specs/bluej/utility/javafx/README.md
+++ b/.specs/bluej/utility/javafx/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-utility-javafx
+type: submodule-design
+title: "JavaFX Utilities"
+status: active
+parent: bluej-utility
+---
+
 # JavaFX Utilities
 
 JavaFX-specific utility classes (59 files + 3 dialog + 5 binding).

--- a/.specs/bluej/views/README.md
+++ b/.specs/bluej/views/README.md
@@ -1,3 +1,11 @@
+---
+id: bluej-views
+type: submodule-design
+title: "Views"
+status: active
+parent: bluej
+---
+
 # Views
 
 Class reflection view layer (12 files). Provides a cached, read-only representation of Java classes and their members for display in inspectors, code completion, and the extensions API.

--- a/.specs/boot/README.md
+++ b/.specs/boot/README.md
@@ -1,3 +1,11 @@
+---
+id: boot
+type: module-design
+title: "Boot Module"
+status: active
+parent: bluej-greenfoot-architecture
+---
+
 # Boot Module
 
 Entry point for both BlueJ and Greenfoot. Dynamically constructs the classpath from `lib/*.jar`, shows a splash screen, and loads `bluej.Main` via reflection using a custom URLClassLoader.

--- a/.specs/greenfoot/README.md
+++ b/.specs/greenfoot/README.md
@@ -1,3 +1,13 @@
+---
+id: greenfoot
+type: module-design
+title: "Greenfoot Simulation IDE"
+status: active
+parent: bluej-greenfoot-architecture
+depends-on:
+  - bluej
+---
+
 # Greenfoot Simulation IDE
 
 Greenfoot is a 2D game/simulation IDE built on top of BlueJ. Students create scenarios by extending `World` and `Actor` classes. Provides collision detection, audio, image manipulation, and a visual execution environment with Run/Pause/Step controls.

--- a/.specs/greenfoot/collision/README.md
+++ b/.specs/greenfoot/collision/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-collision
+type: submodule-design
+title: "Collision Detection"
+status: active
+parent: greenfoot
+---
+
 # Collision Detection
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/core/README.md
+++ b/.specs/greenfoot/core/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-core
+type: submodule-design
+title: "Greenfoot Simulation Core"
+status: active
+parent: greenfoot
+---
+
 # Greenfoot Simulation Core
 
 Simulation engine and initialization layer (18 files). Runs in the debug VM and drives the act() cycle. Manages world state, project lifecycle, and image caching.

--- a/.specs/greenfoot/event/README.md
+++ b/.specs/greenfoot/event/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-event
+type: submodule-design
+title: "Event System"
+status: active
+parent: greenfoot
+---
+
 # Event System
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/export/README.md
+++ b/.specs/greenfoot/export/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-export
+type: submodule-design
+title: "Scenario Export"
+status: active
+parent: greenfoot
+---
+
 # Scenario Export
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/gui/README.md
+++ b/.specs/greenfoot/gui/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-gui
+type: submodule-design
+title: "GUI (Rendering & Input)"
+status: active
+parent: greenfoot
+---
+
 # GUI (Rendering & Input)
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/guifx/README.md
+++ b/.specs/greenfoot/guifx/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-guifx
+type: submodule-design
+title: "Greenfoot JavaFX UI"
+status: active
+parent: greenfoot
+---
+
 # Greenfoot JavaFX UI
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/guifx/classes/README.md
+++ b/.specs/greenfoot/guifx/classes/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-guifx-classes
+type: submodule-design
+title: "Greenfoot Class Diagram"
+status: active
+parent: greenfoot-guifx
+---
+
 # Greenfoot Class Diagram
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/guifx/export/README.md
+++ b/.specs/greenfoot/guifx/export/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-guifx-export
+type: submodule-design
+title: "Greenfoot Export UI"
+status: active
+parent: greenfoot-guifx
+---
+
 # Greenfoot Export UI
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/guifx/images/README.md
+++ b/.specs/greenfoot/guifx/images/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-guifx-images
+type: submodule-design
+title: "Image Library UI"
+status: active
+parent: greenfoot-guifx
+---
+
 # Image Library UI
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/guifx/soundrecorder/README.md
+++ b/.specs/greenfoot/guifx/soundrecorder/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-guifx-soundrecorder
+type: submodule-design
+title: "Sound Recorder UI"
+status: active
+parent: greenfoot-guifx
+---
+
 # Sound Recorder UI
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/importer/README.md
+++ b/.specs/greenfoot/importer/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-importer
+type: submodule-design
+title: "Scratch Importer"
+status: active
+parent: greenfoot
+---
+
 # Scratch Importer
 
 Imports Scratch projects into Greenfoot (16 files). Converts Scratch's stage/sprite model into Greenfoot's World/Actor model, importing images, sounds, and basic structure.

--- a/.specs/greenfoot/platforms/README.md
+++ b/.specs/greenfoot/platforms/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-platforms
+type: submodule-design
+title: "Platform Abstraction"
+status: active
+parent: greenfoot
+---
+
 # Platform Abstraction
 
 Strategy pattern (9 files) supporting two execution contexts: IDE mode (running inside BlueJ) and standalone mode (exported JAR). Three delegate interfaces each have IDE and standalone implementations.

--- a/.specs/greenfoot/record/README.md
+++ b/.specs/greenfoot/record/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-record
+type: submodule-design
+title: "Greenfoot Recorder"
+status: active
+parent: greenfoot
+---
+
 # Greenfoot Recorder
 
 "Save the World" recording system (1 file). Captures interactive user actions and generates a `prepare()` method as Stride code that can reproduce the world state.

--- a/.specs/greenfoot/sound/README.md
+++ b/.specs/greenfoot/sound/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-sound
+type: submodule-design
+title: "Greenfoot Audio System"
+status: active
+parent: greenfoot
+---
+
 # Greenfoot Audio System
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/util/README.md
+++ b/.specs/greenfoot/util/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-util
+type: submodule-design
+title: "Greenfoot Utilities"
+status: active
+parent: greenfoot
+---
+
 # Greenfoot Utilities
 
 > Auto-generated from code analysis. Review and refine.

--- a/.specs/greenfoot/vmcomm/README.md
+++ b/.specs/greenfoot/vmcomm/README.md
@@ -1,3 +1,11 @@
+---
+id: greenfoot-vmcomm
+type: submodule-design
+title: "VM Communication"
+status: active
+parent: greenfoot
+---
+
 # VM Communication
 
 Inter-VM communication protocol (4 files) using memory-mapped shared memory with a three-lock synchronization protocol between IDE (Main VM) and user scenario code (Debug VM).

--- a/.specs/kotlin-for-bluej/DESIGN_DOC.md
+++ b/.specs/kotlin-for-bluej/DESIGN_DOC.md
@@ -1,3 +1,15 @@
+---
+id: kotlin-for-bluej
+type: architecture-design
+title: "Kotlin for BlueJ — Architecture Design"
+status: active
+parent: goal-and-requirements
+depends-on:
+  - bluej
+tags:
+  - kotlin
+---
+
 # Kotlin for BlueJ — Architecture Design
 
 > Architecture for adding Kotlin as a third language in BlueJ, targeting an educational MVP subset.
@@ -103,4 +115,4 @@ No new threads. Kotlin uses existing threading:
 | Parser & Lexer | `.specs/kotlin-for-bluej/parser/README.md` |
 | Class Diagram | `.specs/kotlin-for-bluej/diagram/README.md` |
 | Top-Level Functions | `.specs/kotlin-for-bluej/toplevel/README.md` |
-| Build & Distribution | `.specs/kotlin-for-bluej/build/README.md` |
+| Build & Distribution | `.specs/kotlin-for-bluej/distribution/README.md` |

--- a/.specs/kotlin-for-bluej/DESIGN_DOC.md
+++ b/.specs/kotlin-for-bluej/DESIGN_DOC.md
@@ -52,6 +52,7 @@ Kotlin joins Java and Stride as a teaching language. New Kotlin classes live alo
 - `Diagnostic` -- add `KOTLIN` DiagnosticOrigin
 - `Package` -- Kotlin stdlib on classpath, `.kt` file discovery
 - `Boot` -- `"kotlin-*.jar"` patterns for runtime classpath
+- `Config` / `Main` -- Kotlin editor-open counter (`session.numeditors.kotlin`) and `&kotlineditors=` in the launch stats ping; the ping's guard requires all three language counts to be present, so the first launch after upgrade sends no editor stats (accepted trade-off)
 - `build.gradle` -- `kotlin-compiler-embeddable` and `kotlin-stdlib` dependencies
 
 ### New Components

--- a/.specs/kotlin-for-bluej/compiler/README.md
+++ b/.specs/kotlin-for-bluej/compiler/README.md
@@ -1,3 +1,16 @@
+---
+id: kotlin-for-bluej-compiler
+type: module-design
+title: "Kotlin Compiler Integration"
+status: active
+parent: kotlin-for-bluej
+depends-on:
+  - bluej-compiler
+  - boot
+tags:
+  - kotlin
+---
+
 # Kotlin Compiler Integration
 
 > Programmatic Kotlin compilation within BlueJ by wrapping `kotlin-compiler-embeddable` (K2) behind the existing `Compiler` interface.

--- a/.specs/kotlin-for-bluej/compiler/file-form-validation/README.md
+++ b/.specs/kotlin-for-bluej/compiler/file-form-validation/README.md
@@ -1,3 +1,13 @@
+---
+id: kotlin-for-bluej-compiler-file-form-validation
+type: submodule-design
+title: "Kotlin File Form Validation"
+status: active
+parent: kotlin-for-bluej-compiler
+tags:
+  - kotlin
+---
+
 # Kotlin File Form Validation
 
 > Pre-compilation validation enforcing BlueJ's one-concept-per-file model with hard errors that mirror javac's file restrictions.

--- a/.specs/kotlin-for-bluej/diagram/README.md
+++ b/.specs/kotlin-for-bluej/diagram/README.md
@@ -1,3 +1,16 @@
+---
+id: kotlin-for-bluej-diagram
+type: module-design
+title: "Class Diagram Integration"
+status: active
+parent: kotlin-for-bluej
+depends-on:
+  - bluej-pkgmgr-target
+  - kotlin-for-bluej-compiler
+tags:
+  - kotlin
+---
+
 # Class Diagram Integration
 
 > How Kotlin classes appear and behave on BlueJ's visual class diagram.

--- a/.specs/kotlin-for-bluej/diagram/companion-objects/README.md
+++ b/.specs/kotlin-for-bluej/diagram/companion-objects/README.md
@@ -1,3 +1,13 @@
+---
+id: kotlin-for-bluej-diagram-companion-objects
+type: submodule-design
+title: "Companion Object Methods as Static Operations"
+status: active
+parent: kotlin-for-bluej-diagram
+tags:
+  - kotlin
+---
+
 # Companion Object Methods as Static Operations
 
 > Invoking Kotlin `companion object` methods from the class diagram as if they were static methods of the enclosing class.

--- a/.specs/kotlin-for-bluej/distribution/README.md
+++ b/.specs/kotlin-for-bluej/distribution/README.md
@@ -1,3 +1,15 @@
+---
+id: kotlin-for-bluej-build
+type: module-design
+title: "Build & Distribution"
+status: active
+parent: kotlin-for-bluej
+depends-on:
+  - boot
+tags:
+  - kotlin
+---
+
 # Build & Distribution
 
 > How Kotlin dependencies are declared, assembled, discovered at runtime, and shipped to end users.

--- a/.specs/kotlin-for-bluej/editor/README.md
+++ b/.specs/kotlin-for-bluej/editor/README.md
@@ -1,3 +1,16 @@
+---
+id: kotlin-for-bluej-editor
+type: module-design
+title: "Kotlin Editor & Syntax"
+status: active
+parent: kotlin-for-bluej
+depends-on:
+  - bluej-editor
+  - kotlin-for-bluej-parser
+tags:
+  - kotlin
+---
+
 # Kotlin Editor & Syntax
 
 > Kotlin syntax highlighting and scope coloring by extending BlueJ's incremental parser infrastructure, reusing `JavaSyntaxView` unchanged.

--- a/.specs/kotlin-for-bluej/editor/auto-indent/README.md
+++ b/.specs/kotlin-for-bluej/editor/auto-indent/README.md
@@ -1,3 +1,13 @@
+---
+id: kotlin-for-bluej-editor-auto-indent
+type: submodule-design
+title: "Kotlin Auto-Indent"
+status: active
+parent: kotlin-for-bluej-editor
+tags:
+  - kotlin
+---
+
 # Kotlin Auto-Indent
 
 > Token-driven indenter for `.kt` files. Computes target indents from

--- a/.specs/kotlin-for-bluej/editor/highlighting/README.md
+++ b/.specs/kotlin-for-bluej/editor/highlighting/README.md
@@ -1,3 +1,15 @@
+---
+id: kotlin-for-bluej-editor-highlighting
+type: submodule-design
+title: "Kotlin Code Highlighting"
+status: active
+parent: kotlin-for-bluej-editor
+depends-on:
+  - bluej-editor-highlighting
+tags:
+  - kotlin
+---
+
 # Kotlin Code Highlighting
 
 > Token-level syntax coloring and how it integrates with BlueJ's shared highlighting infrastructure.

--- a/.specs/kotlin-for-bluej/editor/psi-scope/README.md
+++ b/.specs/kotlin-for-bluej/editor/psi-scope/README.md
@@ -1,3 +1,13 @@
+---
+id: kotlin-for-bluej-editor-psi-scope
+type: submodule-design
+title: "PSI-Based Scope Detection"
+status: active
+parent: kotlin-for-bluej-editor
+tags:
+  - kotlin
+---
+
 # PSI-Based Scope Detection
 
 > Uses the full Kotlin PSI parser from `kotlin-compiler-embeddable` to build accurate scope structure for `JavaSyntaxView` scope coloring.

--- a/.specs/kotlin-for-bluej/parser/README.md
+++ b/.specs/kotlin-for-bluej/parser/README.md
@@ -1,3 +1,15 @@
+---
+id: kotlin-for-bluej-parser
+type: module-design
+title: "Kotlin Parser & Lexer"
+status: active
+parent: kotlin-for-bluej
+depends-on:
+  - bluej-parser
+tags:
+  - kotlin
+---
+
 # Kotlin Parser & Lexer
 
 > `bluej.parser.kotlin` -- Tokenization, scope detection, and class metadata extraction for Kotlin `.kt` files, leveraging PSI from `kotlin-compiler-embeddable`.

--- a/.specs/kotlin-for-bluej/parser/incremental-reparse/README.md
+++ b/.specs/kotlin-for-bluej/parser/incremental-reparse/README.md
@@ -1,3 +1,13 @@
+---
+id: kotlin-for-bluej-parser-incremental-reparse
+type: submodule-design
+title: "Incremental PSI Reparse for Kotlin"
+status: active
+parent: kotlin-for-bluej-parser
+tags:
+  - kotlin
+---
+
 # Incremental PSI Reparse for Kotlin
 
 > Tiered incremental reparse strategy to reduce per-keystroke cost from ~50-100ms to ~0.1-20ms for common edits.

--- a/.specs/kotlin-for-bluej/toplevel/README.md
+++ b/.specs/kotlin-for-bluej/toplevel/README.md
@@ -1,3 +1,16 @@
+---
+id: kotlin-for-bluej-toplevel
+type: module-design
+title: "Top-Level Functions Support"
+status: active
+parent: kotlin-for-bluej
+depends-on:
+  - bluej-pkgmgr-target
+  - kotlin-for-bluej-parser
+tags:
+  - kotlin
+---
+
 # Top-Level Functions Support
 
 > Kotlin files with only top-level functions as first-class entities on BlueJ's class diagram.

--- a/.specs/lang-stride/README.md
+++ b/.specs/lang-stride/README.md
@@ -1,3 +1,11 @@
+---
+id: lang-stride
+type: module-design
+title: "Stride Language API"
+status: active
+parent: bluej-greenfoot-architecture
+---
+
 # Stride Language API
 
 A minimal public library providing utility classes for the Stride language. Bundled with compiled Stride programs and available to student code both inside the IDE and in standalone exports.

--- a/.specs/threadchecker/README.md
+++ b/.specs/threadchecker/README.md
@@ -1,3 +1,13 @@
+---
+id: threadchecker
+type: module-design
+title: "Thread-Safety Checker"
+status: active
+parent: bluej-greenfoot-architecture
+depends-on:
+  - anns-threadchecker
+---
+
 # Thread-Safety Checker
 
 A javac compiler plugin that statically verifies `@OnThread` thread-safety contracts at compile time. Hooks into the ANALYZE phase to walk the AST and check that all method calls, lambda expressions, field accesses, and overrides respect thread-tag compatibility.

--- a/bluej/src/main/java/bluej/Config.java
+++ b/bluej/src/main/java/bluej/Config.java
@@ -143,6 +143,7 @@ public final class Config
     private static boolean isDebugVm = true; // Default to true, will be corrected on main VM
     public static final String EDITOR_COUNT_JAVA = "session.numeditors.java";
     public static final String EDITOR_COUNT_STRIDE = "session.numeditors.stride";
+    public static final String EDITOR_COUNT_KOTLIN = "session.numeditors.kotlin";
     public static final String MESSAGE_LATEST_SEEN = "bluej.latest.msg";
     private static long MAX_DEBUG_LOG_SIZE = 1048576;
 
@@ -800,6 +801,14 @@ public final class Config
                 saveAppProperties();
             }
             break;
+            case Kotlin:
+            {
+                int kotlinEditors = getPropInteger(EDITOR_COUNT_KOTLIN, 0, userProps);
+                kotlinEditors += 1;
+                userProps.setProperty(EDITOR_COUNT_KOTLIN, Integer.toString(kotlinEditors));
+                saveAppProperties();
+            }
+            break;
             default: break;
         }
     }
@@ -818,6 +827,7 @@ public final class Config
         {
             case Java: return getPropInteger(EDITOR_COUNT_JAVA, -1, userProps);
             case Stride: return getPropInteger(EDITOR_COUNT_STRIDE, -1, userProps);
+            case Kotlin: return getPropInteger(EDITOR_COUNT_KOTLIN, -1, userProps);
             default: return -1;
         }
     }
@@ -830,6 +840,7 @@ public final class Config
     {
         userProps.setProperty(EDITOR_COUNT_JAVA, "0");
         userProps.setProperty(EDITOR_COUNT_STRIDE, "0");
+        userProps.setProperty(EDITOR_COUNT_KOTLIN, "0");
         saveAppProperties();
     }
 

--- a/bluej/src/main/java/bluej/Main.java
+++ b/bluej/src/main/java/bluej/Main.java
@@ -1,6 +1,6 @@
 /*
  This file is part of the BlueJ program. 
- Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2021,2022,2023,2025  Michael Kolling and John Rosenberg
+ Copyright (C) 1999-2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2021,2022,2023,2025,2026  Michael Kolling and John Rosenberg
  
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 
@@ -391,12 +391,14 @@ public class Main
         String editorStats = "";
         int javaEditors = Config.getEditorCount(Config.SourceType.Java);
         int strideEditors = Config.getEditorCount(Config.SourceType.Stride);
+        int kotlinEditors = Config.getEditorCount(Config.SourceType.Kotlin);
         try
         {
-            if (javaEditors != -1 && strideEditors != -1)
+            if (javaEditors != -1 && strideEditors != -1 && kotlinEditors != -1)
             {
                 editorStats = "&javaeditors=" + URLEncoder.encode(Integer.toString(javaEditors), "UTF-8")
-                    + "&strideeditors=" + URLEncoder.encode(Integer.toString(strideEditors), "UTF-8");
+                    + "&strideeditors=" + URLEncoder.encode(Integer.toString(strideEditors), "UTF-8")
+                    + "&kotlineditors=" + URLEncoder.encode(Integer.toString(kotlinEditors), "UTF-8");
             }
         }
         catch (UnsupportedEncodingException ex)

--- a/bluej/src/test/java/bluej/ConfigEditorCountTest.java
+++ b/bluej/src/test/java/bluej/ConfigEditorCountTest.java
@@ -1,0 +1,119 @@
+/*
+ This file is part of the BlueJ program. 
+ Copyright (C) 2026  Michael Kolling and John Rosenberg
+
+ This program is free software; you can redistribute it and/or 
+ modify it under the terms of the GNU General Public License 
+ as published by the Free Software Foundation; either version 2 
+ of the License, or (at your option) any later version. 
+
+ This program is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+ GNU General Public License for more details. 
+
+ You should have received a copy of the GNU General Public License 
+ along with this program; if not, write to the Free Software 
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA. 
+
+ This file is subject to the Classpath exception as provided in the  
+ LICENSE.txt file that accompanied this code.
+ */
+package bluej;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Properties;
+
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the per-language editor-open counters used by the launch-time
+ * usage statistics ping (see Main.updateStats), in particular the Kotlin
+ * counter (session.numeditors.kotlin).
+ */
+public class ConfigEditorCountTest
+{
+    private static File tempUserHome;
+
+    @BeforeClass
+    public static void initConfig() throws Exception
+    {
+        // If another test initialised Config already, we cannot redirect the
+        // user properties to a temp dir; skip rather than risk writing to the
+        // developer's real bluej.properties.
+        Assume.assumeFalse("Config already initialised by another test", Config.isInitialised());
+
+        tempUserHome = Files.createTempDirectory("bluej-config-test").toFile();
+
+        Properties props = new Properties();
+        props.put("bluej.debug", "true");
+        props.put("bluej.userHome", tempUserHome.getAbsolutePath());
+        Config.initialise(Boot.getBluejLibDir(), props, false);
+
+        // Double-check the redirect took effect before any test writes properties.
+        Assume.assumeTrue("User config dir not redirected to temp dir",
+            Config.getUserConfigDir().getAbsolutePath()
+                .startsWith(tempUserHome.getAbsolutePath()));
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception
+    {
+        // deleteOnExit() cannot remove non-empty directories, so delete recursively.
+        if (tempUserHome != null) {
+            try (var paths = Files.walk(tempUserHome.toPath())) {
+                paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+        }
+    }
+
+    @Test
+    public void testEditorCountLifecycle() throws Exception
+    {
+        // Fresh properties: no counter has ever been written, all read -1.
+        assertEquals(-1, Config.getEditorCount(Config.SourceType.Java));
+        assertEquals(-1, Config.getEditorCount(Config.SourceType.Stride));
+        assertEquals(-1, Config.getEditorCount(Config.SourceType.Kotlin));
+
+        // Recording increments only the matching counter.
+        Config.recordEditorOpen(Config.SourceType.Kotlin);
+        Config.recordEditorOpen(Config.SourceType.Kotlin);
+        assertEquals(2, Config.getEditorCount(Config.SourceType.Kotlin));
+        assertEquals(-1, Config.getEditorCount(Config.SourceType.Java));
+        assertEquals(-1, Config.getEditorCount(Config.SourceType.Stride));
+
+        Config.recordEditorOpen(Config.SourceType.Java);
+        Config.recordEditorOpen(Config.SourceType.Stride);
+        assertEquals(1, Config.getEditorCount(Config.SourceType.Java));
+        assertEquals(1, Config.getEditorCount(Config.SourceType.Stride));
+        assertEquals(2, Config.getEditorCount(Config.SourceType.Kotlin));
+
+        // Reset zeroes all three (so the next launch reads 0, not -1).
+        Config.resetEditorsCount();
+        assertEquals(0, Config.getEditorCount(Config.SourceType.Java));
+        assertEquals(0, Config.getEditorCount(Config.SourceType.Stride));
+        assertEquals(0, Config.getEditorCount(Config.SourceType.Kotlin));
+
+        // The Kotlin counter must be persisted to the user properties file
+        // (recordEditorOpen/resetEditorsCount save it), so it survives to the
+        // next session's stats ping.
+        File propsFile = Config.getUserConfigFile("bluej.properties");
+        assertTrue("bluej.properties should exist at " + propsFile, propsFile.exists());
+
+        Properties onDisk = new Properties();
+        try (var in = Files.newInputStream(propsFile.toPath())) {
+            onDisk.load(in);
+        }
+        assertTrue("persisted properties should contain " + Config.EDITOR_COUNT_KOTLIN,
+            onDisk.containsKey(Config.EDITOR_COUNT_KOTLIN));
+    }
+}


### PR DESCRIPTION
Adds Kotlin to the editor-open counters sent by the anonymous launch-time usage-stats ping, so Kotlin usage is measurable alongside Java and Stride.

- **Config**: new `session.numeditors.kotlin` counter (record / read / reset) — previously the Kotlin record call was silently dropped
- **Main.updateStats**: appends `&kotlineditors=N` to the ping URL; editor stats are sent only when all three counts exist
- **Tests**: new `ConfigEditorCountTest` for counter lifecycle and persistence (uses a temp dir, never touches a real `~/.bluej`)
- **Specs**: documents the stats ping in the bluej spec; also carries the spec-graph registration commit (frontmatter + CLAUDE.md → AGENTS.md rename)

Note: the stats server needs to accept the new `kotlineditors` parameter.